### PR TITLE
ATSIGN CHAOS - Chaosnet support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ A list of [known ITS machines](doc/machines.md).
    - ARCDEV, transparent file system access to archive files.
    - ARCSAL, archive salvager.
    - ARGUS, alerts you when specified users login or logout.
+   - ATSIGN CHAOS, Chaosnet support.
    - ATSIGN DEVICE, load device drivers.
    - ATSIGN TARAKA, starts dragons.
    - ATSIGN TCP, TCP support.

--- a/build/build.tcl
+++ b/build/build.tcl
@@ -535,6 +535,11 @@ respond "*" "\033g"
 respond "*" ":midas sys;atsign tcp_syseng;@tcp\r"
 expect ":KILL"
 
+# Chaosnet support
+respond "*" ":midas sysbin;_syseng;@chaos\r"
+expect ":KILL"
+respond "*" ":link device;atsign chaos,sysbin;@chaos bin\r"
+
 respond "*" ":link syseng;netwrk 999999,sysnet;netwrk >\r"
 
 respond "*" ":midas .;ts redrct_sysnet;redrct\r"


### PR DESCRIPTION
We didn't have DEVICE; ATSIGN CHAOS built, even thought the source is there.  I'm about to try using Chaosnet, so I'm adding it now.