### PR TITLE
TIMSRV typo

### DIFF
--- a/build/build.tcl
+++ b/build/build.tcl
@@ -969,7 +969,7 @@ expect ":KILL"
 # timsrv
 respond "*" ":midas sysbin;timsrv bin_sysnet;timsrv\r"
 expect ":KILL"
-respond "*" ":link device;tcp syn045,sysbin;timesrv bin\r"
+respond "*" ":link device;tcp syn045,sysbin;timsrv bin\r"
 
 # mailt
 respond "*" ":link sys;ts mailt,sys2;ts emacs\r"


### PR DESCRIPTION
Spelled TIMESRV in build.tcl.