### PR TITLE
DATE - print date and time

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ A list of [known ITS machines](doc/machines.md).
    - CROCK, analog watch.
    - CROSS, cross assembler for micros.
    - CTIMES, Chaosnet time server.
+   - DATE, print date and time.
    - DATSRV, server for RFC 867 Daytime protocol.
    - DCROCK, digital watch.
    - DDTDOC, interactive DDT documentation.

--- a/build/build.tcl
+++ b/build/build.tcl
@@ -674,6 +674,10 @@ respond "*" ":link .info.;mail info,.info.;qmail info\r"
 respond "*" ":midas sys1;ts time_sysen2;time\r"
 expect ":KILL"
 
+# DATE
+respond "*" ":midas sys1;ts date_sysen3;date\r"
+expect ":KILL"
+
 # PWMAIL
 respond "*" ":midas sys;ts pwmail_ksc;qmail\r"
 respond "PWORD version (Y or N)? " "Y\r"

--- a/src/sysen3/date.2
+++ b/src/sysen3/date.2
@@ -1,0 +1,137 @@
+;-*-MIDAS-*-
+
+TITLE DATE		; Display date and time
+
+; This program has the current century hardcoded,
+; so it needs to be updated every 100 years
+
+T==0
+
+A=1
+B=2
+C=3
+D=4
+
+A1=5
+
+TTY==1
+
+PTTY=<001000,,>
+
+LOC 41
+	JSR UUOH
+
+LOC 100
+
+UUOH:	0
+	MOVEM A1,ASAV
+	MOVEI A1,440600			; SIXBIT byte pointer
+	HRLM A1,40
+.PTTY:	ILDB A1,40
+	CAIN A1,'@
+	 JRST .RET
+	ADDI A1,40			; Convert to ASCII
+	.IOT TTY,A1
+	JRST .PTTY
+.RET:	MOVE A1,ASAV
+	JRST 2,@UUOH
+
+GO:	.OPEN TTY,.+1
+	 1,,'TTY
+	PTTY [SIXBIT /   @/]
+	.RDATE T,
+	LDB A,[360400,,T]		; First digit of year
+	IMULI A,10.
+	LDB B,[300400,,T]		; Second digit of year
+	ADD A,B
+	IDIVI A,4
+	IMULI A,5
+	ADD A,B
+	LDB C,[140600,,T]		; Month
+	TLNE T,A
+	 ADDI C,10.
+	JUMPN B,.+3
+	CAIG C,22
+	 SOJ A,
+	ADD A,MONTAB-1-'0 (C)
+	LDB B,[060400,,T]		; First digit of day
+	IMULI B,10.
+	LDB D,[000400,,T]		; Second digit of day
+	ADD A,D
+	ADD A,B	
+CAL2:	ADDI A,5			; This century starts on a Saturday
+	IDIVI A,7
+	PTTY @WKDAY(B)
+	PTTY @MONTH-1-'0 (C)
+	LDB B,[001400,,T]		; MMDD
+	ROT B,-14
+	TLO B,40
+	 TLNN B,170000
+	  LSH B,6
+	PTTY B
+	PTTY [SIXBIT /, 20@/]		; Century
+	MOVSI B,777700
+	AND B,T
+	TLO B,40
+	 PTTY B
+	PTTY [SIXBIT /  @/]
+	.RTIME B,
+	LSHC A,2*6
+	LSH A,6
+	IORI A,':
+	LSHC A,2*6
+	LSH A,6
+	IORI A,':
+	CAMGE A,[SIXBIT /12:00:/]
+	 JRST TPRT
+	SUB A,[010200,,]
+	TLNN A,002000
+	 ADD A,[771200,,]
+	XORI B,210000
+TPRT:	XORI B,'AM'@
+	PTTY A
+	.IOT A,[15]			; CR
+	.LOGOUT 1,
+	ASCII /:KILL/
+	.USET
+	0
+
+MONTH:	[SIXBIT/JANUARY @/]
+	[SIXBIT/FEBRUARY @/]
+	[SIXBIT/MARCH @/]
+	[SIXBIT/APRIL @/]
+	[SIXBIT/MAY @/]
+	[SIXBIT/JUNE @/]
+	[SIXBIT/JULY @/]
+	[SIXBIT/AUGUST @/]
+	[SIXBIT/SEPTEMBER @/]
+	[SIXBIT/OCTOBER @/]
+	[SIXBIT/NOVEMBER @/]
+	[SIXBIT/DECEMBER @/]
+
+MONTAB:	0
+	3
+	3
+	6
+	1
+	4
+	6
+	2
+	5
+	0
+	3
+	5
+
+WKDAY:	[SIXBIT/MONDAY, @/]
+	[SIXBIT/TUESDAY, @/]
+	[SIXBIT/WEDNESDAY, @/]
+	[SIXBIT/THURSDAY, @/]
+	[SIXBIT/FRIDAY, @/]
+	[SIXBIT/SATURDAY, @/]
+	[SIXBIT/SUNDAY, @/]
+
+CONSTANTS
+
+ASAV:	0
+
+END GO


### PR DESCRIPTION
SYS1; TS DATE

Sources are missing for this, however, SV has:

HACK; DATE 2

which, although when assembled creates a very different executable appears to work correctly and improves upon the SYS1; TS DATE binary in the PI distribution in that it can handle years post 1999 correctly. Not sure if we want to use this source, but we should consider it.