### PR TITLE
Build SIMH from GitHub repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 *~
 /out
 /start
-/build/klh10/stamp
+/build/*/stamp
 /src/system/config.*
 /user/*/*

--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "tools/klh10"]
 	path = tools/klh10
 	url = https://github.com/PDP-10/klh10
+[submodule "tools/simh"]
+	path = tools/simh
+	url = https://github.com/simh/simh

--- a/Makefile
+++ b/Makefile
@@ -17,13 +17,14 @@ NSALV = bin/boot/salv.rp06
 DSKDMP = bin/boot/dskdmp.rp06
 
 KLH10=${PWD}/tools/klh10/tmp/bld-ks-its/kn10-ks-its 
+SIMH=${PWD}/tools/simh/BIN/pdp10
 ITSTAR=${PWD}/tools/itstar/itstar
 WRITETAPE=${PWD}/tools/tapeutils/tapewrite
 
 all: out/rp0.dsk
 
 out/rp0.dsk: build/simh/init out/minsys.tape out/salv.tape out/dskdmp.tape build/build.tcl out/sources.tape build/$(EMULATOR)/stamp
-	expect -f build/$(EMULATOR)/build.tcl
+	PATH=${PWD}/tools/simh/BIN:$$PATH expect -f build/$(EMULATOR)/build.tcl
 
 out/minsys.tape: $(ITSTAR)
 	mkdir -p out
@@ -53,7 +54,10 @@ build/$(EMULATOR)/stamp: start
 start: build/$(EMULATOR)/start
 	ln -s $< $*
 
-build/klh10/stamp: $(KLH10) start
+build/klh10/stamp: $(KLH10)
+	touch $@
+
+build/simh/stamp: $(SIMH)
 	touch $@
 
 $(KLH10):
@@ -66,6 +70,9 @@ $(KLH10):
 	make base-ks-its; \
 	make -C bld-ks-its install
 
+$(SIMH):
+	cd tools/simh; make pdp10
+
 $(ITSTAR):
 	cd tools/itstar; make
 
@@ -73,4 +80,4 @@ $(WRITETAPE):
 	cd tools/tapeutils; make
 
 clean:
-	rm -rf out start
+	rm -rf out start build/*/stamp

--- a/README.md
+++ b/README.md
@@ -37,12 +37,10 @@ we'd be delighted to test this on a real KS10.
 ### Usage
 
 To build ITS with this repository, you need some tools installed:
-make, C compiler, and expect.  Also, if you plan to use the SIMH
-emulator, it needs to be installed and accessible as `pdp10`.  The
-KLH10 emulator is built from source code.  Ensure all submodules are
-checked out, and then type `make EMULATOR=simh` or `make
-EMULATOR=klh10`.  This will leave built files in the `out` directory,
-one of which is a disk image with ITS installed.
+make, C compiler, and expect.  Ensure all submodules are checked out,
+and then type `make EMULATOR=simh` or `make EMULATOR=klh10`.  This
+will leave built files in the `out` directory, one of which is a disk
+image with ITS installed.
 
 To start ITS, type `./start`.  If you see `KLH10#`, type `go` and
 Enter.  When you see the `DSKDMP` prompt, type `its`, press Enter, and

--- a/build/simh/stamp
+++ b/build/simh/stamp
@@ -1,1 +1,0 @@
-For now, install SIMH separately.

--- a/build/simh/start
+++ b/build/simh/start
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-pdp10 build/simh/boot
+tools/simh/BIN/pdp10 build/simh/boot


### PR DESCRIPTION
Once SIMH is fixed to do ITS 1-proceed right, we should probably switch to the latest GitHub version.

I have already done the work:  
https://github.com/PDP-10/its/tree/lars/simh