### PR TITLE
Purify DECUUO

### DIFF
--- a/build/build.tcl
+++ b/build/build.tcl
@@ -918,8 +918,14 @@ respond "*" ":link sys;ts mailt,sys2;ts emacs\r"
 respond "*" ":midas device;atsign rmtdev_gz;rmtdev\r"
 
 # decuuo
-respond "*" ":midas decsys;ts dec_decuuo\r"
+respond "*" ":midas decsys;_decuuo\r"
 expect ":KILL"
+respond "*" ":job decuuo\r"
+respond "*" ":load decsys;decuuo bin\r"
+respond "*" "purify\033g"
+respond "TS DEC" "\r"
+respond "*" ":kill\r"
+
 respond "*" ":midas decsys;_decbot\r"
 expect ":KILL"
 


### PR DESCRIPTION
Found this:

; An unPURIFY'd binary should exist on all machines as DECSYS;DECUUO BIN.  
; The installed pure binary should be called DECSYS;TS DEC, linked to from SYS.  
; In addition, on AI, the DRAWing system programs actually run DRAW;TS DECUUO  
; which should point to the pure binary which has been installed for the  
; DRAWing system (normally also DECSYS;TS DEC, but sometimes may be an older version).

; When a new version is installed, the old DECSYS;DECUUO BIN should be moved  
; to BACKUP;DECUUO BINnnn where nnn is the version number.  The date of  
; the new file should be set to that of the old.  Then, the old version's  
; binary should be copied to DECSYS;DECUUO BIN, loaded, and  PURIFY'd with  
; PURIFY$G.   

; After assembling a new version of DECUUO, it should be loaded up and dumped  
; back out with GAPFLS$G.  This will flush most of the wasted space,  
; making loading the file much faster.  Page 0 is not flushed, since flushing  
; it would disable breakpoint-proceed in DDT until the time DECUUO gets around  
; to recreating that page.  PURIFY does flush the page, since otherwise  
; booting in DECUUO would clobber page 0 of the program doing the booting.
