### PR TITLE
Fixes incorrect link for SYS1; TS ESPELL.

### DIFF
--- a/build/build.tcl
+++ b/build/build.tcl
@@ -840,7 +840,7 @@ expect ":KILL"
 # spell
 respond "*" ":midas sys1;ts spell_syseng;spell\r"
 expect ":KILL"
-respond "*" ":link sys1;ts espell,sys;ts spell\r"
+respond "*" ":link sys1;ts espell,sys1;ts spell\r"
 
 # jobs
 respond "*" ":midas sys2;ts jobs_sysen1;jobs\r"


### PR DESCRIPTION
This is supposed to be a link to SYS1;TS SPELL, but is currently a link
to SYS;TS SPELL (which doesn't exist).

Resolves #300.