### PR TITLE
Make the KLH10 dskdmp script start automatically.

### DIFF
--- a/build/klh10/build.tcl
+++ b/build/klh10/build.tcl
@@ -18,14 +18,12 @@ proc start_dskdmp {} {
     #respond "KLH10>" "zero\r"
     quit_emulator
     uplevel #0 {spawn ./kn10-ks-its dskdmp.ini}
-    expect "EOF"
-    respond "KLH10#" "go\r"
+    expect "Starting KN10"
 }
 
 proc start_its {} {
     uplevel #0 {spawn ./kn10-ks-its dskdmp.ini}
-    expect "EOF"
-    respond "KLH10#" "go\r"
+    expect "Starting KN10"
 }
 
 proc mount_tape {file} {

--- a/build/klh10/dskdmp.ini
+++ b/build/klh10/dskdmp.ini
@@ -27,3 +27,4 @@ devdef dz0  ub3   dz11   addr=760010 br=5 vec=340
 
 load @.ddt-u
 load dskdmp.216bin
+go


### PR DESCRIPTION
This is to make it easier for users to start ITS with the current set of scripts.