### PR TITLE
Fix bugs in OD.

### DIFF
--- a/src/libdoc/od.3
+++ b/src/libdoc/od.3
@@ -3,18 +3,21 @@
 (eval-when (eval load compile)
   (load '((liblsp) lispm fasl)))
 
+(defun print-file-offset (x)
+  (format t "~&~6,'0O:  " x))
+
 (defun print-octal (word)
-  (format t "~6,'0O" (load-byte (quotient word 1000000) 0 18.))
-  (format t "~6,'0O  " (load-byte (remainder word 1000000) 0 18.)))
+  (format t "~12,'0O  " word))
 
 (defun print-half (word)
   (let ((half (quotient word 1000000)))
+    (if (not (zerop (logand half 400000)))
+       (setq half (+ half -1000000)))
     (format t "~7O,," half)
-    (setq half (load-byte (remainder word 1000000) 0 18.))
+    (setq half (remainder word 1000000))
     (if (not (zerop (logand half 400000)))
        (setq half (+ half -1000000)))
     (format t "~7<~O~;~>  "half)))
-;    (format t "~7O  "half)))
 
 (defvar squoze-chars
   '(" " "0" "1" "2" "3" "4" "5" "6" "7" "8" "9"
@@ -24,9 +27,9 @@
 
 (defun print-squoze (word)
   (let ((result nil))
-    (setq word (load-byte word 0 32.))
+    (setq word (remainder word (times 65536. 65536.)))
     (loop for i from 0 below 6 do
-	  (let ((ch (abs (remainder word 40.))))
+	  (let ((ch (remainder word 40.)))
 	    (setq ch (nth ch squoze-chars))
 	    (push ch result)
 	    (setq word (quotient word 40.))))
@@ -37,7 +40,7 @@
 (defun print-sixbit (word)
   (let ((result nil))
     (loop for i from 0 below 6 do
-	  (let ((ch (abs (remainder word 64.))))
+	  (let ((ch (remainder word 64.)))
 	    (push (+ ch 32.) result)
 	    (setq word (quotient word 64.))))
     (format t "~A  " (implode result))))
@@ -46,16 +49,17 @@
   (setq word (quotient word 2))
   (let ((result nil))
     (loop for i from 0 below 5 do
-	  (let ((ch (abs (remainder word 128.))))
+	  (let ((ch (remainder word 128.)))
 	    (if (< ch 32.)
 	      (setq ch "."))
 	    (push ch result)
-	    (setq word (quotient word 128))))
+	    (setq word (quotient word 128.))))
     (format t "~A  " (implode result))))
 
 (defun read-word (input)
   (let ((word (in input)))
-    (format t "~&")
+    (if (minusp word)
+	(setq word (plus word (times 1000000 1000000))))
     (print-octal word)
     (print-half word)
     (print-squoze word)
@@ -71,8 +75,10 @@
 (defun print-binary (file)
   (with-open-file (input file '(single fixnum in))
     (eoffn input #'goodbye)
-    (format t "~&~12A  SQUOZE  SIXBIT  ASCII~%" "OCTAL")
-    (loop while t do 
+    (format t "~&         ~12A  ~16A  SQUOZE  SIXBIT  ASCII~%"
+	    "OCTAL" "HALF-WORDS")
+    (loop for i from 0 while t do 
+          (print-file-offset i)
 	  (read-word input))))
 
 (defun toplevel ()


### PR DESCRIPTION
Maclisp doesn't do bitwise operations on bignums, so I had to use QUOTIENT and REMAINDER to access bytes in a full words.  But then I ran into trouble with negative numbers.

This fix avoids negative numers altogether.  Also adds file offsets to the output.