### PR TITLE
Use Ubuntu 14 in Travis build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: c
+dist: trusty
 sudo: required
 env:
   - EMULATOR=simh

--- a/build/dependencies.sh
+++ b/build/dependencies.sh
@@ -1,8 +1,6 @@
 install_linux() {
-    sudo add-apt-repository ppa:dns/gnu -y
     sudo apt-get update -myq
     sudo apt-get install -my expect
-    sudo apt-get install --only-upgrade autoconf
     if test "$EMULATOR" = simh; then
 	sudo apt-get install simh
     fi


### PR DESCRIPTION
Its autoconf version is good enough to build KLH10, so we don't have to get it from the dns/gnu PPA.

This ought to put an end to the unstablilty in the apt-get install phase.