### PR TITLE
Expect script doesn't define "abort"

### DIFF
--- a/build/build.tcl
+++ b/build/build.tcl
@@ -1,3 +1,9 @@
+proc abort {} {
+    puts ""
+    puts "The last command timed out."
+    exit 1
+}
+
 proc type s {
     sleep .1
     foreach c [split $s ""] {


### PR DESCRIPTION
When there's a timeout, build.tcl calls abort, but there's no such procedure defined.