### PR TITLE
Simplify starting by providing a script.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *~
 /out
+/start
 /build/klh10/stamp
 /src/system/config.*
 /user/*/*

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,13 @@ out/dskdmp.tape: $(WRITETAPE) $(RAM) $(DSKDMP)
 	mkdir -p out
 	$(WRITETAPE) -n 2560 $@ $(RAM) $(DSKDMP)
 
-build/klh10/stamp: $(KLH10)
+build/$(EMULATOR)/stamp: start
+	touch $@
+
+start: build/$(EMULATOR)/start
+	ln -s $< $*
+
+build/klh10/stamp: $(KLH10) start
 	touch $@
 
 $(KLH10):
@@ -67,4 +73,4 @@ $(WRITETAPE):
 	cd tools/tapeutils; make
 
 clean:
-	rm -rf out
+	rm -rf out start

--- a/README.md
+++ b/README.md
@@ -44,14 +44,10 @@ checked out, and then type `make EMULATOR=simh` or `make
 EMULATOR=klh10`.  This will leave built files in the `out` directory,
 one of which is a disk image with ITS installed.
 
-To start ITS, either type
-- `pdp10 build/simh/boot` for SIMH, or
-- `cd build/klh10; sudo kn10-ks-its dskdmp.ini` and then `go` at the
-  `KLH10#` prompt.  Sudo is only needed to enable networking.
-
-When you see the `DSKDMP` prompt, type `its`, press Enter, and then
-`ESC g`.  Eventually, you will see `SYSTEM JOB USING THIS CONSOLE`.
-You are now ready to log in, so type Control-Z.  See
+To start ITS, type `./start`.  If you see `KLH10#`, type `go` and
+Enter.  When you see the `DSKDMP` prompt, type `its`, press Enter, and
+then `ESC g`.  Eventually, you will see `SYSTEM JOB USING THIS
+CONSOLE`.  You are now ready to log in, so type Control-Z.  See
 [doc/DDT.md](doc/DDT.md) for a list of useful commands.  When done,
 shut down orderly by typing `:lock` and then `5down`.
 

--- a/build/klh10/start
+++ b/build/klh10/start
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# Optional; needed for networking.
+SUDO=sudo
+
+cd build/klh10
+$SUDO ./kn10-ks-its dskdmp.ini

--- a/build/simh/start
+++ b/build/simh/start
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+pdp10 build/simh/boot


### PR DESCRIPTION
Now users can just type `./start` to get going.

Unfortunately, KLH10 doesn't like to get a `go` command right after reading dskdmp.ini.  That will result in a MFDCLB.  Why?!?