### PR TITLE
Fixed missing link (SYS2; TS =) to SYS; TS SRCCOM.

### DIFF
--- a/build/build.tcl
+++ b/build/build.tcl
@@ -548,6 +548,7 @@ expect ":KILL"
 
 respond "*" ":midas sys;ts srccom_sysen2;srccom\r"
 expect ":KILL"
+respond "*" ":link sys2;ts =,sys;ts srccom\r"
 
 respond "*" ":midas .mail.;comsat_sysnet;comsat\r"
 expect ":KILL"


### PR DESCRIPTION
Resolves #110.