### PR TITLE
Fix NSALV unit number conversion bug

### DIFF
--- a/src/kshack/nsalv.261
+++ b/src/kshack/nsalv.261
@@ -831,7 +831,7 @@ TERMIN
 ;;; Non-skip means unit was unknown to QTRAN.
 
 QCNVT:	MOVSI B,-NUNITS
-	CAMN A,QTRAN(B)
+	CAME A,QTRAN(B)
 	 AOBJN B,.-1
 	JUMPGE B,CPOPJ		; Not found, don't skip
 	MOVEI B,(B)		; Found, extract virtual unit number
@@ -8685,6 +8685,7 @@ WXWDS:	BLOCK 4
 
 
 ;;; Physical/Virtual unit translation hack.
+;;; Index the table with a virtual unit number to get the physical unit.
 ;;; RH of entry is physical drive.
 ;;;   "4.9 means second half 
 ;;;     (No longer does anything, now that Memowrecks have been


### PR DESCRIPTION
John Wilson's [build.info](https://github.com/PDP-10/its/blob/master/doc/build.info#L35-L42) says there's a bug in NSALV.  Our source doesn't have the fix, but we may well be running his fixed binary.  We should check this, and if so, fix our source code too.

There are two places to check:
- bin/boot/salv.rp06, and
- build/klh10/@.nsalv-260-u