### PR TITLE
SYSHST additions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ SRC = system syseng sysen1 sysen2 sysen3 sysnet kshack dragon channa	\
       midas _teco_ emacs emacs1 rms klh syshst sra mrc ksc eak gren	\
       bawden _mail_ l lisp libdoc comlap lspsrc nilcom rwk	\
       inquir acount gz sys decsys ecc alan sail kcc kcc_sy c
-DOC = info _info_ sysdoc sysnet kshack _teco_ emacs emacs1 c kcc
+DOC = info _info_ sysdoc sysnet syshst kshack _teco_ emacs emacs1 c kcc
 BIN = sys2 device emacs _teco_ lisp liblsp alan inquir sail comlap c
 
 # These directories are put on the minsys tape.

--- a/build/build.tcl
+++ b/build/build.tcl
@@ -517,7 +517,7 @@ expect ":KILL"
 respond "*" ":midas kshack;ts mtboot_kshack;mtboot\r"
 expect ":KILL"
 
-respond "*" ":midas syshst;_syshst;hosts3\r"
+respond "*" ":midas syshst;ts hosts3_syshst;hosts3\r"
 expect ":KILL"
 
 respond "*" ":link syseng;t20mac 999999,system;t20mac >\r"
@@ -526,10 +526,8 @@ respond "*" ":midas syshst;_syshst;h3make\r"
 expect ":KILL"
 
 # build binary host table
-respond "*" ":job hosts3\r"
-respond "*" ":load syshst; hosts3 bin\r"
-respond "*" ":jcl /insert syshst; h3text > /outfil sysbin; hosts3 bin\r"
-respond "*" "\033g"
+respond "*" ":syshst;hosts3 /insert syshst; h3text > /outfil sysbin; hosts3 bin\r"
+expect ":KILL"
 
 # basic TCP support
 respond "*" ":midas sys;atsign tcp_syseng;@tcp\r"

--- a/doc/syshst/-read-.-this-
+++ b/doc/syshst/-read-.-this-
@@ -1,0 +1,19 @@
+AI: SYSHST; directory for host tables.
+
+This is the home of the master sources for the MIT host tables,
+or for copies in cases where the master source is a LispM namespace
+or some such.  Changes to files should be announced to INFO-HOSTS@AI,
+bug reports as well.  See -WHAT- -FILE- for more info.
+
+XX:<HOSTS> (available as XX: HOSTS; from ITS EMACS) is a backup of
+this directory and contains various other cruft.  There's a nightly
+batch job on XX to keep things current.
+
+Please do not touch anything in this directory unless you know what
+you are doing.  Read the documentation and ask the people on
+INFO-HOSTS if it's not clear.
+
+There is some documentation of XXRFC810 format in -THIS- -TOO-.
+There is an explaination of which files are what in -WHAT- -FILE-.
+
+--SRA 7 October 86.

--- a/doc/syshst/-this-.-too-
+++ b/doc/syshst/-this-.-too-
@@ -1,0 +1,155 @@
+This file describes the state things were in around December 1985.
+Since then I have moved the host compilation process for ITS to XX
+(ie, XX now compiles tables and installs them on the ITS machines as
+well as on XX itself).  The ITS flavors of the various TECO macros,
+XFILEs, etc, are preserved in AI: SYSHST; AR2 HSTSRC.  They need to be
+kept around as a backup in case XX is down for long periods of time.
+
+If you want to figre out what is going on these days, browse through
+AI: SYSHST; and XX: HOSTS;.
+
+--sra 17 June 86
+----------------------------------------------------------------
+
+[Bugs in MAKHST, MAKDOM, or this documentation to SRA@XX]
+
+This file describes the new host table format (or "extended extended
+RFC810 format").  This is the format used to store the host/domain
+data for all MIT machines (or that is the intent anyway).  The format
+is an extension of the format used by the HOSTS3 compiler ("extended
+RFC810 format").  The basic motivation for all this cruft is to keep
+all the host data in a single set of files, in spite of the fact that
+this data is used in entirely different ways by the Chaosnet and the
+Internet.  If you want to flame about the religious issues involved
+here, send mail to NAMECALLERS@MC, a list of people who are
+collectively responsible for implementing this crock.
+
+== Format:
+
+The only real change is the addition of a new entry type, DOMAIN.
+This is still somewhat freeform; I am open to suggestions as to
+improvements.  The DOMAIN entry contains three kinds of information,
+all related to the domain system (but read on, this matters to
+Chaosnet people too).  These are: (1) the name of the domain (loading
+origin if this is fed into a nameserver), (2) the data for the SOA RR,
+and a list of nameservers (with optional addresses) for this domain.
+  The format is:
+
+DOMAIN : <domain-name> : <class> : <source>: <bug-address> : 
+ 	 <serial> : <refresh> : <retry> : <expire> : <minimum> :
+ 	 <nameserver> {<address>} {,<nameserver> {<address>}} :
+ 
+(where all of this is on a single line, of course).  Of these, only
+the <domain-name> field is currently of any consequence to Chaosnet
+hosts or to hosts that keep their SOA and NS data in a seperate file.
+Thus the brief form looks like
+
+DOMAIN : EECS.MIT.EDU :
+
+This will work if fed to the MAKHST program, which doesn't care about
+SOAs or NSs.  It will *not* work if fed to MAKDOM.  People maintaining
+domain nameservers presumably understand what these fields mean (see
+RFC883 if you aren't sure).  An example of the complex form (again,
+suppressing the line break):
+
+DOMAIN : LCS.MIT.EDU : IN : XX.LCS.MIT.EDU : BUG-LCS-DOMAIN.XX.LCS.MIT.EDU
+       : 0 : 7200 : 600 : 3600000 : 60 : XX.LCS.MIT.EDU 10.0.0.44,
+         MILO.LCS.MIT.EDU :  
+
+Things to note:
+
+The <address> fields may be blank if the machines acting as
+nameservers are all in this domain (and thus have their addresses
+listed elsewhere in this file).  If there is an address it is the
+entire rest of the subfield (up to the delimiting comma or colon);
+this allows for future expansion for Chaosnet nameservers if these
+prove to be useful.
+
+The <serial> field may be zero; in this case the <serial> value in the
+SOA record is the version number of the source file containing this
+DOMAIN entry.  Obviously this only makes sense when the master copy of
+the file is kept on a machine that implements version numbers.
+
+The existing filter programs assume that the DOMAIN entry, if it
+exists at all, will come before any HOST, GATEWAY, or NET entries.
+This could be fixed if anybody gives me a good reason.
+
+One other note: the redundant nicknames for machines have been
+removed.  Ie, where there used to be an entry listing names
+"MIT-XX.ARPA, MIT-XX, XX", there will now be an entry that only lists
+"XX".  The filters can cons up this kind of trivial name easily, and
+it turned out to be a lot easier to add the "MIT-"s and ".ARPA"s in
+the right places than to remove them from the wrong ones.
+
+== Programs:
+
+There are currently two filter programs, MAKDOM and MAKHST.  Both
+could use improvement if anybody is so inclined.
+
+
+MAKDOM:
+
+This is a C program which will run on Twenex or Berkeley Unix.  Since
+these are currently the only operating systems likely to be running
+domain nameservers (as opposed to resolvers), this seemed like a
+reasonable choice.  It converts this host table format into the form
+specified in RFC883 for zone master files.  It behaves like a vanilla
+unix filter program, so you can pipe to it, etc, if you have some
+reason to do so.  Documentation at this point is just a long comment
+at the begining.  There are various switches to control what kind of
+RRs are written and to control how many forms of generated nicknames
+to add, etc.  Ask me (sra@xx) if you want a copy.
+
+
+MAKHST:
+
+This is a filter to convert the new host table format into something
+that can be fed to the HOSTS3 compiler (or used directly by any
+machine that has been using MC: SYSNET; HSTMIT >).  It is implemented
+as (gasp) a dumped TECO program.  It has a semi-reasonable command
+scanner which will parse a JCL that looks similar to most old ITS or
+BOTTOMS-10 programs (if you run it without any JCL it will type out an
+error message explaining the argument format).  Since HOSTS3 only runs
+on PDP10s and the host tables all currently live on AI (with copies on
+XX), the fact that TECO only runs on PDP10s should not be much of a
+restriction.  There are (or will be) XFILEs and .CTL files to do the
+right frobs to run this filter and feed the results to HOSTS3.  Like
+MAKDOM, MAKHST has various switches that let you control nickname
+hacking, DOMAIN entry parsing, etc.
+
+There is a third filter program, HSTNIC.  This is also written in
+TECO.  It is a little different from the others in that it is not
+concerned with the new host table format.  Rather, it does two things.
+Firstly, it removes all references to MIT from HSTNIC, since all MIT
+hosts should now be in our own tables, quite possibly with different
+names than the NIC has on file.  Secondly, HSTNIC punts any machine
+names in the HSTNIC file that would conflict with MIT nicknames.  Eg,
+UW-EDDIE's nickname of EDDIE gets punted because that conflicts with
+the MIT machine in building 38.  The current implementation of this is
+extremely kludgy and takes much longer than it should.  I will fix it
+some day if I get around to it....
+
+== Files:
+
+HSTMIT has been split up into a number of files, one per domain within
+MIT and a few extras for groups within MIT that will probably become
+domains soon.  The reason for the split is that the source files will
+probably not all live on the same machine any more.  (There have to be
+copies on whatever machine is putting together HOSTS3 files, but these
+will probably be secondary copies that are kept current via FTP.)  The
+ITS names should be obvious, things like HSTLCS >, HSTAI >, etc, and
+the conventions on XX are a direct mapping of the MC filenames.
+Doesn't really matter so long as responsible people tell whoever is
+generating HOSTS3 files where everything is and what it is called.
+
+The NET entries for MIT will be moved into a seperate file of their
+own, MC: SYSHST; HSTNET > or something like that.  To avoid name
+collisions, The HOSTS3 compilation will also be using a hacked up
+version of HSTNIC > with all the MIT entries removed (this is one of
+the reasons why the MIT NET entries go in a seperate file).  Again,
+all this will be done by some hairy XFILE or .CTL file and shouldn't
+need human attention unless it breaks.  But it will be somewhat
+compute bound.....
+
+That should be basicly it.  Updates will of course be posted to
+INFO-HOSTS@MC.

--- a/doc/syshst/-what-.-file-
+++ b/doc/syshst/-what-.-file-
@@ -1,0 +1,203 @@
+XX:<HOSTS>-WHAT-.-FILE-.1,  5-Sep-86 15:21:21, Edit by SRA
+
+This file attempts to document the important files related to MIT host
+tables, where the files come from, where they go, etcetera.  No
+warranty implied....
+
+
+Which tables:
+
+	The "MIT host tables" include information for the MIT
+	chaosnet and Internet networks 18.0.0.0 and 128.52.0.0.  There
+	are also a few overflows from the Arpanet (10.0.0.0) and in
+	past days Symbolics and CISL have also been part of the tables
+	for various reasons.  The "MIT host tables" are the
+	authoritative source of information for the MIT Chaosnet.
+	They also contain authoritative information for much of the
+	relevant Internet data, but here the organization is not as
+	clean; you should also check with the MIT Telecommunications
+	Office, who run the MIT.EDU domain and the campus network.
+	Contact Jeff Schiller <jis@bitsy.mit.edu> for details.
+
+Directories:
+
+	Host tables primarily live in the SYSHST directory on AI
+	(AI:SYSHST;) and in the HOSTS directory on XX (XX:<HOSTS>).
+	Other machines will presumably have local copies of these.
+	Some of the files also live in XX:<SYSTEM>; these are ones
+	that are used directly by XX's system programs.  Similarly,
+	the binary HOSTS3 file lives in the SYSBIN directory on all
+	ITS machines.
+
+
+Programs:
+
+Most relevant programs are in XX:<HOSTS>.  I used various languages as
+was convient (TECO, Twenex CTL, Twenex PCL, Twenex CMD, C, MIDAS).
+You are welcome to read this stuff but probably don't want to touch it
+unless you are a Real Hero.
+
+
+Mailing lists:
+
+The primary list for host table related issues is INFO-HOSTS@AI (aka
+AI.AI.MIT.EDU).  There are a couple of spinoff lists.
+INFO-HOSTS-UPDATE@AI is a list for people who want to receive SRCCOMs
+of changes to HSTMIT from the nightly XX batch job.
+INFO-HOSTS-REQUEST is the usual list addition/removal address.
+NAMECALLERS@AI is a list to discuss the MIT implementation of the
+DARPA Domain system.  You're welcome to listen in but don't speak
+unless you know what you are talking about.
+
+Source files:
+
+XX:<HOSTS>HOSTS.NIC:
+	This is a copy of the Internet host table maintained by the
+	Network Information Center under DARPA contract.  It is the
+	closest thing available to a complete listing of the Internet,
+	but is somewhat deficient (due to the unmanageable size of the
+	table).  The version number of this file tracks the version
+	number of [SRI-NIC]NETINFO:HOSTS.TXT.  MIT machines desiring a
+	copy of the unadulterated NIC table should copy the one from
+	XX rather than getting it directly from the NIC; this was an
+	official request from the NIC, to help cut down on the load on
+	SRI-NIC due to FTP servers.
+
+	To update this file, send mail to HOSTMASTER@NIC.
+
+AI:SYSHST;HSTNET >
+	This file contains about ten lines of machine readable data
+	(network names and numbers for MIT nets).  This part is seldom
+	changed.  Most of the file is a comment (ignored by the table
+	compilers) listing the current subnet assignments for the MIT
+	networks.  This is the authoritative listing.  No changes
+	should be made to subnet numbers without checking this file to
+	see if there is a conflict.  There is a small self appointed
+	militia who police this file for reasonableness; talk to the
+	people on INFO-HOSTS@AI if you need details.
+
+AI:SYSHST;HSTLCS >
+	This is the authoritative host table for LCS.  It is dumped
+	from the LCS LispM namespace every time a "significant" change
+	is made to the namespace.  Editing the file is a waste of
+	time, edit the namespace instead.  Format is a little odd to
+	support some additional functionality for the LCS.MIT.EDU
+	domain.  A copy of this file lives in XX:<HOSTS>HSTLCS.TXT.
+	This file is also the source for the LCS.MIT.EDU domain.
+
+AI:SYSHST;HSTAI >
+	This is the authoritative host table for the AI lab.  It is
+	dumped from the AI LispM namespace.  Again, edit the namespace
+	instead of the file.  File format doesn't have the weird LCS
+	kludges.  A copy of this file lives in XX:<HOSTS>HSTAI.TXT.
+	This file contains the same data as the AI.MIT.EDU domain.
+
+AI:SYSHST;HSTEE >
+	Table for the EECS "domain" (still part of MIT.EDU).  Hand
+	edited, but usually pretty up to date.  Is the authoritative
+	source for EECS Chaosnet machines.  Internet addresses here
+	have to be cleared with Telecommunications, but changes should
+	be reflected in this file so that machines which don't grok
+	domains yet can keep up with things.  Copy in
+	XX:<HOSTS>HSTEE.TXT.
+
+AI:SYSHST;HSTATH >
+	Table for the Project Athena "domain" (still part of MIT.EDU).
+	Hand edited, may or may not be up to date at a given moment.
+	Authoritative source for Athena Chaos machines.  Copy lives in
+	XX:<HOSTS>HSTATH.TXT.
+
+AI:SYSHST;HSTG >
+	Table for machines not part of LCS, AI, Athena, or EECS.
+	Hand edited, may or may not be up to date.  Authoritative for
+	Chaosnet.  Copy in XX:<HOSTS>HSTG.TXT.
+
+AI:SYSHST;HSTXXX >
+	This is a file of additions and kludges that need to be added
+	to the NIC host table (some machines at Stanford and
+	Symbolics, other things as needed).  You probably shouldn't
+	edit this.
+
+Generated files (produced by XX's nightly host table job):
+
+XX:<HOSTS>HSTMIT.TXT
+	Merge of HSTLCS, HSTAI, HSTATH, HSTEE, and HSTG.  This has all
+	the special kludges fixed up, names expanded, etcetera.  This
+	is the closest thing there is to a single table listing all
+	MIT machines.  Copy in AI:SYSHST;HSTMIT >.
+
+XX:<HOSTS>HSTNIC.TXT
+	This is derived from the NIC host table.  A few known bad
+	names and/or addresses are removed, any nicknames that
+	conflict with MIT machines are removed.  Any machines that
+	look "insignificant" are removed (workstations at sites other
+	than MIT, etcetera).  The contents of this file are subject to
+	change without notice as becomes necessary to feed this file
+	into some of the later stages of the compilation process.
+	HSTXXX is prepended to the NIC data in this file.  No data for
+	MIT machines appears in this file; it is implicitly assumed
+	that the data in the MIT tables superceedes whatever the NIC
+	has on file.
+
+XX:<SYSTEM>HOSTS.TXT
+	This is HSTMIT followed by HSTNIC, but without the Chaosnet
+	data.  It is as close to a "complete" listing of the DARPA
+	Internet as can be made with the current setup.  XX uses this
+	file for its old Internet host table software (XX also uses
+	the new Domain system, but that's a different issue).
+	Machines that want a copy of the NIC table with the MIT data
+	fixed should use this file.
+
+XX:<HOSTS>HOSTS3.TXT
+	This is a file suitable for feeding to the HOSTS3 binary table
+	compiler.  It contains all the essential data from HSTMIT
+	followed by HSTNIC.  Some amount of pruning is done to this
+	file to fit the address space constraints of the HOSTS3
+	compiler (at present, all the services entries are removed).
+	Contents subject to change without notice.
+
+XX:<SYSTEM>HOSTS3.BIN
+	This is the compiled binary HOSTS3 table.  Many programs on
+	ITS and Twenex use this.  Copies can be found in the <SYSTEM>
+	directory on all MIT Twenex machines and in the SYSBIN;
+	directory on all ITS machines.  Version numbers of the ITS
+	copies track that of the XX:<SYSTEM> copy.
+
+XX:<HOSTS>HOSTS2.TXT
+	An old format of host table (MIDAS hackers should note the
+	syntax!).  Somewhat useless because it can only handle IP
+	addresses with the third octet zeroed.  Used to produce...
+
+XX:<SYSTEM>HOSTS2.BIN
+	The compiled binary HOSTS2 format file.  Maintained for upward
+	compatibility.  No new programs should use this.
+
+XX:<HOSTS>HOST3C.TXT
+	A listing of just the Chaosnet machines from HSTMIT.  Name is
+	somewhat confusing, since the file format is actually HOSTS2.
+	I think the unix binary table compiler reads this file.  Is
+	called HOST3C because it is used to produce...
+
+XX:<SYSTEM>HOST3C.BIN
+	A HOSTS3 binary format listing of the MIT Chaosnet.
+
+XX:<HOSTS>MITGWS.TXT
+	A listing of (IP) gateways and (Chaos) bridges, produced from
+	HSTMIT.  No warranty, but very handy for tracking down
+	network problems, since it is usually more up to date than any
+	of the gateway maps available.  Copy in AI:SYSHST;MITGWS >.
+
+XX:<HOSTS>CHAOSHOSTS.CHAOS-ALL
+	A file in the format used by unix sendmail, usually installed
+	as /etc/chaoshosts.  This file contains a listing of all
+	chaosnet hosts at MIT (derived from HSTMIT).
+
+XX:<HOSTS>CHAOSHOSTS.CHAOS-ONLY
+	Same as CHAOSHOSTS.CHAOS-ALL but only lists hosts that are on
+	the chaosnet but aren't on the Internet.  Depending on whether
+	your vax is or isn't on the net you will want one or the other
+	of these files so that sendmail can route mail as efficiently
+	as possible.
+
+There are some other files associated with the LCS.MIT.EDU domain, but
+that's a whole separate topic and not relevant here.

--- a/doc/syshst/hosts3.readme
+++ b/doc/syshst/hosts3.readme
@@ -1,0 +1,10 @@
+If you are looking for the source code to the HOSTS3 program because you
+read a comment in SYSENG;NETWRK, be informed that the latest version
+because the latest version is the one that runs on XX at 4am via batch
+job and it may or may not compile correctly on ITS because the page
+granularity is finer on 20x and at one point I needed every word of
+address space I could get out of the program.  See the file named (from
+ITS EMACS) XXSRC: SYS.SYSTEM; HOSTS MID if you care.  I don't think
+there are any changes other than address space twiddles.
+
+--sra 12 Nov 86

--- a/doc/syshst/hstinf.recent
+++ b/doc/syshst/hstinf.recent
@@ -1,0 +1,6775 @@
+Received: from MC.LCS.MIT.EDU (CHAOS 3131) by AI.AI.MIT.EDU; 11 Dec 89 12:22:19 EST
+Received: from lcs.mit.edu (CHAOS 15044) by MC.LCS.MIT.EDU; 11 Dec 89 12:09:05 EST
+From: Rob Austein <sra@lcs.mit.edu>
+Sender: sra@mintaka.lcs.mit.edu
+To: DAR@xv.mit.edu
+CC: info-hosts@MC.lcs.mit.edu
+In-reply-to: daverose@xv.mit.edu's message of 10 Dec 89 14:58:42 EST 2838311922@XENOPHOBIA.MIT.EDU
+Subject: Up-to-date list of hosts
+Date: Mon, 11 Dec 89 12:02:21 EST
+Message-ID:  <8912111202.aa06752@mintaka.lcs.mit.edu>
+
+   Date: 10 Dec 89 14:58:42 EST
+   From: daverose@xv.mit.edu
+
+   Can you tell me how to obtain an up-to-date hosts file?  Thanks.
+
+There are a bunch of automaticly maintained tables (various formats
+and subsets) available via anonymous FTP from mintaka.lcs.mit.edu in
+the directory hosts/misc.  If there's a particular format or subset
+you want that's not present, ask, we may be generating it and just not
+bothering to export it.
+
+NB: If you want the NIC table, -please- get it from mintaka or from
+bitsy.mit.edu, not from the NIC (per request of the NIC staff).
+
+Here's what's currently in mintaka.lcs.mit.edu:~anonymous/hosts/misc:
+
+  -rw-r--r--  1 root         3562 Dec 11 04:58 chaoshosts.chaos-only
+
+Automaticly generated list of names of hosts that are only reachable
+by chaosnet, for sendmail.cf routing kludge.
+
+  -rw-r--r--  1 root       690896 Dec 11 04:59 hosts.nic
+
+Verbatim copy of NIC host table (NIC.DDN.MIL:NETINFO:HOSTS.TXT).
+
+  -rw-r--r--  1 root        37224 Dec 11 04:59 hosts2.txt
+
+Automaticly generated HOSTS2 host table for MIT chaosnet.
+
+  -rw-r--r--  1 root       165346 Dec 11 04:59 hstcamp.txt
+
+(Almost) verbatim copy of bitsy.mit.edu:~anonymous/hosts/hstcamp.txt
+(we run it through an AWK script to get the number of ":" characters
+per line right, the verbatim table from MIT Telecommunications
+violates RFC-810 (et al) syntax rules).
+
+  -rw-r--r--  1 root       112326 Dec 11 04:59 hstlcs.txt
+
+Verbatim copy of LCS host table as generated from Lisp Machine
+namespace (AI: SYSHST; HSTLCS >).
+
+  -rw-r--r--  1 root       149480 Dec 11 04:59 hstmit.txt
+
+Automaticly generated "MIT" host table.  Does not currently include
+hstcamp.txt for historical reasons; this should be fixed someday.
+
+  -rw-r--r--  1 root        14091 Dec 11 04:59 hstnet.txt
+
+Verbatim copy of AI: SYSHST; HSTNET >, the "official" MIT subnet
+allocation table.
+
+  -rw-r--r--  1 root        12212 Dec 11 04:59 hstxxx.txt
+
+Verbatim copy of AI: SYSHST; HSTXXX > (if you need to ask, you don't
+want to know...).
+
+Please continue to address inquiries to INFO-HOSTS@AI.AI.MIT.EDU.
+
+--Rob
+
+
+Received: from MC.LCS.MIT.EDU (CHAOS 3131) by AI.AI.MIT.EDU; 10 Dec 89 15:09:41 EST
+Received: from lcs.mit.edu (CHAOS 15044) by MC.LCS.MIT.EDU; 10 Dec 89 15:07:58 EST
+Received: from ATHENA.MIT.EDU by mintaka.lcs.mit.edu id aa12986;
+          10 Dec 89 15:01 EST
+Received: from [18.86.0.190] by ATHENA.MIT.EDU with SMTP
+	id AA21294; Sun, 10 Dec 89 15:00:31 EST
+Subject: Up-to-date list of hosts
+To: info-hosts@MC.lcs.mit.edu
+Cc: dar@xv.mit.edu
+Reply-To: DAR@xv.mit.edu
+From: daverose@xv.mit.edu
+Message-Id: 2838311922@XENOPHOBIA.MIT.EDU
+Date: 10 Dec 89 14:58:42 EST
+
+Can you tell me how to obtain an up-to-date hosts file?  Thanks.
+
+Dave Rosenblitt
+
+
+
+
+
+Received: from MC.LCS.MIT.EDU (CHAOS 3131) by AI.AI.MIT.EDU 27 Jan 89 16:20:25 EST
+Date: Fri, 27 Jan 89 16:19:03 EST
+From: Rob Austein <SRA@MC.LCS.MIT.EDU>
+Subject:  two changes: XX and Multics
+To: Info-Hosts@AI.AI.MIT.EDU, SRA@MC.LCS.MIT.EDU
+Message-ID: <531731.890127.SRA@MC.LCS.MIT.EDU>
+
+1) XX's primary name in the host tables is now "LCS.MIT.EDU", with
+   "XX.LCS.MIT.EDU" as a nickname.  This is just a reordering, but it
+   might confuse some people.  XX's primary function these days is as
+   the LCS.MIT.EDU maildrop, and XX no longer has any "users".
+
+2) Multics.MIT.EDU has been gone for a year now, so I commented it out
+   of HSTG >.
+
+
+Received: from GAFFA.MIT.EDU (TCP 2217400013) by AI.AI.MIT.EDU 26 Jan 89 16:10:24 EST
+Received: by GAFFA.MIT.EDU (5.54/DA0.1)
+	id AA02804; Thu, 26 Jan 89 16:09:47 EST
+Message-Id: <8901262109.AA02804@GAFFA.MIT.EDU>
+From: Doug Alan <nessus@ATHENA.MIT.EDU>
+Reply-To: Doug Alan <nessus@ATHENA.MIT.EDU>
+To: info-hosts@AI.AI.MIT.EDU
+Subject: GAFFA
+Date: Thu, 26 Jan 89 16:09:44 EST
+Sender: nessus@GAFFA.MIT.EDU
+
+I added the Chaos host 'GAFFA' to the file ai:syshst;hstee >.  It's
+address is 37013.  It's Internet address is 18.62.0.11 .
+
+|>oug /\lan
+
+Received: from REAGAN.AI.MIT.EDU (CHAOS 13065) by AI.AI.MIT.EDU 18 Jan 89 18:30:52 EST
+Received: from PIGPEN.AI.MIT.EDU by REAGAN.AI.MIT.EDU via CHAOS with CHAOS-MAIL id 167099; Wed 18-Jan-89 18:21:41 EST
+Date: Wed, 18 Jan 89 18:21 EST
+From: Alan Bawden <Alan@AI.AI.MIT.EDU>
+Subject: Chaos-net adresses
+To: ROLL@KICKI.STACKEN.KTH.SE
+cc: Info-HOSTS@AI.AI.MIT.EDU
+In-Reply-To: <19890116210039.6.ALAN@PIGPEN.AI.MIT.EDU>
+Message-ID: <19890118232152.9.ALAN@PIGPEN.AI.MIT.EDU>
+
+    Date: Mon, 16 Jan 89 16:00 EST
+    From: Alan Bawden <Alan@AI.AI.MIT.EDU>
+    ...
+    I would like to allocate two subnets for Peter.  Since he has the old KL-10
+    and its front-end 11, I propose to transfer ownership of subnet 3 to him.
+    Also he will soon have a small local Chaosnet, and will need a second
+    subnet for that.
+
+OK, Chaos subnets 3 and 63 (octal, 51 decimal) now belong to the Royal
+Institute of Technology.  Subnet 3 is the one the KL has always used to
+talk to its network 11.  Subnet 63 was previously unused.  The comments in
+the HSTNET file refer people to ROLL if they have any questions.
+
+Received: from PIGPEN.AI.MIT.EDU by AI.AI.MIT.EDU via Chaosnet; 16 JAN 89  16:08:32 EST
+Date: Mon, 16 Jan 89 16:00 EST
+From: Alan Bawden <Alan@AI.AI.MIT.EDU>
+Subject: Chaos-net adresses
+To: ROLL@KICKI.STACKEN.KTH.SE, Info-HOSTS@AI.AI.MIT.EDU
+cc: Alan@AI.AI.MIT.EDU
+In-Reply-To: <12460923678.29.411.15980@KICKI.STACKEN.KTH.SE>
+Message-ID: <19890116210039.6.ALAN@PIGPEN.AI.MIT.EDU>
+
+    Date:  8-Jan-89 15:38:08 +0100
+    From: Peter Lothberg <ROLL@KICKI.STACKEN.KTH.SE>
+    ...
+    2,)  Do we need to coordinate the chaos-host numbers with the other chaos
+	 based hosts @ mit...
+
+I would like to allocate two subnets for Peter.  Since he has the old KL-10
+and its front-end 11, I propose to transfer ownership of subnet 3 to him.
+Also he will soon have a small local Chaosnet, and will need a second
+subnet for that.
+
+He and I both realize that there is no real need to coordinate subnet
+numbers, since it is unlikely that we will ever join the two Chaosnets, but
+who knows?  We have numbers to spare it seems.  (Will LMI ever want its 9
+reserved subnet numbers?) 
+
+Any objections?  I presume I just edit AI:SYSHST;HSTNET appropriately?
+
+Received: from XX.LCS.MIT.EDU (CHAOS 2420) by AI.AI.MIT.EDU 30 Dec 88 10:34:09 EST
+Received: from KODIAK.MIT.EDU by XX.LCS.MIT.EDU via Chaosnet; 30 Dec 88 10:30-EST
+Date: Fri, 30 Dec 88 10:30 EST
+From: David Goodine <dmg@ANA.MIT.EDU>
+Subject: AI: SYSHST; HSTG 120
+To: info-hosts@AI.AI.MIT.EDU
+cc: dmg@goldilocks
+Message-ID: <19881230153045.6.DMG@KODIAK.MIT.EDU>
+
+
+This file contains a change I made to switch the SPEECH
+alias to point to host ANA instead of to host GOLDILOCKS.
+
+-dmg
+
+Received: from DARJEELING.MIT.EDU by AI.AI.MIT.EDU via Chaosnet; 12 DEC 88  19:55:11 EST
+Date: Mon, 12 Dec 88 19:54 EST
+From: Michael McIlrath <mbm@DARJEELING.MIT.EDU>
+Subject: 18.62/chaos 76 => syshst; hstee?
+To: info-hosts@AI.AI.MIT.EDU
+Message-ID: <19881213005411.9.MBM@DARJEELING.MIT.EDU>
+
+
+Does anyone have any objection to the IP and
+chaos hosts currently listed in AI:syshst; HSTG
+that are on IP subnet 18.62 and/or chaos subnet
+076 moving to the HSTEE file?  
+
+This wire is now a semi-autonomous region and I
+would like to have a dedicated place to keep up 
+with our stuff.  This will also include the 
+existing hosts in HSTEE (to the extent that they
+really DO exist!)
+
+--mike
+
+Received: from SRI-NIC.ARPA (TCP 1200000063) by AI.AI.MIT.EDU 19 Nov 88 17:13:01 EST
+Date: Sat, 19 Nov 88 14:04:51 PST
+From: Douglas Weiman <WEIMAN@SRI-NIC.ARPA>
+Subject: Re: added Xenon to HSTG
+To: Kevin_Crowston@XV.MIT.EDU
+cc: info-hosts@ai.ai.mit.edu
+In-Reply-To: <0.43520.29067.23803.10052@XV.MIT.EDU>
+Message-ID: <12447886878.25.WEIMAN@SRI-NIC.ARPA>
+
+
+
+Kevin -
+
+Because of the size of the Host Table and the push toward the use of
+the domain system, we are not registering individual internet hosts
+that are already under fully-registered domains.
+
+Since the host mentioned in your message is within the MIT.EDU domain,
+and therefore fully accessible to the Internet community, we can not
+register it in the Host Table.
+
+If you have any other concerns, please let us know.
+
+
+Thanks -
+
+
+Douglas
+Hostmaster
+
+
+-------
+
+Received: from XV.MIT.EDU (TCP 2225400004) by AI.AI.MIT.EDU 15 Nov 88 18:24:40 EST
+Received: from MITMS1-E52: by XV.MIT.EDU; 11 Mar 88 14:48:06 EST
+cc: Kevin_Crowston@XV.MIT.EDU
+To: info-hosts@ai.ai.mit.edu
+Subject: added Xenon to HSTG
+From: Kevin_Crowston@XV.MIT.EDU
+Date: 15 Nov 88 18:18:30 EST
+Message-ID: <0.43520.29067.23803.10052@XV.MIT.EDU>
+Sender: Kevin_Crowston@XV.MIT.EDU
+
+I added an entry for a PC and sometimes print server,
+
+HOST : XENON : 18.86.0.153 : IBMPC : MSDOS ::
+
+It's in E53-322, and I'm the contact:
+
+Kevin Crowston
+x 2781.
+
+
+
+Received: from MC.LCS.MIT.EDU (CHAOS 3131) by AI.AI.MIT.EDU 28 Oct 88 16:06:41 EDT
+Received: from XV.MIT.EDU (TCP 2225400004) by MC.LCS.MIT.EDU 28 Oct 88 16:03:09 EDT
+Received: from MITMS1-E40: by XV.MIT.EDU; 11 Mar 88 14:48:06 EST
+To: info-hosts@mc.lcs.mit.edu
+Subject: adding workstations
+From: Kevin@XV.MIT.EDU
+Sender: 
+Date: 28 Oct 88 15:48:47 EDT
+Message-ID: <0.43520.20995.61221.10022@XV.MIT.EDU>
+Sender: Kevin_Crowston@XV.MIT.EDU
+
+What's the general feeling about adding workstations to the MIT hosts
+tables?  I have about 25, possibly expanding to 35 or 40.  We rarely
+need to talk directly to them, but it would be nice if the nameservers knew 
+enough about them to be able to answer IN-ADDR type queries...  any feeling
+about whether or not to add them?
+
+
+Kevin
+
+
+
+Received: from XX.LCS.MIT.EDU (CHAOS 2420) by AI.AI.MIT.EDU  6 Oct 88 14:59:37 EDT
+Date: Thu, 6 Oct 1988  14:55 EDT
+Message-ID: <SRA.12436318085.BABYL@XX.LCS.MIT.EDU>
+From: Rob Austein <SRA@XX.LCS.MIT.EDU>
+To:   Info-Hosts@AI.AI.MIT.EDU, Info-Hosts-Update@AI.AI.MIT.EDU
+Subject: MIT-foo nicknames flushed from HSTMIT & HOSTS3 tables
+
+After the dust settled, the most reasonable suggestion was to turn off
+the automatic nickname generation in the host table compiler job.  So
+all the MIT-foo.ARPA nicknames, etc, will no longer be present in
+future tables.  Sites which still use this stuff might want to
+consider updating any instances of MIT-foo names to the real
+cannonical names now, before the last copies of the old tables become
+inaccessable.
+
+The list of changes caused by this is so large that the SRCCOM will
+not be sent out as a mail message to INFO-HOSTS-UPDATE; interested
+parties should look in XX:<HOSTS> for the diffs.
+
+At this point I am unlikely to make changes to the code except to fix
+major bugs on XX or the ITS machines; pleas for other changes will be
+listened to but are unlikely to be acted upon.
+
+--Rob
+
+Received: from XX.LCS.MIT.EDU (CHAOS 2420) by AI.AI.MIT.EDU 22 Sep 88 12:46:10 EDT
+Date: Thu 22 Sep 88 11:34:37-EDT
+From: Rob Austein <SRA@XX.LCS.MIT.EDU>
+Subject: End of the road, anybody got any bright ideas?
+To: Info-Hosts@AI.AI.MIT.EDU, Bug-COMSAT@AI.AI.MIT.EDU
+Message-ID: <12432611487.23.SRA@XX.LCS.MIT.EDU>
+
+The HOSTS3 compiler ran out of address space again, and I've run out of
+clever ideas for how to automaticly discard useless information to make
+everything important fit again.  So unless somebody comes up with some
+bright idea, this means the end of the comprehensive HOSTS3 table
+and its derivatives.  There is no problem with continuing to produce
+the chaosnet host tables,  although at the moment that process is
+also stopped due to the breakage of the comprehensive table.
+
+Once again I ask that anybody left using the comprehensive table
+make themselves known.  We already know about the ITS machines.
+Anyone else?  If I don't hear loud screams (and suggestions)
+I'll assume that from this point on the HOSTS3 table stuff is
+an ITS internal maintainance issue of no interest to anyone else.
+
+--Rob
+-------
+
+Received: from MC.LCS.MIT.EDU (CHAOS 3131) by AI.AI.MIT.EDU 15 Sep 88 00:49:52 EDT
+Received: from wheat-chex.ai.mit.edu (TCP 20015023057) by MC.LCS.MIT.EDU 14 Sep 88 23:22:26 EDT
+Received: by wheat-chex.ai.mit.edu; Wed, 14 Sep 88 23:22:53 EDT
+Date: Wed, 14 Sep 88 23:22:53 EDT
+From: foner@wheaties.ai.mit.edu (Leonard N. Foner)
+Message-Id: <8809150322.AA28206@wheat-chex.ai.mit.edu>
+To: sun-bugs@wheaties.ai.mit.edu, sra@xx, info-hosts@mc.lcs.mit.edu
+Subject: TAC -> WC loses, TERMINUS -> WC wins; why?
+Cc: foner@wheaties.ai.mit.edu
+
+I just spent a frustrating time connected to WC from MIT-TAC (I was
+trying to keep load off Terminus, and had misplaced the direct phone
+numbers).
+
+Coming in from the TAC, with me as the only non-idle user on WC, I got
+extremely bursty I/O.  It came about a line at a time, with an average
+speed of about 300 baud on a 1200 baud connection.  This looks like
+some fairly repeatable network lossage combined with a smallish buffer
+(one line is much less than 576 octets...).
+
+I hung up and came in through Terminus immediately thereafter.  No
+problems, normal I/O.
+
+Has anyone else experienced problems with the TAC?  I've never had
+this bursty behavior talking to other AI/LCS hosts, though it's been a
+while since I've used the TAC, and this could be new behavior.
+
+						<LNF>
+
+P.S.  I have no idea where this message should *really* be going.  If
+there's some more appropriate place, please forward it and CC me.  Tnx.
+
+
+Date: Fri,  9 Sep 88 16:00:14 EDT
+From: "Michael A.  Patton" <MAP@AI.AI.MIT.EDU>
+Subject:  I allocated subnet 037 (decimal 31.)
+To: INFO-HOSTS@AI.AI.MIT.EDU
+Message-ID: <440333.880909.MAP@AI.AI.MIT.EDU>
+
+I allocated subnet Octal 037, Decimal 31 for use as the SLIP subnet
+for LCS hosts off SLUDGE.  The updated line from HSTNET is:
+
+SUBNET :  037 : 18.31.0.0   : LCS.MIT.EDU : LCS SLIP subnet off Sludge
+
+Received: from MC.LCS.MIT.EDU (CHAOS 3131) by AI.AI.MIT.EDU 16 Aug 88 03:43:49 EDT
+Date: Tue, 16 Aug 88 03:43:23 EDT
+From: Rob Austein <SRA@MC.LCS.MIT.EDU>
+Subject:  Host table and LCS.MIT.EDU zone updates missing for a little while
+To: Info-Hosts@AI.AI.MIT.EDU, Postmaster@AI.AI.MIT.EDU
+Reply-To: Whorfin@MC.LCS.MIT.EDU
+Message-ID: <466978.880816.SRA@MC.LCS.MIT.EDU>
+
+One of the disks in XX's primary filesystem headcrashed this evening,
+and I'll be out of town for the rest of the week by the time the
+filesystem can be put back together, so all the batch jobs that run at
+wee hours on XX will be out of commission until next week.  In
+particular, SYSBIN;HOSTS3 BIN on the ITS machines and LCS.ZONE on the
+LCS unix machines will not be updated until the batch jobs are running
+again; please talk to Mike Patton <MAP@AI.AI.MIT.EDU> if some
+emergency requires that changes be made before XX is fixed.
+
+--Rob
+
+
+Received: from GOLDILOCKS.MIT.EDU (CHAOS 15470) by AI.AI.MIT.EDU 20 Jul 88 15:05:38 EDT
+Received: from WINNIE-THE-POOH.MIT.EDU by GOLDILOCKS.MIT.EDU via CHAOS with CHAOS-MAIL id 51610; Wed 20-Jul-88 15:09:53 EDT
+Date: Wed, 20 Jul 88 15:05 EDT
+From: David H. Kaufman <Qux@GOLDILOCKS.MIT.EDU>
+Subject: SPEECH going away
+To: info-hosts@AI.AI.MIT.EDU
+Message-ID: <19880720190552.7.QUX@WINNIE-THE-POOH.MIT.EDU>
+Zippy-Says: I think I am an overnight sensation right now!!
+
+SPEECH will be going out of service sometime in October.  This means
+that the gateway between subnets 1 and 033 (provided by SPEECH-11) will
+very probably disappear as well.  This will leave BYPASS as the primary
+(perhaps the only) subnet 1 gateway on this side of the tracks.
+
+EECS-11 is listed in HSTEE as having an address on sn 076 (37142) and in
+the Lispm namespace as having an address on sn 025 (12542).  At the
+current writing, neither of these appear in its routing table.
+
+PLASMA is listed in HSTG & the namespace as being on subnet 1, but it
+doesn't seem to be there either.  There's also something called EETEST
+in the namespace that doesn't seem to be out there.
+
+Received: from XX.LCS.MIT.EDU (CHAOS 2420) by AI.AI.MIT.EDU  9 Jul 88 15:28:42 EDT
+Date: Sat 9 Jul 88 15:24:46-EDT
+From: Rob Austein <SRA@XX.LCS.MIT.EDU>
+Subject: Automatic table update
+To: info-hosts@AI.AI.MIT.EDU
+Message-ID: <12412992582.34.SRA@XX.LCS.MIT.EDU>
+
+Zermatt seems to have refrained from barfing on the LCS namespace for
+several days, so the automatic host table update job on XX is running
+again.
+-------
+
+Received: from XX.LCS.MIT.EDU (CHAOS 2420) by AI.AI.MIT.EDU  8 Jul 88 12:52:40 EDT
+Date: Fri, 8 Jul 1988  12:48 EDT
+Message-ID: <SRA.12412702011.BABYL@XX.LCS.MIT.EDU>
+From: Rob Austein <SRA@XX.LCS.MIT.EDU>
+To:   namecallers@MC.LCS.MIT.EDU, info-hosts@AI.AI.MIT.EDU
+Subject: machine readable subnet table in AI:SYSHST;HSTNET >: clarification
+
+I forgot a paragraph in the previous message.
+
+The naming authority for a given subnet should not be confused with
+some kind of limitation on the names of the hosts on that subnet; the
+naming authority field simply specifies which zone's nameservers have
+responsibility for providing the IN-ADDR data.  Eg, there are a number
+of AI lab machines on subnet 18.26.0.0, but LCS is responsible for
+providing the IN-ADDR data for subnet 18.26.0.0.  Think of "the naming
+authority for this subnet is FOO" as meaning "the nameservers that are
+authoritative for the FOO zone are also authoritative for the IN-ADDR
+data for this subnet".
+
+Received: from XX.LCS.MIT.EDU (CHAOS 2420) by AI.AI.MIT.EDU  8 Jul 88 12:45:38 EDT
+Date: Fri, 8 Jul 1988  12:41 EDT
+Message-ID: <SRA.12412700658.BABYL@XX.LCS.MIT.EDU>
+From: Rob Austein <SRA@XX.LCS.MIT.EDU>
+To:   namecallers@MC.LCS.MIT.EDU, info-hosts@AI.AI.MIT.EDU
+Subject: machine readable subnet table in AI:SYSHST;HSTNET >
+
+I finally had sufficient motivation to design (with some help from
+Mike Patton) a machine readable syntax for the master MIT subnet table
+that lives on AI.  I've placed a copy of the file in the usual place
+(AI: SYSHST; HSTNET >).
+
+Comments and corrections welcome.  Please indicate whether your
+comments/corrections refer to the SYNTAX of the table or the DATA that
+is presently in the table; Mike and I are well aware that some of the
+data is horribly out of date.
+
+If the comments and the syntax are clear enough that you understand
+the table, please feel free (nay, encouraged) to update anything you
+know to be obsolete.  If the syntax or comments are too opaque, please
+say so.
+
+The data I'm trying to distribute via this table is the following:
+ 1) Subnet masks for all known MIT networks.
+ 2) Which IP network (one at most) a given subnet is part of.
+ 3) Which portion of MIT is the naming authority for a particular
+    subnet (eg, LCS owns subnet 18.26.0.0); the notation is less
+    general than the domain system itself, but seems sufficient for
+    the way we allocate subnets and domains at MIT.
+ 4) Whether or not this subnet is believed to be allocated properly
+    (ie, whether there is a known conflict with this subnet because
+    somebody didn't follow the rules).
+ 5) A text string indicating physical location and/or a contact.
+
+Eventually I hope to have a program that will do some kind of
+automated consistancy checking of this table against both itself and
+the combined MIT host tables so that it can notify the appropriate
+people if somebody does something weird.
+
+The proximate cause of all this is that I need to automate the
+proceedure by which the LCS zone file constructor job figures out
+which subnets of net 18 LCS currently owns so that it can generate the
+right IN-ADDR zone files.
+
+--Rob
+
+Received: from XX.LCS.MIT.EDU (CHAOS 2420) by AI.AI.MIT.EDU  6 Jul 88 11:34:34 EDT
+Date: Wed 6 Jul 88 11:30-EDT
+From: Rob Austein <SRA@XX.LCS.MIT.EDU>
+Subject: Automatic host table updates temporarily disabled
+To: Info-Hosts@AI.AI.MIT.EDU
+
+I've turned off the automatic update job that generates new host tables
+on XX and the ITS machines, due to a problem with the LCS lispm namespace.
+XX, the ITS machines, and the LCS domain nameservers have been backed out
+of the bad generated files.  I'll turn the updater back on as soon as the
+problem is under control.
+
+Received: from XX.LCS.MIT.EDU (CHAOS 2420) by AI.AI.MIT.EDU  6 Jul 88 11:34:34 EDT
+Date: Wed 6 Jul 88 11:30-EDT
+From: Rob Austein <SRA@XX.LCS.MIT.EDU>
+Subject: Automatic host table updates temporarily disabled
+To: Info-Hosts@AI.AI.MIT.EDU
+
+I've turned off the automatic update job that generates new host tables
+on XX and the ITS machines, due to a problem with the LCS lispm namespace.
+XX, the ITS machines, and the LCS domain nameservers have been backed out
+of the bad generated files.  I'll turn the updater back on as soon as the
+problem is under control.
+
+Received: from XX.LCS.MIT.EDU (CHAOS 2420) by AI.AI.MIT.EDU 31 May 88 22:58:42 EDT
+Date: Tue, 31 May 1988  22:57 EDT
+Message-ID: <SRA.12402851293.BABYL@XX.LCS.MIT.EDU>
+From: Rob Austein <SRA@XX.LCS.MIT.EDU>
+To:   Info-Hosts@AI.AI.MIT.EDU
+Subject: Bozos adding Athena's DIALUP machine to Tech Square namespaces
+
+Would whoever keeps adding Athena's DIALUP (aka M11-111-1.MIT.EDU)
+machine to the Tech Square namespaces please come talk to me?  I'm
+getting tired of deleting it, presumably you're getting tired of
+adding it too.
+
+Thanks.
+
+--Rob
+
+Received: from MC.LCS.MIT.EDU (CHAOS 3131) by AI.AI.MIT.EDU 12 May 88 04:05:58 EDT
+Received: from GAAK.LCS.MIT.EDU (TCP 2206400041) by MC.LCS.MIT.EDU 11 May 88 16:26:42 EDT
+Received: by GAAK.LCS.MIT.EDU (4.12/4.7); Wed, 11 May 88 12:39:35 ast
+Date: Wed, 11 May 88 12:39:35 ast
+From: map@GAAK.LCS.MIT.EDU (Michael A. Patton)
+Message-Id: <8805111639.AA00549@GAAK.LCS.MIT.EDU>
+To: Info-Hosts@mc
+Subject: [psz@MC.LCS.MIT.EDU: I took another subnet]
+
+Date: Mon, 9 May 88 15:56 EDT
+From: psz@MC.LCS.MIT.EDU
+Sender: TAR@MC.LCS.MIT.EDU
+Subject: I took another subnet
+To: map@GAAK.LCS.MIT.EDU
+Cc: psz@MC.LCS.MIT.EDU, tar@MC.LCS.MIT.EDU
+
+Mike, as threatened, I took subnet 45 (dec) for the chaos/ip link to NEMC.  I recorded
+this in the file AI:SYSHST;HSTNET >.  --Pete Sz.
+
+
+
+Received: from XX.LCS.MIT.EDU (CHAOS 2420) by AI.AI.MIT.EDU  9 May 88 22:28:19 EDT
+Date: Mon, 9 May 1988  22:21 EDT
+Message-ID: <SRA.12397077703.BABYL@XX.LCS.MIT.EDU>
+From: Rob Austein <SRA@XX.LCS.MIT.EDU>
+To:   Info-Hosts@AI.AI.MIT.EDU
+Subject: Host table generation tweaks & impending death of global HOSTS3 table
+
+People who are both interested and alert will have noticed that host
+table compilation has been broken for the last few weeks.  I finally
+bit the bullet and tightened up the TECO code a bit to get rid of some
+unnecessary nicknames, because we needed to get Bloom-Beacon.MIT.EDU
+into the tables ASAP.
+
+The new code will only generate the various nicknames for the primary
+short name of a host.  Eg,
+
+HOST : xxx : FOOBAR,FOO : .... :
+
+now becomes
+
+HOST : xxx : FOOBAR.LCS.MIT.EDU,MIT-FOOBAR.ARPA,MIT-FOOBAR,FOOBAR,FOO : ... :
+
+Formerly, it would have also gotten names FOO.LCS.MIT.EDU,
+MIT-FOO.ARPA, and MIT-FOO.  The change saves a few pages of string
+space, which made the difference in getting the compiler to run again.
+The one exception to this rule is that VX.LCS.MIT.EDU, by special
+dispensation, still gets the full range of nicknames for their former
+name (MIT-VAX), since that's still their primary name on Usenet.
+Hosts in the AI lab table are uneffected by this change; if I find the
+time I'll probably switch all the tables in AI: SYSHST; over to work
+the way HSTAI does so that I can stop maintaining this silly nickname
+generation code.
+
+This is about as far as I can take the various tricks without removing
+stuff that people think is essential.  The next casualty will probably
+be all names of the form "MIT-foo" and "MIT-foo.ARPA".  I expect that
+there will be a lot of weeping and wailing when this happens.  The
+time after that, we'll have no choice but to start removing hosts from
+one of the tables (or remove one of the tables entirely, or remove all
+nicknames from hosts in the NIC table, or something equally drastic).
+
+Hostmasters and Postmasters are hereby warned that I expect the
+comprehensive HOSTS3 table generation effort to stop working for good
+sometime within the next year and should plan accordingly.
+
+--Rob
+
+Received: from XX.LCS.MIT.EDU (CHAOS 2420) by AI.AI.MIT.EDU 23 Feb 88 18:31:32 EST
+Date: Tue, 23 Feb 1988  18:29 EST
+Message-ID: <SRA.12377123370.BABYL@XX.LCS.MIT.EDU>
+From: Rob Austein <SRA@XX.LCS.MIT.EDU>
+To:   CR-People@XX.LCS.MIT.EDU, Info-Hosts@AI.AI.MIT.EDU
+Subject: LCS|TANDOOR aka TANDOOR.LCS.MIT.EDU
+
+Will the person who added the machine TANDOOR to the LCS namespace
+please either send me email or refrain from editing the LCS namespace
+in the future?  You screwed up, and one of the things you broke was
+the mechanism by which I usually track down people who screw up
+without having to broadcast the lossage.
+
+Thanks.
+
+--Rob
+
+Received: from GOLDILOCKS.MIT.EDU (CHAOS 15470) by AI.AI.MIT.EDU 23 Feb 88 15:49:35 EST
+Received: from WINNIE-THE-POOH.MIT.EDU by GOLDILOCKS.MIT.EDU via CHAOS with CHAOS-MAIL id 22407; Tue 23-Feb-88 15:51:55 EST
+Date: Tue, 23 Feb 88 15:46 EST
+From: David Kaufman and Bob Armstrong <SR.KAUFMAN@SPEECH.MIT.EDU>
+Sender: Qux@GOLDILOCKS.MIT.EDU
+Subject: SN 022/18.
+To: info-hosts@AI.AI.MIT.EDU
+Message-ID: <880223154647.1.QUX@WINNIE-THE-POOH.MIT.EDU>
+
+We've snagged sn 022/18. for the RLE backbone Ethernet (coming soon to a
+building near you).
+
+
+Date: Fri, 19 Feb 88 14:04:46 EST
+From: Richard Mlynarik <MLY@AI.AI.MIT.EDU>
+Subject: substantia-gelatinosa
+To: cbip@OZ.AI.MIT.EDU
+cc: INFO-HOSTS@AI.AI.MIT.EDU
+Message-ID: <329081.880219.MLY@AI.AI.MIT.EDU>
+
+Because of un*x braindeath (tm), substantia-gelatinosa.ai.mit.edu
+has been renamed substantia-nigra.ai.mit.edu, aka nigra.
+
+The suns apparently limit the length of a host's name to 31 characters.
+
+Received: from XX.LCS.MIT.EDU (CHAOS 2420) by AI.AI.MIT.EDU  4 Feb 88 17:27:26 EST
+Date: Thu, 4 Feb 1988  17:21 EST
+Message-ID: <SRA.12372130311.BABYL@XX.LCS.MIT.EDU>
+From: Rob Austein <SRA@XX.LCS.MIT.EDU>
+To:   Internet-Contacts-Routine@XX.LCS.MIT.EDU, Registrar@SRI-NIC.ARPA,
+      Postmaster@SRI-NIC.ARPA
+cc:   Info-Hosts@AI.AI.MIT.EDU
+Subject: Mailing list INTERNET-CONTACTS@XX.LCS.MIT.EDU
+Reply-To: Internet-Contacts-Request@LCS.MIT.EDU
+
+As part of cleaning up the list of SysAdmins and contact points for
+LCS in the NIC's records, I split the list INTERNET-CONTACTS@XX into
+two sublists; mail to INTERNET-CONTACTS will still reach both lists.
+
+INTERNET-CONTACTS-ROUTINE is for people who want to receive both
+emergency messages and routine stuff like notifications of new host
+tables, DDN management bulletins, etcetera.
+
+INTERNET-CONTACTS-ACTION-ONLY is for people who only want to get
+emergency messages from the NIC.  This is primarily intended for LCS
+sysadmins, but anybody can join if they so desire.
+
+For those who don't remember, I set up INTERNET-CONTACTS back in '85
+to protect the NIC from having to know email addresses for each and
+every administrator of each and every VAX 750 at MIT.  Here in the
+future, the problem is even worse than it was then, so I'm trying to
+resurect interest in using this list.  Once I sort through the list of
+hosts that the NIC currently has on file, I'll be asking to have all
+the LCS hosts list INTERNET-CONTACTS as the email address for the
+point of contact in the Registrar database, regardless of who is
+system administrator of the host this week.
+
+NIC people: Please change all occurrences of "INTERNET-CONTACTS@XX" in
+the lists of recipients for routine matters (host table notifications,
+DDN MGT messages, etcetera) to INTERNET-CONTACTS-ROUTINE@LCS.MIT.EDU.
+
+INTERNET-CONTACTS people: please let me know which list, if either,
+you want to be on.
+
+Thanks,
+
+--Rob
+
+Received: from PTT.LCS.MIT.EDU (TCP 2206400163) by AI.AI.MIT.EDU 22 Jan 88 14:00:09 EST
+Received: from shep.sage by PTT.LCS.MIT.EDU via PCMAIL with DMSP
+	id AA22735; Fri, 22 Jan 88 14:02:50 EST
+Date: Fri, 22 Jan 88 14:02:50 EST
+Message-Id: <8801221902.AA22735@PTT.LCS.MIT.EDU>
+To: info-hosts@ai.ai.mit.edu
+Subject: LARCH.LCS.MIT.EDU, new address
+Sender: shep@PTT.LCS.MIT.EDU
+From: shep@PTT.LCS.MIT.EDU
+Repository: PTT
+Originating-Client: sage
+
+
+LARCH.LCS.MIT.EDU is now at 18.26.0.95.  It's old address (18.10.0.90)
+will no longer work.
+
+
+
+Received: from XX.LCS.MIT.EDU (CHAOS 2420) by AI.AI.MIT.EDU 14 Dec 87 15:41:56 EST
+Date: Sunday, 13 December 1987  16:23-EST
+Message-ID: <SRA.12358480435.BABYL@XX.LCS.MIT.EDU>
+Sender: Rich Zellich <ZELLICH@SRI-NIC.ARPA>
+From: Rich Zellich <ZELLICH@SRI-NIC.ARPA>
+To: List-Coordinators-1: ;@XX.LCS.MIT.EDU
+Subject:   WISCVM being changed to CUNYVM
+ReSent-From: SRA@XX.LCS.MIT.EDU
+ReSent-To: Info-Hosts@AI.AI.MIT.EDU
+ReSent-Date: Mon 14 Dec 1987 15:40-EST
+
+Following message forwarded from the BitNet source FYI:
+-Rich
+-------------------------------------------------------
+
+
+
+As has been announced in a number of places, the Internet <-> BITNET gateway 
+at WISCVM (WISCVM.WISC.EDU) is going away.  The final date for using that 
+gateway is Dec 15, 1987.
+
+BITNET has been working with the Internet administration to provide a set of 
+multiple regional gateways between the two networks.  Until that time when a 
+suitable technical solution is developed, an interim solution has been put in
+place, effective immediately.
+
+From the BITNET side, mail should be sent to SMTP@INTERBIT.  The node is 
+currently in the tables distributed by BITNIC, and now points towards CUNYVM.
+ At a later date, this will point to the appropriate regional gateway.  The 
+distributed DOMAIN NAMES file is being updated to point at SMTP@INTERBIT 
+instead of SMTP@WISCVM.  The updated file will be distributed as the normal 
+distribution on Monday, Dec 7.  All sites, especially those other than end 
+nodes, should ensure that the latest tables are installed.
+
+For those on the Internet side, the first of the gateways is at 
+CUNYVM.CUNY.EDU (CUNYVM on the BITNET side).  Any mail formerly sent to 
+user%node.BITNET@WISCVM.WISC.EDU should now be sent to 
+user%node.BITNET@CUNYVM.CUNY.EDU.  This is an interim solution until the full
+set of gateways is in place.  At that time, notice will be sent out giving 
+details of the new gateways.
+
+Those users on other networks who use WISCVM as a gateway to BITNET need to 
+modify their mailer tables appropriately.
+
+The code running in the gateway is fully compatible with the code currently 
+running at the WISCVM gateway.  Any mail which worked at the WISCVM gateway 
+will work with the CUNYVM gateway.
+
+If any problems are experienced, you may direct any discussion to 
+POSTMASTER@CUNYVM.CUNY.EDU.
+
+Note:  The node CUNYVM.CUNY.EDU on the Internet is the same as CUNYVM.BITNET.
+ This node now has a direct connection to the Internet.
+
+Ben Yalow
+Director of Systems & Programming
+City University of New York/University Computer Center
+BITNET: YBMCU@CUNYVM           Internet: YBMCU@CUNYVM.CUNY.EDU
+
+Received: from XX.LCS.MIT.EDU (CHAOS 2420) by AI.AI.MIT.EDU  1 Dec 87 14:16:27 EST
+Date: Tue, 1 Dec 1987  14:13 EST
+Message-ID: <SRA.12355056670.BABYL@XX.LCS.MIT.EDU>
+From: Rob Austein <SRA@XX.LCS.MIT.EDU>
+To:   Info-Hosts@AI.AI.MIT.EDU
+Subject: MILO.LCS.MIT.EDU:/etc/nameserver/ns.ca
+
+    Date: Friday, 20 November 1987  16:39-EST
+    From: Rob Austein <SRA@XX.LCS.MIT.EDU>
+    Re:   Changes to root nameservers and other exciting things
+
+    I updated MILO.LCS.MIT.EDU:/etc/nameserver/ns.ca to know about the
+    current list of nameservers (the list changed drasticly this week).
+
+This seems to have stirred interest among people who then run afoul of
+the standard 4.2 anonymous FTP braindamage trying to read the file.
+
+Use TFTP instead of FTP if you want to get this file.
+
+Received: from XX.LCS.MIT.EDU (CHAOS 2420) by AI.AI.MIT.EDU 20 Nov 87 16:44:22 EST
+Date: Fri, 20 Nov 1987  16:39 EST
+Message-ID: <SRA.12352199729.BABYL@XX.LCS.MIT.EDU>
+From: Rob Austein <SRA@XX.LCS.MIT.EDU>
+To:   Namecallers@AI.AI.MIT.EDU, Info-HOSTS@AI.AI.MIT.EDU,
+      VAX-Wizards@MILO.LCS.MIT.EDU, netreq@ATHENA.MIT.EDU
+cc:   CR-People@XX.LCS.MIT.EDU
+Subject: Changes to root nameservers and other exciting things
+
+I updated MILO.LCS.MIT.EDU:/etc/nameserver/ns.ca to know about the
+current list of nameservers (the list changed drasticly this week).
+ALLSPICE.LCS.MIT.EDU has also been updated.  Maintainers of other LCS
+unix machines should copy the file from milo to wherever it lives on
+the local machine (/etc/nameserver/ns.ca under LCS 4.2, /etc/named.ca
+under LCS ultrix and LCS 4.3).  Non-LCS people are welcome to copy the
+file too, but I make no promise that it has what you want.
+
+Two other things.  First, ALLSPICE.LCS.MIT.EDU still hasn't made it
+into the list of authoritative nameservers for LCS, although I know
+that the MIT zone files have been updated at least once since Tim
+Shepard requested this.  Telecomunications people, please take care of
+this (yes, Jeff, I'm still smiling at this point, no flames yet).
+
+Second, I don't know how many of the people receiving this message
+read Namedroppers@NIC, so I'm enclosing a recent message from Paul
+Mockapetris on the subject of antisocial resolvers.  I agree with Paul
+that the only way this will ever be fixed is by running banner
+headlines pointing at the guilty parties.  Some of the real losers are
+here at MIT, so please read this if you haven't seen it already.
+
+--Rob
+
+Date: Thursday, 19 November 1987  22:26-EST
+From: MOCKAPETRIS@A.ISI.EDU
+To:   namedroppers@SRI-NIC.ARPA, bind@UCBARPA.BERKELEY.EDU
+Re:   Who's bad?
+
+One of the problems with the root service is that there are a lot of
+host sourcing bad requests of various flavors.  While I realize that
+many people have better things to do than to play with their domain
+software, I believe that a little peer pressure could go a long way
+toward cleaning up the mess.
+
+I suggest that you check the following list to determine whether your
+hosts are good, bad or ugly.  Sending bogons or too many requests are
+the issues.  Busy hosts may need to send a lot of requests, but some
+of the traffic really looks excessive.  I'd also appreciate it if you
+could send me (not the list) a message identifying good and bad
+implementations/versions; I'll send out a summary.
+
+For the purposes of this discussion, a bogon is a domain packet
+received by the server which is a response, not a request.  Most
+bogons appear to ask for the NS RRs for the root.  The TOPS-20 root
+servers don't respond to bogons, and I believe newer versions of BIND
+also toss bogons.  Please don't "fix" your machine by having it clear
+the response bit; there is no good reason to ask for root server
+changes every minute anyway.  They just don't change that often.
+
+The statistics are for the root server on ISIA
+between 19-Nov-87 03:20:22 and 19-Nov-87 21:11:22)
+
+Name server requests:28654 Bogons:50085 Parse fails:1
+27.8 queries/min 48.5 bogons/min 0.0 parse failure/min
+
+(That's right, the server is ignoring almost 2/3 of its input)
+
+(In the following table, the Start column gives the raw count of
+packets from the specified Host, and the Done column is the number of
+responses sent.  More than 99% of the difference is due to bogons.
+The %Done column is the percentage of good traffic from the specified
+host.  The average time is elapsed ms between reading the packet and
+finishing with it, and only includes good transactions.  No, I don't
+totally understand the time differences; yes, the times are a bit
+suspect, but there are some wierd factors involved.
+
+For example, the first host, ADS.ARPA, seems well behaved.  It sent in
+102 requests and got 102 answers.  The second in the list, 128.6.14.2,
+sent in 1654 bogons, all of which were ignored. Its bad.)
+
+Name server client host distribution
+
+ Start %All   Done %Done Avg time Host
+   102  0.1    102 100.0    186.5 128.229.1.24	ADS.ARPA
+  1654  2.1      0   0.0 ******** 128.6.14.2	
+  1633  2.1      1   0.1    108.0 36.8.0.8	PESCADERO.STANFORD.EDU
+  1369  1.7    554  40.5     66.6 35.1.1.10	UMIX.CC.UMICH.EDU
+  1223  1.6     36   2.9    416.1 128.121.8.1	
+  2868  3.6   1884  65.7     56.1 192.11.34.1	
+  1234  1.6      0   0.0 ******** 128.83.138.12	RATLIFF.CS.UTEXAS.EDU
+  1218  1.5      0   0.0 ******** 128.163.128.51	
+   767  1.0      0   0.0 ******** 128.52.22.14	PREP.AI.MIT.EDU
+   233  0.3    233 100.0     39.4 129.3.1.3	
+  3022  3.8   3022 100.0     91.1 35.2.64.64	
+   523  0.7    523 100.0     82.1 26.1.0.3	
+  1272  1.6      0   0.0 ******** 128.97.16.21	
+   971  1.2      0   0.0 ******** 128.52.32.13	WHEATIES.AI.MIT.EDU
+   959  1.2      0   0.0 ******** 36.63.0.171	
+   214  0.3    214 100.0     42.6 128.10.2.5	PENDRAGON.CS.PURDUE.EDU
+  1369  1.7      0   0.0 ******** 128.32.142.25	
+  1087  1.4     15   1.4    459.3 192.11.34.5	
+  1331  1.7      0   0.0 ******** 128.49.5.1	MPLVAX.NOSC.MIL
+   973  1.2      0   0.0 ******** 128.32.139.100	
+   148  0.2    148 100.0    158.3 26.0.0.73	SRI-NIC.ARPA
+  1240  1.6      0   0.0 ******** 128.163.128.6	
+  1265  1.6      0   0.0 ******** 128.218.1.16	
+   759  1.0     15   2.0    367.9 128.36.0.1	YALE.ARPA
+    49  0.1      0   0.0 ******** 192.5.39.2	DEWEY.UDEL.EDU
+  1118  1.4     14   1.3    307.3 192.12.69.1	ARIZONA.EDU
+  1321  1.7      0   0.0 ******** 192.31.152.33	ROSETTA.COM
+  1517  1.9      0   0.0 ******** 128.128.16.1	AQUA.WHOI.EDU
+  1402  1.8      0   0.0 ******** 128.97.16.17	
+   306  0.4    306 100.0     21.2 128.10.2.1	PURDUE.EDU
+  1355  1.7      0   0.0 ******** 128.97.16.103	
+  1187  1.5      0   0.0 ******** 128.112.34.19	
+  1127  1.4      1   0.1    164.0 128.6.4.16	CAIP.RUTGERS.EDU
+  1248  1.6      0   0.0 ******** 128.32.136.12	LILAC.BERKELEY.EDU
+  1390  1.8      0   0.0 ******** 128.97.16.13	
+  1346  1.7      0   0.0 ******** 128.52.32.4	
+  1088  1.4      0   0.0 ******** 36.22.0.8	CASCADE.STANFORD.EDU
+  1140  1.4      0   0.0 ******** 128.112.28.1	
+   384  0.5      0   0.0 ******** 192.26.85.1	NORTHWESTERN.ARPA
+   655  0.8      0   0.0 ******** 128.101.32.8	CS-GW.D.UMN.EDU
+   568  0.7    568 100.0    238.9 10.2.0.94	UMN-REI-UC.ARPA
+  1374  1.7      3   0.2     67.3 10.0.0.91	WARD.CS.WASHINGTON.EDU
+  1369  1.7      0   0.0 ******** 128.32.131.135	
+  1277  1.6      0   0.0 ******** 192.11.34.4	
+  1367  1.7      0   0.0 ******** 128.32.142.70	
+  1305  1.7      0   0.0 ******** 36.2.0.102	
+  1646  2.1      0   0.0 ******** 128.6.14.9	
+  1039  1.3      0   0.0 ******** 128.112.6.40	MIND.PRINCETON.EDU
+   304  0.4     58  19.1    214.6 128.36.0.3	YALE-BULLDOG.ARPA
+   887  1.1    887 100.0     51.4 128.2.13.21	LANCASTER.ANDREW.CMU.EDU
+     9  0.0      9 100.0    130.4 18.62.0.6	EDDIE.MIT.EDU
+   340  0.4    340 100.0     68.5 26.5.0.73	TWG.ARPA
+    46  0.1     46 100.0    187.6 128.121.51.1	JVNC.CSC.ORG
+   424  0.5    424 100.0    149.2 26.3.0.103	A.ISI.EDU
+   125  0.2    125 100.0    258.7 128.32.136.9	JADE.BERKELEY.EDU
+    12  0.0     12 100.0     62.8 26.1.0.34	LBL-CSAM.ARPA
+  1359  1.7      0   0.0 ******** 192.12.221.4	CSD4.MILW.WISC.EDU
+   131  0.2    131 100.0    178.3 128.6.5.46	
+   716  0.9    716 100.0     62.3 128.6.4.7	RUTGERS.EDU
+   177  0.2    177 100.0    214.8 128.91.2.13	SUPER.UPENN.EDU
+   842  1.1    842 100.0     53.9 128.197.2.62	BUCSD.BU.EDU
+     3  0.0      3 100.0    257.7 18.26.0.92	THEORY.LCS.MIT.EDU
+    55  0.1     55 100.0     13.0 36.2.0.101	
+     4  0.0      4 100.0    197.8 128.97.28.19	ULYSSES.CS.UCLA.EDU
+    30  0.0     30 100.0    279.6 128.109.130.5	
+   148  0.2    148 100.0     76.4 10.3.0.89	COLUMBIA.EDU
+     7  0.0      7 100.0     81.0 18.26.0.99	
+   150  0.2    150 100.0    200.2 128.32.136.22	VIOLET.BERKELEY.EDU
+   469  0.6    469 100.0    110.1 192.5.23.6	BRL-VGR.ARPA
+    65  0.1     65 100.0    446.4 10.2.0.78	UCBVAX.BERKELEY.EDU
+    59  0.1     59 100.0     32.9 15.255.17.2	
+   119  0.2    119 100.0    225.8 35.1.192.4	ACAL.EECS.UMICH.EDU
+    29  0.0     29 100.0     78.5 35.1.128.32	
+    42  0.1     42 100.0     54.0 35.1.128.16	CITI.UMICH.EDU
+    68  0.1     68 100.0     57.1 192.5.48.2	MORDRED.CS.PURDUE.EDU
+   102  0.1    102 100.0    331.8 128.9.0.32	VENERA.ISI.EDU
+   112  0.1    112 100.0     65.1 128.15.0.24	INTREPID.S1.GOV
+     1  0.0      1 100.0     14.0 128.210.0.5	L.CC.PURDUE.EDU
+    49  0.1     49 100.0     13.2 36.22.0.35	
+     2  0.0      2 100.0     17.5 128.2.250.134	
+    85  0.1     85 100.0     85.2 128.205.1.2	
+    48  0.1     48 100.0     85.6 192.12.63.14	
+    41  0.1     41 100.0    190.3 128.102.18.3	AMES.ARPA
+   185  0.2    185 100.0     33.4 192.12.15.31	BNLX.ARPA
+     8  0.0      8 100.0    268.6 128.61.1.251	TROLL-GW.GATECH.EDU
+     4  0.0      4 100.0    116.8 128.46.151.1	NEWTON.PHYSICS.PURDUE.EDU
+   242  0.3    242 100.0     51.8 128.15.16.16	TERMINUS.S1.GOV
+     1  0.0      1 100.0     34.0 128.109.130.91	
+   171  0.2    171 100.0     80.7 192.5.23.2	BRL-VMB.ARPA
+   125  0.2    125 100.0    164.0 192.5.23.8	SEM.BRL.MIL
+     4  0.0      4 100.0    191.5 128.2.222.217	
+    19  0.0     19 100.0    169.7 129.4.16.70	TRWIND.TRW.COM
+    73  0.1     73 100.0    188.7 10.1.0.111	GATEWAY.MITRE.ORG
+   172  0.2    172 100.0     94.3 128.135.4.2	ODDJOB.UCHICAGO.EDU
+    95  0.1     95 100.0     20.4 36.12.0.135	
+    20  0.0     20 100.0    119.1 128.42.17.10	
+     4  0.0      4 100.0     80.8 128.91.254.1	
+    42  0.1     42 100.0    100.6 128.32.137.13	ERNIE.BERKELEY.EDU
+     1  0.0      1 100.0     33.0 128.104.30.17	
+    21  0.0     21 100.0    347.5 128.2.254.132	G.GP.CS.CMU.EDU
+    30  0.0     30 100.0     54.5 26.16.0.18	ABS6.ARPA
+    33  0.0     33 100.0    168.3 10.1.0.37	ASC.CC.PURDUE.EDU
+    14  0.0     14 100.0      4.3 36.2.0.104	
+     9  0.0      9 100.0    142.9 128.2.254.137	K.GP.CS.CMU.EDU
+    10  0.0     10 100.0     74.9 128.32.137.5	
+    77  0.1     77 100.0    264.7 26.6.0.106	VAX.DARPA.MIL
+    54  0.1     54 100.0    119.4 192.5.19.1	ICS.UCI.EDU
+   146  0.2    146 100.0    111.6 192.5.19.31	ROME.UCI.EDU
+    43  0.1     43 100.0    140.2 128.114.130.3	UCSCC.UCSC.EDU
+    16  0.0     16 100.0     22.8 36.2.0.103	
+    22  0.0     22 100.0    190.6 128.92.192.16	PRESTO.IG.COM
+    21  0.0     21 100.0    187.4 128.138.240.1	BOULDER.COLORADO.EDU
+   715  0.9    715 100.0    124.7 10.7.0.2	SUN.COM
+    10  0.0     10 100.0    461.4 10.0.0.4	CS.UTAH.EDU
+    16  0.0     16 100.0    348.5 192.12.141.129	UUNET.UU.NET
+   194  0.2    194 100.0    125.4 192.5.23.3	BRL-SMOKE.ARPA
+    47  0.1     47 100.0    173.9 128.3.254.23	LBL.GOV
+    66  0.1     66 100.0     79.0 192.5.25.4	BRL-ADM.ARPA
+    18  0.0     18 100.0     63.6 10.4.0.17	TIS.ARPA
+   114  0.1    114 100.0     41.9 10.5.0.25	POTOMAC.ADS.COM
+     9  0.0      9 100.0    187.2 192.12.216.4	VAXC.STEVENS-TECH.EDU
+    53  0.1     53 100.0    113.9 128.174.30.3	
+     4  0.0      4 100.0    113.0 128.2.254.157	ROVER.RI.CMU.EDU
+    15  0.0     15 100.0    145.1 26.4.0.103	ADA-VAX.ISI.EDU
+    93  0.1     93 100.0    340.1 128.174.5.50	UXC.CSO.UIUC.EDU
+    25  0.0     25 100.0    184.3 128.32.135.1	BACH.BERKELEY.EDU
+    33  0.0     33 100.0    132.8 128.99.0.1	NRTC.NORTHROP.COM
+    29  0.0     29 100.0    158.2 128.99.0.16	ISD.NRTC.NORTHROP.COM
+     3  0.0      3 100.0     17.3 128.92.192.12	KIWI.IG.COM
+    46  0.1     46 100.0    212.7 10.11.0.20	SCCGATE.SCC.COM
+     8  0.0      8 100.0    153.3 128.54.2.129	AMOS.LING.UCSD.EDU
+     1  0.0      1 100.0    123.0 10.5.0.54	TYBALT.CALTECH.EDU
+     8  0.0      8 100.0     39.9 128.2.254.143	ISL1.RI.CMU.EDU
+     2  0.0      2 100.0    420.0 128.2.250.71	
+     2  0.0      2 100.0     26.5 128.138.238.18	
+     2  0.0      2 100.0     59.5 128.2.220.17	
+     5  0.0      5 100.0    102.8 128.104.39.10	
+    42  0.1     42 100.0    203.5 10.4.0.96	LINC.CIS.UPENN.EDU
+     1  0.0      1 100.0     34.0 18.70.0.59	
+   140  0.2    140 100.0    134.9 128.63.8.5	APG-5.ARPA
+   115  0.1    115 100.0     65.2 127.0.0.1	
+    12  0.0     12 100.0    192.6 128.97.28.28	LANAI.CS.UCLA.EDU
+   739  0.9    739 100.0     33.7 15.255.16.26	
+   839  1.1    839 100.0     29.5 15.255.16.5	
+     8  0.0      8 100.0    129.9 128.97.28.26	MAUI.CS.UCLA.EDU
+     2  0.0      2 100.0      6.5 128.148.55.4	
+   838  1.1      0   0.0 ******** 128.193.32.5	CHROMA.CS.ORST.EDU
+    23  0.0     23 100.0     27.5 36.8.0.154	
+     1  0.0      1 100.0    219.0 128.32.132.1	
+    19  0.0     19 100.0    107.8 26.2.0.95	ANGBAND.S1.GOV
+     8  0.0      8 100.0    150.1 128.2.250.16	WB1.CS.CMU.EDU
+    36  0.0     36 100.0    263.8 10.7.0.82	SH.CS.NET
+    90  0.1     90 100.0    173.8 128.62.1.126	
+    10  0.0     10 100.0     45.7 192.5.23.40	BRL-SVC.ARPA
+     2  0.0      2 100.0    605.5 128.210.0.2	I.CC.PURDUE.EDU
+    28  0.0     28 100.0     93.4 128.2.11.131	ANDREW.CMU.EDU
+     7  0.0      7 100.0     97.0 128.210.2.2	J.CC.PURDUE.EDU
+    11  0.0     11 100.0    229.1 128.118.6.4	
+   170  0.2    170 100.0     87.4 10.0.0.94	CS.WISC.EDU
+    25  0.0     25 100.0     70.6 10.0.0.31	CCA.CCA.COM
+    52  0.1     52 100.0    113.9 128.6.4.61	ELBERETH.RUTGERS.EDU
+   165  0.2    165 100.0    182.1 10.4.0.5	RELAY.CS.NET
+    13  0.0     13 100.0    102.6 35.1.1.7	MCR.UMICH.EDU
+    12  0.0     12 100.0     98.6 128.193.32.1	CS.ORST.EDU
+    63  0.1     63 100.0    283.2 128.182.65.2	B.PSC.EDU
+     1  0.0      1 100.0     33.0 128.2.217.32	
+     6  0.0      6 100.0    140.2 18.10.0.86	MILO.LCS.MIT.EDU
+    14  0.0     14 100.0     94.3 128.46.129.15	EE.ECN.PURDUE.EDU
+     1  0.0      1 100.0     94.0 128.122.129.7	VLSI1.ULTRA.NYU.EDU
+    25  0.0     25 100.0     13.2 36.8.0.136	
+     7  0.0      7 100.0    216.9 128.210.0.4	K.CC.PURDUE.EDU
+   115  0.1    115 100.0    146.1 128.39.2.2	IFI.UIO.NO
+     4  0.0      4 100.0    120.8 128.46.129.30	EI.ECN.PURDUE.EDU
+    22  0.0     22 100.0    186.7 192.5.220.1	BLUTO.SCC.COM
+     1  0.0      1 100.0     15.0 192.5.143.102	
+     6  0.0      6 100.0    222.7 26.0.0.58	NYU.EDU
+    18  0.0     18 100.0    147.6 36.19.0.210	GSB-HOW.STANFORD.EDU
+     7  0.0      7 100.0     69.4 26.6.0.53	EGLIN-VAX.ARPA
+    95  0.1     95 100.0     50.9 128.102.16.1	VIKING.ARC.NASA.GOV
+     9  0.0      9 100.0    102.4 26.9.0.21	NMFECC.ARPA
+     1  0.0      1 100.0     36.0 128.2.220.59	
+    20  0.0     20 100.0    140.8 128.105.2.1	SPOOL.WISC.EDU
+    16  0.0     16 100.0    150.6 128.42.1.4	IAPETUS.RICE.EDU
+   120  0.2    120 100.0    118.4 10.0.0.44	XX.LCS.MIT.EDU
+    20  0.0     20 100.0     69.3 128.118.6.2	PSUVAX1.PSU.EDU
+     1  0.0      1 100.0    218.0 128.2.250.68	
+    21  0.0     21 100.0    201.0 26.7.0.16	DECWRL.DEC.COM
+     9  0.0      9 100.0     41.8 128.45.0.52	SONORA.DEC.COM
+    18  0.0     18 100.0     61.8 128.63.9.2	BRL-IBD.ARPA
+    29  0.0     29 100.0    273.4 128.9.0.33	VAXA.ISI.EDU
+    17  0.0     17 100.0    167.5 128.32.137.7	CAD.BERKELEY.EDU
+   179  0.2    179 100.0    185.4 128.182.65.1	A.PSC.EDU
+     2  0.0      2 100.0     16.5 18.72.0.41	
+    16  0.0     16 100.0    180.8 128.122.130.1	GBA.NYU.EDU
+    31  0.0     31 100.0    114.9 36.8.0.46	SCORE.STANFORD.EDU
+     1  0.0      1 100.0    291.0 128.6.21.5	
+     8  0.0      8 100.0    276.8 128.45.0.5	
+     6  0.0      6 100.0    199.8 128.150.55.10	
+     7  0.0      7 100.0    182.4 192.5.48.3	MERLIN.CS.PURDUE.EDU
+ 10163 12.9   8894  87.5     89.8 ***** Others *****
+
+[End of included message]
+
+Received: from XX.LCS.MIT.EDU (CHAOS 2420) by AI.AI.MIT.EDU 15 Nov 87 17:27:48 EST
+Date: Sun, 15 Nov 1987  17:25 EST
+Message-ID: <SRA.12350897288.BABYL@XX.LCS.MIT.EDU>
+From: Rob Austein <SRA@XX.LCS.MIT.EDU>
+To:   Info-Hosts@AI.AI.MIT.EDU
+Subject: WARNING -- HOSTS3.BIN and friends being pruned some more
+
+As some of you may have noticed, XX hasn't been generating new HOSTS3
+tables for about a week now.  The HOSTS3 compiler ran out of address
+space again.  It has gotten to the point where there is simply no
+addres space left to reallocate, again.  So, I made the table pruning
+code more obnoxious.  It will now completely remove non-MIT hosts that
+it thinks are workstations, such as IBM-PCs, rather than just removing
+nicknames for such hosts.
+
+Beware of bad table versions for the next few days.  I may discover
+the hard way that I've pruned out some essential host; I was going to
+remove all SUN machines except at SUN.COM, until I realized that
+RUTGERS.EDU is now a SUN.
+
+Please send me mail if you think you've been screwed by this.
+
+Received: from XX.LCS.MIT.EDU (CHAOS 2420) by AI.AI.MIT.EDU 26 Oct 87 17:07:53 EST
+Date: Mon 26 Oct 87 15:46:21-EST
+From: John Wroclawski <JTW@XX.LCS.MIT.EDU>
+To: info-hosts@AI.AI.MIT.EDU
+Message-ID: <12345636427.12.JTW@XX.LCS.MIT.EDU>
+
+I snarfed subnet 52 octal/42 decimal for a RLE ethernet...
+-------
+
+Received: from MC.LCS.MIT.EDU (CHAOS 3131) by AI.AI.MIT.EDU 25 Oct 87 20:59:48 EST
+Received: from XX.LCS.MIT.EDU (CHAOS 2420) by MC.LCS.MIT.EDU 25 Oct 87 20:58:51 EST
+Date: Sun 25 Oct 87 20:57:20-EST
+From: John Romkey <ROMKEY@XX.LCS.MIT.EDU>
+Subject: penguin.zbt.mit.edu??
+To: info-hosts@MC.LCS.MIT.EDU
+Message-ID: <12345430895.28.ROMKEY@XX.LCS.MIT.EDU>
+
+A friend of mine ran into this problem...systems using domain
+name resolvers seem to be able to figure out who 'penguin.zbt.mit.edu'
+is, but it doesn't appear in the ITS host tables, so, at the least,
+MC doesn't know it.
+					- john
+-------
+
+
+Received: from XX.LCS.MIT.EDU (CHAOS 2420) by AI.AI.MIT.EDU 22 Sep 87 18:52:28 EDT
+Return-Path: <namedroppers-RELAY@SRI-NIC.ARPA>
+Received: from SRI-NIC.ARPA by XX.LCS.MIT.EDU with TCP/SMTP; Tue 22 Sep 87 18:42:31-EDT
+Received: from venera.isi.edu by SRI-NIC.ARPA with TCP; Tue 22 Sep 87 15:08:04-PDT
+Posted-Date: Tue, 22 Sep 87 15:07:29 PDT
+Message-Id: <8709222207.AA03045@venera.isi.edu>
+Received: from LOCALHOST by venera.isi.edu (5.54/5.51)
+	id AA03045; Tue, 22 Sep 87 15:07:30 PDT
+To: tcp-ip@sri-nic.arpa, namedroppers@sri-nic.arpa
+Cc: bind@ucbarpa.berkeley.edu, 2nd-root@nic.nyser.net
+Subject: Change in root servers
+Date: Tue, 22 Sep 87 15:07:29 PDT
+From: Paul Mockapetris <pvm@venera.isi.edu>
+ReSent-Date: Tue, 22 Sep 87 15:26:54 PDT
+ReSent-From: Mary Stahl <STAHL@SRI-NIC.ARPA>
+ReSent-To: namedroppers@SRI-NIC.ARPA
+ReSent-Message-ID: <12336741835.31.STAHL@SRI-NIC.ARPA>
+ReSent-Date: Tue 22 Sep 87 18:45:09-EDT
+ReSent-From: Rob Austein <SRA@XX.LCS.MIT.EDU>
+ReSent-To: mit-ip-people@MC.LCS.MIT.EDU, info-hosts@AI.AI.MIT.EDU
+ReSent-Message-ID: <12336745157.52.SRA@XX.LCS.MIT.EDU>
+
+The root server set for the domain system will change in October.
+
+The C.ISI.EDU machine is going to its just reward, and its name server
+will stop some time in October.  Toast its demise with a root bier.  The
+NIC will remove it from the domain database approximately one week in
+advance.  Gunter-Adam.arpa will join the official set of root servers
+before C's demise.
+
+As a more long term solution, shakedown of several new root servers
+"closer" to the east coast, NSFnet, etc is underway, and should be
+provide a long term solution.
+
+paul
+
+
+Date: Tue, 18 Aug 87 22:31:02 EDT
+From: "J. Noel Chiappa" <JNC@AI.AI.MIT.EDU>
+Sender: JNC1@AI.AI.MIT.EDU
+Subject: Proteon subnets
+To: INFO-HOSTS@AI.AI.MIT.EDU, mit-ip-people@MC.LCS.MIT.EDU
+cc: JNC@AI.AI.MIT.EDU, bug-cgw@MONK.PROTEON.COM
+Message-ID: <243647.870818.JNC1@AI.AI.MIT.EDU>
+
+	Proteon has now completely shifted over to its own IP
+network number (128.185, as I recall) and has given up the
+block of MIT subnet numbers (122.-135.) it was using. These
+numbers can be reused at will.
+
+	Noel
+
+Received: from XX.LCS.MIT.EDU (CHAOS 2420) by AI.AI.MIT.EDU 13 Jul 87 17:27:39 EDT
+Date: Monday, 13 July 1987  16:36-EDT
+Message-ID: <SRA.12318118265.BABYL@XX.LCS.MIT.EDU>
+Sender: "Eric S. Crawley" <Crawley@ALDERAAN.SCRC.SYMBOLICS.COM>
+From: "Eric S. Crawley" <Crawley@ALDERAAN.SCRC.SYMBOLICS.COM>
+To: mit-ip-people@MC.LCS.MIT.EDU
+cc: CGay@ALDERAAN.SCRC.SYMBOLICS.COM
+Subject:   SCRC Ethernet change
+ReSent-From: SRA@XX.LCS.MIT.EDU
+ReSent-To: Info-Hosts@ai.ai.mit.edu
+ReSent-Date: Mon 13 Jul 1987 17:24-EDT
+
+On Saturday, July 18, the hosts on the SCRC Ethernet (192.10.41.0) are
+having their addresses changed to network 128.81.41.0.  The gateways
+will still advertise routes to 192.10.41.0 until things settle down.
+Please make whatever changes are necessary to your local tables and
+namespaces.  The hostmaster@sri-nic has been notified so the domain
+servers should get the proper information and a new host table should be
+available soon afterwards (we hope).
+	-Eric
+
+Received: from XX.LCS.MIT.EDU (CHAOS 2420) by AI.AI.MIT.EDU 15 Jun 87 22:31:43 EDT
+Date: Monday, 15 June 1987  21:00-EDT
+Message-ID: <SRA.12310833657.BABYL@XX.LCS.MIT.EDU>
+Sender: "James William O'Toole Jr." <james@ZERMATT.LCS.MIT.EDU>
+From: "James William O'Toole Jr." <james@ZERMATT.LCS.MIT.EDU>
+To: psrg@ZERMATT.LCS.MIT.EDU
+cc: mit-ip-people@MC.LCS.MIT.EDU
+Subject:   subnet 30 (decimal) extended, at least temporarily
+ReSent-From: SRA@XX.LCS.MIT.EDU
+ReSent-To: Info-Hosts@ai.ai.mit.edu
+ReSent-Date: Mon 15 Jun 1987 22:29-EDT
+
+I have attached the old IRIS cable to the second floor end of the
+ethernet cable for subnet 30 (decimal), and moved it in the fourth
+floor area from the old IRIS location to the room across from 403.
+
+I have removed Cronkite from subnet 26 (decimal) and added it to
+subnet 30 (decimal) via a vampire-style tap on the IRIS cable.
+[Old address 18.26.0.89, New address 18.30.0.36]
+
+I have enabled Cls's ethernet board once again, telling it that it
+is on subnet 30 decimal, address 18.30.0.35.
+
+I have attempted to update the Symbolics nameservers with this
+information, but I'm not sure they like it.
+
+Traffic with Cls currently will probably perform strangely, because
+it will be slightly confused by having two interfaces.  I can't
+shut the ringnet interface down now, even if I chose to, because
+Cls is being used to test the ringnet on the second floor (I
+think).
+
+  --Jim
+
+P.S. Anyone knowing the precise length of the subnet 30 (decimal)
+     ethernet cables (and/or the IRIS cable) should speak up.  It is
+     possible that the addition of the IRIS piece puts it over the
+     limit, although I doubt it.
+
+Received: from GOLDILOCKS.MIT.EDU by AI.AI.MIT.EDU via Chaosnet; 28 MAY 87  08:32:00 EDT
+Received: from WINNIE-THE-POOH.MIT.EDU by GOLDILOCKS.MIT.EDU via CHAOS with CHAOS-MAIL id 3608; Thu 28-May-87 08:30:09 EDT
+Date: Thu, 28 May 87 08:29 EDT
+From: David H. Kaufman <Sr.Kaufman@SPEECH.MIT.EDU>
+Subject: Baloo and Paddington
+To: info-hosts@AI.AI.MIT.EDU
+Message-ID: <870528082934.2.QUX@WINNIE-THE-POOH.MIT.EDU>
+Zippy-Says: Yow!  It's some people inside the wall!  This is better than mopping!
+
+Oh yeah.  I added Baloo and Paddington to HSTG yesterday.  They're 3640s
+that are going to arrive last week, or at latest sometime before the Red
+Sox win their next pennant.
+
+Date: Wed, 27 May 87 03:10:29 EDT
+From: "Pandora B. Berman" <CENT@AI.AI.MIT.EDU>
+Subject: addition
+To: INFO-HOSTS@AI.AI.MIT.EDU
+Message-ID: <205683.870527.CENT@AI.AI.MIT.EDU>
+
+tired of EAK's mail not reaching him.
+added GLACIER.STANFORD.EDU to HSTXXX.
+ME@SAIL gave me the host #.
+hope it's correct.
+
+Received: from XX.LCS.MIT.EDU (CHAOS 2420) by AI.AI.MIT.EDU  7 May 87 12:18:17 EDT
+Date: Thu 7 May 87 12:10-EDT
+From: Rob Austein <SRA@XX.LCS.MIT.EDU>
+Subject: MIT-KNOWHOW
+To: Info-Hosts@AI.AI.MIT.EDU, go@ZERMATT.LCS.MIT.EDU
+
+Would somebody who thinks they understand what is going on with the
+host variously known as MIT-KNOWHOW, MIT-KNOW-HOW, KNOWHOW.MIT.EDU,
+KNOWHOW.LCS.MIT.EDU, LCS|KNOWHOW, and MIT|KNOWHOW, please send me mail
+explaining things?  The machine is listed as being on two different
+subnets in two different buildings, aside from being in two namespaces
+and at least one wrong host table on AI.  This is probably not what
+you wanted....
+
+Thanks.
+
+--Rob
+
+Received: from GOLDILOCKS.MIT.EDU by AI.AI.MIT.EDU via Chaosnet; 5 MAY 87  14:02:53 EDT
+Received: from SMOKEY.MIT.EDU by GOLDILOCKS.MIT.EDU via CHAOS with CHAOS-MAIL id 3030; Tue 5-May-87 14:00:55 EDT
+Date: Tue, 5 May 87 14:00 EDT
+From: David H. Kaufman <Sr.Kaufman@SPEECH.MIT.EDU>
+Subject: Pooh and Friends
+To: info-hosts@AI.AI.MIT.EDU
+Message-ID: <870505140045.1.QUX@SMOKEY.MIT.EDU>
+Zippy-Says: I'm meditating on the FORMALDEHYDE and the ASBESTOS leaking into my
+            PERSONAL SPACE!!
+
+I added WINNIE-THE-POOH (with the obvious nicknames) at Chaos 15471,
+Internet 18.27.0.57.  I also added Goldilocks' nickname of AU.
+
+While I was there, I added the appropriate Internet address for all the
+other Speech Group Lisp machines, and put an identifying comment before
+each machine's entry.
+
+Received: from XX.LCS.MIT.EDU (CHAOS 2420) by AI.AI.MIT.EDU 13 Apr 87 13:43:52 EDT
+Received: from WHORFIN.LCS.MIT.EDU by XX.LCS.MIT.EDU via Chaosnet; 13 Apr 87 13:37-EDT
+Date: Mon, 13 Apr 87 13:41 EDT
+From: Rob Austein <sra@XX.LCS.MIT.EDU>
+Subject: Automatic installation will be turned on tonight
+To: Info-Hosts@AI.AI.MIT.EDU
+Message-ID: <870413134123.1.SRA@WHORFIN.LCS.MIT.EDU>
+
+The 20x machines no longer need to have the pre-April-1 host tables
+(except for Deep-Thought, whose maintainers know about it).  Judging by
+the overwelming volume of response, nobody else cares, so I'll turn
+table installation back on as of tonight.
+
+--Rob
+
+Date: Thu,  9 Apr 87 16:18:26 EDT
+From: "Timothy J. Shepard" <SHEP@AI.AI.MIT.EDU>
+To: INFO-HOSTS@AI.AI.MIT.EDU
+Message-ID: <181906.870409.SHEP@AI.AI.MIT.EDU>
+
+I added NC at chaos 34011 to HSTG for HGA@DT.
+
+Received: from MC.LCS.MIT.EDU (CHAOS 3131) by AI.AI.MIT.EDU  9 Apr 87 14:46:24 EDT
+Received: from CAF.MIT.EDU by MC.LCS.MIT.EDU via Chaosnet; 9 APR 87  14:19:17 EDT
+Received: by caf.MIT.EDU (5.54/4.7) id AA11439; Thu, 9 Apr 87 14:15:11 EDT
+Date: Thu, 9 Apr 87 14:15:11 EDT
+From: george@caf.MIT.EDU (george rittenhouse)
+To: info-hosts@mc, mbm
+Subject: Re:  chaplin, hitchcock
+Cc: boning
+
+thanks.....
+
+
+Received: from MC.LCS.MIT.EDU (CHAOS 3131) by AI.AI.MIT.EDU  9 Apr 87 14:28:14 EDT
+Received: from CAF.MIT.EDU by MC.LCS.MIT.EDU via Chaosnet; 9 APR 87  14:13:51 EDT
+Received: by caf.MIT.EDU (5.54/4.7) id AA11333; Thu, 9 Apr 87 14:09:42 EDT
+Date: Thu, 9 Apr 87 14:09:42 EDT
+From: mbm@caf.MIT.EDU (Mike McIlrath)
+To: info-hosts@mc
+Subject: chaplin, hitchcock
+Cc: boning, george
+
+I have added to ai:syshst;hstg:
+
+chaplin	explorer 18.62.0.238, chaos 37356
+hitchcock uvax2 18.62.0.239
+
+
+Received: from GOLDILOCKS.MIT.EDU by AI.AI.MIT.EDU via Chaosnet; 8 APR 87  10:37:07 EDT
+Received: from SMOKEY.MIT.EDU by GOLDILOCKS.MIT.EDU via CHAOS with CHAOS-MAIL id 1763; Wed 8-Apr-87 10:35:23 EDT
+Date: Wed, 8 Apr 87 10:36 EDT
+From: David H. Kaufman <Sr.Kaufman@SPEECH.MIT.EDU>
+Subject: POLAR
+To: info-hosts@AI.AI.MIT.EDU
+Message-ID: <870408103611.2.QUX@SMOKEY.MIT.EDU>
+Zippy-Says: Yow!  I want to mail a bronzed artichoke to Nicaragua!
+
+I changed the entry for Polar, one of our LMs.  Old:
+	HOST : CHAOS 16210 : POLAR : LISPM : LISPM ::
+
+New:
+	HOST : CHAOS 15437 : POLAR : SYMBOLICS-3600 : LISPM ::
+
+Received: from XX.LCS.MIT.EDU (CHAOS 2420) by AI.AI.MIT.EDU  4 Apr 87 20:36:47 EST
+Date: Sat, 4 Apr 1987  20:33 EST
+Message-ID: <SRA.12291949127.BABYL@XX.LCS.MIT.EDU>
+From: Rob Austein <SRA@XX.LCS.MIT.EDU>
+To:   Info-Hosts@AI.AI.MIT.EDU
+Subject: FYI.  Note funky headers in original message....  --sra
+
+Return-Path: <HOST-UPDATES-LIST-RELAY@SRI-NIC.ARPA>
+Received: from SRI-NIC.ARPA by XX.LCS.MIT.EDU with TCP; Sat 4 Apr 87 18:51:55-EST
+Date: Thu 2 Apr 87 15:56:45-PST
+From: HOSTMASTER@SRI-NIC.ARPA
+Subject: New Host Table - Version #620
+Sender: SUE@SRI-NIC.ARPA
+To: @SRI-NIC.ARPA, "*"@SRI-NIC.ARPA, "@@"@SRI-NIC.ARPA
+Reply-To: HOSTMASTER@SRI-NIC.ARPA
+Location: SRI International, Phone: (415) 859-5539
+Message-ID: <12291407280.15.SUE@SRI-NIC.ARPA>
+
+There is a new host table available from the SRI-NIC.ARPA machine.  The
+file is NETINFO:HOSTS.TXT and it's version #620.
+
+As announced recently in DDN Management Bulletin 32, all
+nondomain-style host names and nicknames are to be removed from the
+Official DoD Internet Host Table.  Host names and nicknames appearing
+in this version, and in all future versions, of the host table will
+conform to domain-style naming conventions.
+
+Many of the old nicknames that users have become accustomed to using
+over the years have been discontinued.  Users will have to specify
+primary hostnames when sending mail to other users, or when using FTP
+or TELNET servers to connect to remote sites.  Although some nicknames
+will remain in the table, users should keep in mind that the purpose
+of a nickname is to provide a transition name when a host changes its
+official name.  The old name becomes a nickname and is kept in the
+table for reasonable period of time, after which time it is removed
+from the table.
+
+If you have any questions/comments send them to HOSTMASTER@SRI-NIC.ARPA.
+
+Sue
+
+Received: from XX.LCS.MIT.EDU (CHAOS 2420) by AI.AI.MIT.EDU  4 Apr 87 18:41:19 EST
+Date: Sat 4 Apr 87 18:37-EST
+From: Rob Austein <SRA@XX.LCS.MIT.EDU>
+Subject: Reader Poll: When can I turn host table installation back on?
+To: Info-Hosts@AI.AI.MIT.EDU
+
+I've had automatic host table installation for XX and the ITS machines
+(and thus indirectly for the other Twenex machines too) turned off
+since 1 April.  The NIC has indeed removed a lot of nicknames from
+the tables.
+
+We now have software for ITS and Twenex which can canonicalize the
+hostnames in mailing list files.  I think the ITS INQUIR databases
+have also been fixed up; it will take another day or so to do this
+on the Twenexes running WATSON/HOLMES.  It would be fairly easy
+to modify these programs so that they use a different copy of HOSTS3.BIN,
+so that they will continue to work if installation of new HOSTS3.BIN
+files is resumed.
+
+Unix machines with domain resolvers are presumably not as troubled
+by all this.  Other machines will have to fend for themselves.
+
+Would anyone object if I turned automatic installation back on as
+soon as the WATSON databases are canonicalized and the Twenex mailing
+list code is patched to use some other filename?  If I don't hear
+from anybody, I'll just turn things back on once the Twenexes are
+ready (I'll send another message when I do this, of course).
+
+--Rob
+
+Received: from XX.LCS.MIT.EDU (CHAOS 2420) by AI.AI.MIT.EDU 17 Feb 87 14:23:39 EST
+Date: Tue, 17 Feb 1987  14:21 EST
+Message-ID: <SRA.12279822867.BABYL@XX.LCS.MIT.EDU>
+From: Rob Austein <SRA@XX.LCS.MIT.EDU>
+To:   Info-Hosts@AI.AI.MIT.EDU
+Subject: Host table outages
+
+Host table generation has been broken for the last few days, first
+because the HOSTS3 compiler overflowed its address space while I was
+at Boskone, then because of some errors in the latest NIC table.  I
+sent the errors along to the NIC for correction, and things should be
+back on track as soon as they get around to fixing the bum entries and
+issuing a new table.
+
+I know that some new LCS microvaxen have been added to the namespace
+while these problems were going on.  If there is anybody who -really-
+needs a new table generated -immediately-, let me know and I'll hand
+edit a usable table together.  But I'd rather not.
+
+--Rob
+
+Received: from XX.LCS.MIT.EDU (CHAOS 2420) by AI.AI.MIT.EDU 12 Feb 87 20:09:52 EST
+Date: Thu, 12 Feb 1987  18:32 EST
+Message-ID: <SRA.12278557883.BABYL@XX.LCS.MIT.EDU>
+From: Rob Austein <SRA@XX.LCS.MIT.EDU>
+To:   Info-Hosts@AI.AI.MIT.EDU
+Subject: XX:<HOSTS>HOSTS.MIT
+
+If there is anyone using the file XX:<HOSTS>HOSTS.MIT (RFC810 format
+dump of MIT.EDU zone), be informed that I just turned on the recursion
+switch in the program that dumps it.  So it will now dump AI.MIT.EDU,
+LCS.MIT.EDU, MEDIA.MIT.EDU, LL.MIT.EDU, and anybody else it finds,
+rather than just MIT.EDU.
+
+Received: from zarathustra.think.com (TCP 1201000006) by AI.AI.MIT.EDU  1 Feb 87 08:06:11 EST
+Received: from urania.Think.COM by zarathustra.think.com; Sat, 31 Jan 87 16:21:20 EST
+Received: by urania.Think.COM; Sat, 31 Jan 87 16:20:31 EST
+Date: Sat, 31 Jan 87 16:20:31 EST
+From: bruce@think.com
+Message-Id: <8701312120.AA01359@urania.Think.COM>
+To: Info-Hosts@ai.ai.mit.edu
+Cc: systems@think.com
+Subject: mail to Think.COM
+
+I am posting this here becuase we have so much mail traffic with MIT.
+
+Soon, many of the machines inside Think.COM will not be directly on
+the Internet (including Godot.Think.COM and Aquinas.Think.COM).  All
+mail to Thinking Machines should be going to the host Think.COM
+(10.4.0.6).  We have been told users who have mail forwarded here
+or who are on mailing lists to use that address, but I am sure there
+are some which still have an explicit internal host name.
+
+So, if you see any mail bouncing becuase it is going to
+user@whatever.think.com, please try getting it to user@think.com.
+
+Thanks,
+--Bruce Nemnich, Thinking Machines Corporation, Cambridge, MA
+  bruce@think.com, seismo!think!bruce, bjn@mitvma.bitnet; +1 617 876 1111
+
+
+Received: from XX.LCS.MIT.EDU (CHAOS 2420) by AI.AI.MIT.EDU 30 Jan 87 17:03:28 EST
+Date: Fri, 30 Jan 1987  16:56 EST
+Message-ID: <SRA.12275132485.BABYL@XX.LCS.MIT.EDU>
+From: Rob Austein <SRA@XX.LCS.MIT.EDU>
+To:   Info-Hosts@AI.AI.MIT.EDU
+Subject: Clarification on nickname flushing
+
+The imminent flushing of all non-domain nicknames from the "host
+tables" applies only to the Internet-wide host table maintained by the
+NIC.  This does not affect nicknames for MIT hosts listed in the
+tables maintained on AI; the tables XX compiles for the PDP-10s (and
+friends) do not use the NIC tables for information about MIT hosts.
+I've been expecting the NIC to do this for the past year, so I
+stopped using the NIC tables for MIT info some time ago.
+
+In other words, as far as the "MIT" (PDP-10) tables are concerned, the
+name "XX" will still exist as a nickname for "XX.LCS.MIT.EDU" but
+"SAIL" will no longer exist as a nickname for "SAIL.Stanford.EDU".
+
+--Rob
+
+Received: from XX.LCS.MIT.EDU (CHAOS 2420) by AI.AI.MIT.EDU 22 Jan 87 14:34:32 EST
+Date: Thu, 22 Jan 1987  14:35 EST
+Message-ID: <SRA.12273009568.BABYL@XX.LCS.MIT.EDU>
+From: Rob Austein <SRA@XX.LCS.MIT.EDU>
+To:   Namecallers@MC.LCS.MIT.EDU, MIT-IP-People@MC.LCS.MIT.EDU,
+      Vax-Wizards@MILO.LCS.MIT.EDU, Postmaster@MC.LCS.MIT.EDU,
+      Info-Hosts@AI.AI.MIT.EDU
+Subject: WARNING: Non-domain nicknames to be removed from NIC tables!
+
+I just received the following.
+
+Note that most of the unix machines currently in existance at MIT will
+be in violation of this directive; very few are cannonicalizing
+"sra@xx" to "sra@xx.lcs.mit.edu" in mail headers.  ITS, TOPS-20, and
+Lispms should be ok; I don't know about status of other operating
+systems.
+
+Date: Thursday, 22 January 1987  12:35-EST
+From: DDN Reference <NIC@SRI-NIC.ARPA>
+To:   MGT: ;
+cc:   nic@SRI-NIC.ARPA
+Re:   DDN MGT Bulletin # 32
+
+********************************************************************** 
+DDN MGT Bulletin 32              DCA DDN Defense Communications System   
+22 Jan 87                        Published by: DDN Network Info Center
+                                    (NIC@SRI-NIC.ARPA)  (800) 235-3155
+
+
+                        DEFENSE  DATA  NETWORK
+
+                         MANAGEMENT  BULLETIN
+
+The DDN MANAGEMENT BULLETIN is distributed online by the DDN Network
+Information Center under DCA contract as a means of communicating
+official policy, procedures and other information of concern to
+management personnel at DDN facilities.  Back issues may be read
+through the TACNEWS server ("@n" command at the TAC) or may be
+obtained by FTP (or Kermit) from the SRI-NIC host [26.0.0.73 or
+10.0.0.51] using login="anonymous" and password="guest".  The pathname
+for bulletins is DDN-NEWS:DDN-MGT-BULLETIN-nn.TXT (where "nn" is the
+bulletin number).
+**********************************************************************
+
+              PHASE 1 OF THE DOMAIN NAME IMPLEMENTATION
+
+The DDN Network Information Center (NIC) is directed to remove all
+nondomain-style host names and nicknames from the Official DoD Host
+Table, NETINFO:HOSTS.TXT, by 31 March 1987.  After that time, names
+which do not conform to domain-style naming conventions, i.e. do not
+have ".domain" extensions, will not be allowed in either the Official
+DoD Host Table or the domain name servers.
+
+Nicknames, or aliases, will not be permitted in either the servers or
+the Official Host Table unless authorized.  Network mailers are
+required to use primary host names and to accept host names containing
+dots (.), as specified in the DDN mail protocols RFC 821 (MILSTD-1781)
+and RFC 822.  If mailers are not now adhering to these protocol
+requirements, they may experience mail delivery problems when the
+nondomain-style names are discontinued.  Users sending electronic mail
+should use primary host names in all mail destinations and sources.
+If nicknames are used, problems may arise in mail delivery.
+
+The NIC will notify Host Administrators as to which names or nicknames
+do not now conform.  Host Administrators may change nonconforming data
+by the usual procedure via Network Change Requests (NCRs) and Network
+Change Directives (NCDs), if they wish, before the 31 March 1987
+deadline.
+
+Host Administrators anticipating problems with this plan should notify
+DCA Code B652 (DCAB652@DDN1.ARPA), or via AUTODIN message, and the NIC
+Hostmaster (HOSTMASTER@SRI-NIC.ARPA) no later than 2 weeks prior to
+the scheduled cutover.
+
+In March of 1984, the DDN began the transition to domain-style names
+with the issuance of DDN Management Bulletin 22.  In that bulletin,
+all hosts were required to change their primary host names to contain
+".domain" extensions in accordance with RFC 897.  At the same time,
+all of the old-style names (without the ".domain" extensions) were
+automatically declared to be nicknames in the Official Host Table,
+NETINFO:HOSTS.TXT.  This use of old-style nicknames was allowed on an
+interim basis to make the transition to domain-style naming easier.
+Almost three years have passed, and this transition period must now
+come to a close.
+
+The transition to naming domains has progressed to the point where
+there are many domain name servers implemented and running.  In order
+to maintain interoperability between hosts on the DDN using the host
+table and hosts using the domain name servers, all hosts must be able
+to recognize domain-style names.  It is imperative that all transition
+names and nicknames be upgraded to domain-style names or be removed
+from NETINFO:HOSTS.TXT so that naming is consistent and so that all
+use of names adheres to the specification for domain names adopted in
+1984.
+
+Received: from XX.LCS.MIT.EDU by AI.AI.MIT.EDU via Chaosnet; 24 NOV 86  23:01:15 EST
+Date: Mon 24 Nov 86 23:03-EST
+From: Rob Austein <SRA@XX.LCS.MIT.EDU>
+Subject: Host table compilation
+To: Info-Hosts@AI.AI.MIT.EDU
+
+Should be back to normal as of tonight.
+
+Received: from MX.LCS.MIT.EDU by AI.AI.MIT.EDU via Chaosnet; 21 NOV 86  06:25:10 EST
+Date: Fri, 21 Nov 86 06:26:33 EST
+From: Rob Austein <SRA@MX.LCS.MIT.EDU>
+Subject: Host table generation...
+To: Info-Hosts@AI.AI.MIT.EDU
+Message-ID: <959046.861121.SRA@MX.LCS.MIT.EDU>
+
+.. will be turned off for the next few days.  Problems on XX.
+
+Received: from XX.LCS.MIT.EDU by AI.AI.MIT.EDU 27 Oct 86 11:41:55 EST
+Date: Mon, 27 Oct 1986  11:40 EST
+Message-ID: <SRA.12250171266.BABYL@XX.LCS.MIT.EDU>
+From: Rob Austein <SRA@XX.LCS.MIT.EDU>
+To:   Info-Hosts@AI.AI.MIT.EDU
+Subject: Media lab change
+
+All the Media-Lab hosts have been removed from AI: SYSHST; HSTG > and
+placed in a new file, HSTMDA >.  This happened late last night.  Since
+there were some primary name changes (MEDIA-LAB.MIT.EDU ->
+MEDIA-LAB.MEDIA.MIT.EDU, etc) there may be some cleaning up required
+on various hosts.  It's a once only deal, I don't think they're
+planning on changing names again soon.
+
+Bogus versions of the files XX:<HOSTS>HSTMIT.TXT (AI:SYSHST;HSTMIT >)
+and XX:<HOSTS>HOSTS3.TXT were created at 4AM due to brain bubbles on
+my part.  The problem has been fixed and a new set of tables has been
+generated and installed on XX and ITS.  There never was a set of
+HOSTS3 binaries (or any other derived files) corresponding to this
+change, so I doubt any machines noticed.  Sorry for any problems (and
+the few known heart attacks) this caused.
+
+--Rob
+
+Date: Mon, 27 Oct 86 08:06:53 EST
+From: Ray Hirschfeld <RAY@AI.AI.MIT.EDU>
+Subject:  Merging the "MIT" host tables and the MIT.EDU domain zones (long)
+To: SRA@XX.LCS.MIT.EDU
+cc: INFO-HOSTS@AI.AI.MIT.EDU
+In-reply-to: Msg of Mon 27 Oct 1986  01:02 EST from Rob Austein <SRA at XX.LCS.MIT.EDU>
+Message-ID: <[AI.AI.MIT.EDU].111114.861027.RAY>
+
+            HSTG >:         18.87.0.23 = HYPATIA.MIT.EDU
+            MIT.EDU zone:   18.87.0.23 = EMMA.MIT.EDU
+    Both listings have the nickname GLOOP.MIT.EDU, so presumably it's the
+    same host.  Comments, Ray, anybody?
+
+The EMMA/HYPATIA conflict is due to another name change done at the
+same time as the CANTOR/BANACH change.  The entry in hstg is correct,
+because I was able to edit it myself.  The other is awaiting update by
+Jeff Schiller.
+
+				Ray
+
+Received: from XX.LCS.MIT.EDU by AI.AI.MIT.EDU 27 Oct 86 01:04:25 EST
+Date: Mon, 27 Oct 1986  01:02 EST
+Message-ID: <SRA.12250055132.BABYL@XX.LCS.MIT.EDU>
+From: Rob Austein <SRA@XX.LCS.MIT.EDU>
+To:   Info-Hosts@AI.AI.MIT.EDU, holtzman@MEDIA-LAB.MIT.EDU, glenn@LL-XN.ARPA
+Subject: Merging the "MIT" host tables and the MIT.EDU domain zones (long)
+
+This is a report on the results of my attempt to produce a single,
+coherent host table by merging the ITS ("MIT") host tables with the
+MIT.EDU zone (and its children).  The latter was obtained by using
+Mark Lottor's program to dump the MIT.EDU zone recursively, then doing
+some fixups.  These were: removal of AI and LCS data (already have in
+all these bits in more useful form), removal of all entries whose
+primary name was a room number (presumably workstations, can't spare
+the space with the current technology) or begins with "MIT-" (see
+below), and adding a default opsys and cpu type where there wasn't one
+listed (see below).  Then I ran the mess through the HOSTS3 compiler.
+Most of this message is a listing of the errors that it turned up.
+
+Once we get these resolved, I can set things up so that this process
+happens automaticly, as part of the nightly table compilation.  This
+will make life easier for getting an accurate listing in the vanilla
+case (j random pc in the MIT.EDU zone), and will at least provide a
+crosscheck for the more complex cases.
+
+Henry Holtzman and Glenn Adams, you are getting this as the domain
+contacts for the MEDIA.MIT.EDU and LL.MIT.EDU zones.  Welcome to the
+debating club.  If either of you wants to be added to Info-Hosts, tell
+me.  You probably should be, if you are maintaining host table type
+things under the MIT.EDU umbrella.
+
+And now the report.
+
+The address for ACHILLES.LL.MIT.EDU (90.0.0.2) looks bogus.  The NIC
+table doesn't list network 90.0.0.0, and there aren't any other
+addresses like this in the table.  Typographical error?
+
+The following hosts are listed as being in the .ARPA domain in the NIC
+table but are listed as being in the LL.MIT.EDU zone according to the
+LL.MIT.EDU nameservers.  I can kludge around this, but the NIC data
+ought to be updated (there are also some mismatches between NIC and
+LL.MIT.EDU on cpu and opsys type for Lincoln Lab hosts):
+        10.4.0.10       LL-EN.ARPA      EN.LL.MIT.EDU
+        10.0.0.10       LL.ARPA         LL.MIT.EDU
+        10.6.0.10       LL-SST.ARPA     SST.LL.MIT.EDU
+        10.1.0.10       LL-VLSI.ARPA    VLSI.LL.MIT.EDU
+        10.2.0.10       LL-XN.ARPA      XN.LL.MIT.EDU
+
+The three known conflicts from the Athena/RLE namespace war:
+KOALA.MIT.EDU           RLE:    SYMBOLICS-3600  Chaos 15435
+                        Athena: VAXSTATION      IP 18.72.0.79
+MATISSE.MIT.EDU         RLE:    SYMBOLICS-3600  Chaos 15416
+                        Athena: VAXSTATION,     IP 18.72.0.214
+RENOIR.MIT.EDU          RLE:    SYMBOLICS-3600  Chaos 15415
+                        Athena: VAXSTATION      IP 18.72.0.108
+This is pending resolution by Jeff Schiller.
+
+The listings for some math department machines seem to be confused.
+Ray Hirschfeld has already explained BANACH/CANTOR (18.87.0.6); this
+will presumably be fixed in the next zone update.  There is also a
+conflict:
+        HSTG >:         18.87.0.23 = HYPATIA.MIT.EDU
+        MIT.EDU zone:   18.87.0.23 = EMMA.MIT.EDU
+Both listings have the nickname GLOOP.MIT.EDU, so presumably it's the
+same host.  Comments, Ray, anybody?
+
+The TAC is now called TAC.MIT.EDU with nickname MIT-TAC.ARPA because
+it makes the automated table merge easier.  The NIC hasn't been
+formally requested to make this change (although they are reading this
+message) nor will they unless somebody really cares.  It takes a
+couple of months and you have to ask the Pentagon's permission.
+
+There are some media lab machines listed in both the MIT.EDU and
+MEDIA.MIT.EDU zones.  Henry Holtzman, I asked you about this before
+and you didn't respond.  According to the traditional definition, a
+host can only have one "primary name".  It is because of this problem
+that I haven't started including the HSTMDA file you put together.
+        18.85.0.1 = AMTGW.MIT.EDU, AMTGW.MEDIA.MIT.EDU
+        18.85.0.3 = ATRP.MIT.EDU, ATRP.MEDIA.MIT.EDU
+        18.85.0.6 = EMS.MIT.EDU, EMS.MEDIA.MIT.EDU
+        18.85.0.2 = MEDIA-LAB.MIT.EDU, MEDIA-LAB.MEDIA.MIT.EDU
+        18.85.0.4 = XEVIOUS.MIT.EDU, XEVIOUS.MEDIA.MIT.EDU
+        18.85.0.5 = ZAXXON.MIT.EDU, ZAXXON.MEDIA.MIT.EDU
+
+The nickname 66-056-1.MIT.EDU appears on several hosts:
+        18.63.0.13 = MOLD.MIT.EDU
+        18.63.0.14 = BACTERIUM.MIT.EDU
+        18.63.0.15 = KNOWHOW.MIT.EDU
+I think the correct one is MOLD, although I've forgotten how I came to
+this conclusion.  Anyway, I made the appropriate change in HSTG a few
+days ago, rest of fix is pending zone update by Jeff Schiller now that
+he knows about it.
+
+There was some lossage associated with the name SIPBVAX.MIT.EDU (a
+nickname for the vax named CHARON).  Problem was that SIPBVAX was a
+nickname for CHARON-CHAOS, not CHARON.  So I moved it.  Sorry, RDZ.
+
+That's it for the fatal errors.
+
+The following hosts have no opsys/cpu data listed in the domain system:
+        E.CRL.MIT.EDU
+        F.CRL.MIT.EDU
+        EN.LL.MIT.EDU
+        GW.LL.MIT.EDU
+        PSAT-IG.LL.MIT.EDU
+        WB-ECHO.LL.MIT.EDU
+        FILMVIDEO.MEDIA.MIT.EDU
+        MORBIUS.MEDIA.MIT.EDU
+        QIX.MEDIA.MIT.EDU
+        XEVIOUS.MEDIA.MIT.EDU
+        ZAXXON.MEDIA.MIT.EDU
+Following a suggestion by someone who probably doesn't want credit for
+the idea, any such entry will get a default CPU type of "POS" and a
+default opsys type of "CTSS" to keep the HOSTS3 compiler from barfing.
+If you don't like it, get your entry fixed.
+
+Jeff, I would like to request (for the Iforgethowmany-th time) that
+the HINFO record for LCS.MIT.EDU be changed to match the one for XX.
+It's confusing people in the outside world (I've gotten several
+complaints).  {LCS.MIT.EDU IN HINFO PDP10 TOPS20}.  Thanks.
+
+The MIT.EDU zone still has a lot of entries with primary names
+begining with "MIT-".  I'm flushing these from the fixed-up table
+automaticly.  In other words, I don't care.  If you do, talk to Jeff
+about getting your entry fixed.  The list is too long to include here;
+I'll leave it around in the file AI: SRA; MIT- HOSTS.
+
+That's it.  Sorry about the length.
+
+--Rob
+
+Received: from XX.LCS.MIT.EDU by AI.AI.MIT.EDU 24 Oct 86 22:28:07 EDT
+Date: Fri, 24 Oct 1986  22:26 EDT
+Message-ID: <SRA.12249491578.BABYL@XX.LCS.MIT.EDU>
+From: Rob Austein <SRA@XX.LCS.MIT.EDU>
+To:   jis@BITSY.MIT.EDU
+Cc:   "J. Spencer Love" <JSLove@MULTICS.MIT.EDU>, Info-Hosts@AI.AI.MIT.EDU
+Subject: Jeff, please comment: host table conflicts
+In-reply-to: Msg of 24 Oct 1986  15:07-EDT from "J. Spencer Love" <JSLove@MIT-MULTICS.ARPA>
+
+Spencer, Jeff is on Info-Hosts, or was the last time I looked.
+
+KOALA.MIT.EDU and RENOIR.MIT.EDU should be the RLE Lisp machines.
+They were there first, and have had their names in the ITS tables for
+a long time.  The E40 Athena VAXSTATIONS by the same names should
+change their names.  Or that's what it looks like from here, anyway.
+
+As it happens, just this afternoon I wrote some TECO code to grovel
+over the output of Mark Lottor's ZONE program (which constructs a
+HOSTS.TXT format file by doing domain zone transfers) and produce
+something that (theoreticly) can be fed into the HOSTS3 compiler along
+with the rest of the tables.  Haven't tried to run it through yet, I
+imagine some more conflicts will appear, but if this works out it
+should simplify life greatly, since any changes Jeff makes in the
+MIT.EDU zone will automaticly be installed in the ITS tables, as will
+the LL.MIT.EDU and MEDIA.MIT.EDU zones.
+
+Will send another message if/when I have results of the attempted
+merge.
+
+--Rob
+
+Date: Fri, 24 Oct 86 19:27:54 EDT
+From: Ray Hirschfeld <RAY@AI.AI.MIT.EDU>
+Subject:  Host table conflicts
+To: JSLove@MULTICS.MIT.EDU
+cc: Schiller@MULTICS.MIT.EDU, INFO-HOSTS@AI.AI.MIT.EDU
+In-reply-to: Msg of Fri 24 Oct 86 15:07 EDT from J. Spencer Love <JSLove at MIT-MULTICS.ARPA>
+Message-ID: <[AI.AI.MIT.EDU].110395.861024.RAY>
+
+    Date: Fri, 24 Oct 86 15:07 EDT
+    From: J. Spencer Love <JSLove at MIT-MULTICS.ARPA>
+    To:   Info-Hosts at AI.AI.MIT.EDU, Schiller at MIT-MULTICS.ARPA
+    Re:   Host table conflicts
+    Posted-Date: 24 Oct 86 15:09 EDT
+
+    ...
+
+    HOSTS.TXT.582 at SRI-NIC.ARPA and hosttable/hstcamp.txt (17:29
+    10/20/86) at BITSY.MIT.EDU and bindtest from HARLEQUIN.MIT.EDU (today)
+    show:
+
+       CANTOR  18.87.0.6
+
+    AI:SYSHST;HSTG 46 shows
+
+       BANACH 18.87.0.6
+       CANTOR 18.87.0.26
+
+    When I telnet to 18.87.0.6, the host gives its name as "hilbert".
+    When I telnet to 18.87.0.26, I time out.  According to bindtest, there
+    is no HILBERT or BANACH in the MIT.EDU domain (although I see a
+    HILBERT in the AI.MIT.EDU domain).
+
+    The MIT-Multics host table will show CANTOR at 18.87.0.6, but somehow
+    I suspect that mail to that name will fail as long as the host thinks
+    it has a different name.
+
+    ...
+
+The machine at 18.87.0.6 changed its name from hilbert to cantor to
+eliminate a nickname conflict with hilbert.ai.mit.edu.  It then
+changed again to banach because the person getting the machine at
+18.87.0.26 (not yet hooked up) wanted the name cantor.  In other
+words, ai:syshst;hstg; is correct, bitsy:/hosttable/hstcamp.txt needs
+to be updated.  I've notified Jeff Schiller of the changes, so this
+should happen eventually.  Despite the fact that the machine answered
+with the name hilbert, it does know that its name is banach.
+
+Received: from MIT-MULTICS.ARPA by AI.AI.MIT.EDU 24 Oct 86 18:08:15 EDT
+Posted-Date:  24 Oct 86 15:09 EDT
+Date:  Fri, 24 Oct 86 15:07 EDT
+From:  "J. Spencer Love" <JSLove@MIT-MULTICS.ARPA>
+Subject:  Host table conflicts
+To:  Info-Hosts@AI.AI.MIT.EDU, Schiller@MIT-MULTICS.ARPA
+Message-ID:  <861024190753.987670@MIT-MULTICS.ARPA>
+
+While constructing a new host table for MIT-Multics, I noticed the following
+unresolved inconsistencies.  I hope that this is useful to someone.  I am
+sending this to both Info-Hosts and directly to Jeff Schiller because I'm not
+sure he's on the list.
+
+HOSTS.TXT.582 at SRI-NIC.ARPA and hosttable/hstcamp.txt (17:29 10/20/86) at
+BITSY.MIT.EDU and bindtest from HARLEQUIN.MIT.EDU (today) show:
+
+   CANTOR  18.87.0.6
+
+AI:SYSHST;HSTG 46 shows
+
+   BANACH 18.87.0.6
+   CANTOR 18.87.0.26
+
+When I telnet to 18.87.0.6, the host gives its name as "hilbert".  When I
+telnet to 18.87.0.26, I time out.  According to bindtest, there is no HILBERT
+or BANACH in the MIT.EDU domain (although I see a HILBERT in the AI.MIT.EDU
+domain).
+
+The MIT-Multics host table will show CANTOR at 18.87.0.6, but somehow I
+suspect that mail to that name will fail as long as the host thinks it has a
+different name.
+
+----
+
+In hstcamp.txt, KOALA.MIT.EDU appears as a VAXTSTATION at 18.72.0.79.
+
+In AI:SYSHST;HSTG 46, KOALA.MIT.EDU appears as a SYMBOLICS-3600 at CHAOS
+15435.
+
+In the MIT-Multics host table, KOALA.MIT.EDU is given to the VAXSTATION, while
+the alias KOALA-BEAR on the lisp machine appears as KOALA-BEAR.MIT.EDU.  I
+would have less trouble with this conflict if KOALA-BEAR were the primary name
+of the lisp machine.
+
+----
+
+In hstcamp.txt, MATISSE.MIT.EDU appears as a VAXSTATION at 18.72.0.214.
+
+In AI:SYSHST;HSTG 46, MATISSE.MIT.EDU appears as a SYMBOLICS-3600 at CHAOS 15416.
+
+In the MIT-Multics host table the lisp machine's address does not appear.
+
+----
+
+In hstcamp.txt, RENOIR.MIT.EDU appears as a VAXSTATION at 18.72.0.108.
+
+In AI:SYSHST;HSTG 46, RENOIR.MIT.EDU appears as a SYMBOLICS-3600 at CHAOS 15415.
+
+Again, in the MIT-Multics host table the lisp machine's address does not
+appear.
+
+----
+
+The name 66-056-1 is still on all three of MOLD, BACTERIUM and KNOWHOW, in
+that order, in hstcamp.txt.  I suspect that the reason the domain resolver
+shows it on KNOWHOW is just that that is the last line claiming the name in
+its input file.
+
+Date: Thu, 23 Oct 86 15:26:12 EDT
+From: Rob Austein <SRA@AI.AI.MIT.EDU>
+Subject:  I removed nickname 66-056-1.MIT.EDU
+To: INFO-HOSTS@AI.AI.MIT.EDU
+Message-ID: <[AI.AI.MIT.EDU].109941.861023.SRA>
+
+from BACTERIUM.MIT.EDU (18.63.0.14) and KNOWHOW.MIT.EDU (18.63.0.15)
+in AI: SYSHST; HSTG >.  According to the MIT.EDU nameservers this
+nickname properly belongs to MOLD.MIT.EDU (18.63.0.13), so I left the
+nickname there.
+
+--Rob
+
+Received: from MC.LCS.MIT.EDU by AI.AI.MIT.EDU via Chaosnet; 10 OCT 86  15:49:28 EDT
+Received: from CAF.MIT.EDU by MC.LCS.MIT.EDU via Chaosnet; 10 OCT 86  15:48:45 EDT
+Return-Path: <mbm@caf>
+Received: by caf.MIT.EDU (5.9/MIT.1x)
+	 on Fri, 10 Oct 86 15:49:19 EDT; User info-hosts@mc; Host mc
+Date: Fri, 10 Oct 86 15:49:19 EDT
+From: Mike McIlrath <mbm@caf>
+To: info-hosts@mc
+Cc: vanni@dspg
+Subject: more updates for dsp and caf
+
+I have updated AI:syshst;hstg to show caf's and dspvax's 18.20
+addresses (probably the only ones using this exotic technology),
+and dspvax's subnet 34 address.  I'll assume anyone who cares
+is on info-host-update and not bother with diffs.
+--mike
+
+Received: from SPEECH.MIT.EDU by AI.AI.MIT.EDU via Chaosnet; 9 OCT 86  12:11:17 EDT
+Date: Thu 9 Oct 86 12:09:38-EDT
+From: "John Wroclawski" <JTW%MIT-SPEECH@XX.LCS.MIT.EDU>
+Subject: Re: H E L P !!!!
+To: SRA@XX.LCS.MIT.EDU, JMILLER%OZ.AI.MIT.EDU@XX.LCS.MIT.EDU,
+    bug-oz%OZ.AI.MIT.EDU@XX.LCS.MIT.EDU
+cc: Jon%VX.LCS.MIT.EDU@XX.LCS.MIT.EDU, rrj%VX.LCS.MIT.EDU@XX.LCS.MIT.EDU,
+    Info-Hosts@AI.AI.MIT.EDU
+In-Reply-To: <SRA.12245427704.BABYL@XX.LCS.MIT.EDU>
+Message-ID: <12245447043.42.JTW@MIT-SPEECH>
+
+Probably OZ just has really old host tables because it munched its
+<SYSTEM> directory again and someone copied in the files from the
+backup copy of <SYSTEM> they keep on another pack. So if their
+automatic updater is running it should fix itself tonight, if
+no one does it sooner.
+
+Someone should change the OZ automatic host table updater to
+put new host tables in KANSAS:<SYSTEM> whenever it does an
+update.
+-------
+
+Received: from MC.LCS.MIT.EDU by AI.AI.MIT.EDU via Chaosnet; 9 OCT 86  10:59:07 EDT
+Received: from CAF.MIT.EDU by MC.LCS.MIT.EDU via Chaosnet; 9 OCT 86  10:51:38 EDT
+Return-Path: <mbm@caf>
+Received: by caf.MIT.EDU (5.9/MIT.1x)
+	 on Thu, 9 Oct 86 10:52:04 EDT; User info-hosts@mc; Host mc
+Date: Thu, 9 Oct 86 10:52:04 EDT
+From: Mike McIlrath <mbm@caf>
+To: sra@xx, jmiller@oz
+Cc: info-hosts@mc
+Subject: oops (lispm namespace)
+
+Sorry, Reagan DOES know about mephistopheles et al. if you ask it 
+about the AI namespace.  I thought MIT namespace queries also searched
+AI, but apparently not.
+--mike
+
+Received: from CAF.MIT.EDU by AI.AI.MIT.EDU via Chaosnet; 9 OCT 86  10:25:37 EDT
+Return-Path: <mbm@caf>
+Received: by caf.MIT.EDU (5.9/MIT.1x)
+	 on Thu, 9 Oct 86 10:25:18 EDT; User Info-Hosts@AI; Host AI
+Date: Thu, 9 Oct 86 10:25:18 EDT
+From: Mike McIlrath <mbm@caf>
+To: JMILLER@oz
+Cc: Info-Hosts@AI, Jon@MIT-VX, rrj@MIT-VX
+In-Reply-To: Mike McIlrath's message of Thu, 9 Oct 86 10:02:34 EDT
+Subject: H E L P !!!!
+
+   From: Mike McIlrath <mbm@caf>
+      From: JMILLER@MIT-OZ
+
+      (2) Just for kicks, can that same person try to see if the lisp
+      machine name space and the host tables on OZ (at least) are in
+      rough agreement.  In particular, I would like to know if the
+      Bobcats we are using (Mephistopheles, Zurich, Geneva, Kallisti,
+      Murren, Michael, and so forth) are correct everywhere.
+   It doesnt look to me like Reagan knows about these at all.
+I should have added that the AI nameserver we talk to, prep, DOES
+seem to know about them.  (I dont really know if it the addrs are
+right, but they answer PING packets.)
+
+
+
+
+
+
+
+
+
+Received: from XX.LCS.MIT.EDU by AI.AI.MIT.EDU  9 Oct 86 10:25:14 EDT
+Date: Thu, 9 Oct 1986  10:23 EDT
+Message-ID: <SRA.12245427704.BABYL@XX.LCS.MIT.EDU>
+From: Rob Austein <SRA@XX.LCS.MIT.EDU>
+To:   JMILLER@OZ.AI.MIT.EDU
+Cc:   Jon@VX.LCS.MIT.EDU, rrj@VX.LCS.MIT.EDU, Info-Hosts@AI.AI.MIT.EDU
+Subject: H E L P !!!!
+In-reply-to: Msg of 9 Oct 1986  09:36-EDT from JMILLER@MIT-OZ
+
+    Date: Thursday, 9 October 1986  09:36-EDT
+    From: JMILLER@MIT-OZ
+
+Keep your shirt on.
+
+    The chaos network seems to be completely fouled up with respect
+    to where MIT-Vax should be contacted.  In particular,
+
+    From my machine (mephistopheles, 18.26.0.168) Vax is no longer
+    accessible.
+
+What address is it trying?  Zermatt and Reagan both have the correct
+address.  As does XX and all of the ITS machines (ie, the core systems
+in the automatic update mechanism are intact).
+
+    From PREP, Vax can be reached on the internet but not on Chaos.
+
+I don't have an account on prep, somebody else will have to check
+this.
+
+    From OZ, Vax cannot be reached at all.
+
+OZ has a totally bogus address for VX, on the wrong subnet (perhaps
+the old address from subnet 032, I don't remember).  OZ has some form
+of automatic host table installation, so there's no point in my fixing
+this because the same program that invented the current bogus host
+table will just invent another one tonight.  Fix, somebody?
+
+    I have been told by TPWB that some parts of the chaos net
+    (probably some gateways) and OZ have an incorrect address for
+    MIT-Vax which is responsible for this.
+
+It might be a routing problem.  Who is TPWB?
+
+    (1) Can someone who knows what he or she is doing please update
+    ALL of the relevant host tables about MIT-Vax.
+
+You have no idea how many machines have copies, most of them out of
+date.  XX generates all the tables anybody could conceivably need, I
+tell everybody about them, but most hosts seem to prefer to go to hell
+their own way.  Their priviledge.
+
+    (2) Just for kicks, can that same person try to see if the lisp
+    machine name space and the host tables on OZ (at least) are in
+    rough agreement.  In particular, I would like to know if the
+    Bobcats we are using (Mephistopheles, Zurich, Geneva, Kallisti,
+    Murren, Michael, and so forth) are correct everywhere.
+
+Lispms seem ok (the namespace servers, anyway).  OZ is definitely
+losing.  I don't know about the bobcats, you'll have to check with a
+local systems guru.
+
+    (3) For my own benefit, can you explain how I should add a new
+    host to all appropriate tables.  Assume I add only internet
+    hosts.
+
+If everybody were getting the automaticly updated (and crosschecked)
+tables from XX, the only thing you'd have to do would be add a
+namespace object from your Lisp machine (assuming you are adding
+something to the LCS-namespace/LCS.MIT.EDU-zone or to the
+AI-namespace/AI.MIT.EDU-zone).  As it stands you pretty much have to
+nag the system hacker of each machine you use if it isn't being done
+to your satisfaction.
+
+    Thank you very much.  Please let me know who, if anyone, is
+    planning to work on this.
+
+I suppose I could fix the OZ problems, if nobody else is willing.  But
+I'd probably do it by having the nightly batch job just get things
+from XX, which seems to bother people (I don't know why).
+
+--Rob
+
+Received: from XX.LCS.MIT.EDU by AI.AI.MIT.EDU  9 Oct 86 10:09:48 EDT
+Date: Thu 9 Oct 86 10:08:12-EDT
+From: "J. Noel Chiappa" <JNC@XX.LCS.MIT.EDU>
+Subject: Re: H E L P !!!!
+To: JMILLER@OZ.AI.MIT.EDU, Info-Hosts@AI.AI.MIT.EDU
+cc: Jon@VX.LCS.MIT.EDU, rrj@VX.LCS.MIT.EDU, JNC@XX.LCS.MIT.EDU
+In-Reply-To: <[MIT-OZ] 9-Oct-86 09:36:29.JMILLER>
+Message-ID: <12245424938.27.JNC@XX.LCS.MIT.EDU>
+
+	Gateways (whether true packet switches or the protocol
+converter gateways from TCP<->CHAOS, you don't say which; they are
+completely different things) don't have any host addresses built
+into them at all.
+
+	Noel
+-------
+
+Received: from CAF.MIT.EDU by AI.AI.MIT.EDU via Chaosnet; 9 OCT 86  10:02:48 EDT
+Return-Path: <mbm@caf>
+Received: by caf.MIT.EDU (5.9/MIT.1x)
+	 on Thu, 9 Oct 86 10:02:34 EDT; User Info-Hosts@AI; Host AI
+Date: Thu, 9 Oct 86 10:02:34 EDT
+From: Mike McIlrath <mbm@caf>
+To: JMILLER@MIT-OZ
+Cc: Info-Hosts@AI, Jon@MIT-VX, rrj@MIT-VX
+In-Reply-To: JMILLER@MIT-OZ's message of 9 Oct 1986 09:36-EDT
+Subject: H E L P !!!!
+
+   Date: 9 Oct 1986 09:36-EDT
+   Sender: JMILLER@MIT-OZ
+   From: JMILLER@MIT-OZ
+
+   The chaos network seems to be completely fouled up with respect
+   to where MIT-Vax should be contacted.  In particular,
+
+   >From my machine (mephistopheles, 18.26.0.168) Vax is no longer
+   accessible.
+
+   >From PREP, Vax can be reached on the internet but not on Chaos.
+
+   >From OZ, Vax cannot be reached at all.
+Well I can reach vax fine from here (IP 18.62.0.232, chaos 37350)
+via both IP and chaos. 
+  
+   ...
+
+   (2) Just for kicks, can that same person try to see if the lisp
+   machine name space and the host tables on OZ (at least) are in
+   rough agreement.  In particular, I would like to know if the
+   Bobcats we are using (Mephistopheles, Zurich, Geneva, Kallisti,
+   Murren, Michael, and so forth) are correct everywhere.
+It doesnt look to me like Reagan knows about these at all.
+
+   (3) For my own benefit, can you explain how I should add a new
+   host to all appropriate tables.  Assume I add only internet
+   hosts.
+Whether IP, chaos, or both, if you want them in the "mit.edu" domain
+and want everyone to know about them, they go in AI:syshst;hstg.
+I THINK the AI domain is supposed to be done via the namespace editor
+on a lisp machine someplace.
+
+   Thank you very much.  Please let me know who, if anyone, is
+   planning to work on this.
+Rob Austein (sra@xx).
+
+   --Jim
+--mike
+
+
+
+Received: from OZ.AI.MIT.EDU by AI.AI.MIT.EDU via Chaosnet; 9 OCT 86  09:37:34 EDT
+Date: 9 Oct 1986 09:36-EDT
+Sender: JMILLER@MIT-OZ
+Subject: H E L P !!!!
+From: JMILLER@MIT-OZ
+To: Info-Hosts@AI
+Cc: Jon@MIT-VX, rrj@MIT-VX
+Message-ID: <[MIT-OZ] 9-Oct-86 09:36:29.JMILLER>
+
+The chaos network seems to be completely fouled up with respect
+to where MIT-Vax should be contacted.  In particular,
+
+From my machine (mephistopheles, 18.26.0.168) Vax is no longer
+accessible.
+
+From PREP, Vax can be reached on the internet but not on Chaos.
+
+From OZ, Vax cannot be reached at all.
+
+I have been told by TPWB that some parts of the chaos net
+(probably some gateways) and OZ have an incorrect address for
+MIT-Vax which is responsible for this.
+
+(1) Can someone who knows what he or she is doing please update
+ALL of the relevant host tables about MIT-Vax.
+
+(2) Just for kicks, can that same person try to see if the lisp
+machine name space and the host tables on OZ (at least) are in
+rough agreement.  In particular, I would like to know if the
+Bobcats we are using (Mephistopheles, Zurich, Geneva, Kallisti,
+Murren, Michael, and so forth) are correct everywhere.
+
+(3) For my own benefit, can you explain how I should add a new
+host to all appropriate tables.  Assume I add only internet
+hosts.
+
+Thank you very much.  Please let me know who, if anyone, is
+planning to work on this.
+
+--Jim
+
+Received: from MC.LCS.MIT.EDU by AI.AI.MIT.EDU via Chaosnet; 8 OCT 86  19:10:01 EDT
+Received: from CAF.MIT.EDU by MC.LCS.MIT.EDU via Chaosnet; 8 OCT 86  18:57:17 EDT
+Return-Path: <mbm@caf>
+Received: by caf.MIT.EDU (5.9/MIT.1x)
+	 on Wed, 8 Oct 86 18:58:01 EDT; User info-hosts@mc; Host mc
+Date: Wed, 8 Oct 86 18:58:01 EDT
+From: Mike McIlrath <mbm@caf>
+To: info-hosts@mc
+Subject: changes to ai:syshst;hstg
+Cc: boning@caf, kmware@caf
+
+I have added cagney and bacall, and deleted chaos service from bogart,
+all microvaxes in building 39.   
+
+Diffs follow.
+55a56
+> HOST : 18.62.0.236 : BACALL : MICROVAX-II : UNIX : TCP/TELNET,TCP/FTP,TCP/SMTP:
+62c63
+< HOST : 18.62.0.234,CHAOS 37352 : BOGART : MICROVAX-II : UNIX : TCP/TELNET,TCP/FTP,TCP/SMTP,TCP/FINGER,CHAOS/MAIL,CHAOS/NAME :
+---
+> HOST : 18.62.0.234 : BOGART : MICROVAX-II : UNIX : TCP/TELNET,TCP/FTP,TCP/SMTP,TCP/FINGER:
+75a77
+> HOST : 18.62.0.235 : CAGNEY : MICROVAX-II : UNIX : TCP/TELNET,TCP/FTP,TCP/SMTP:
+
+Received: from XX.LCS.MIT.EDU by AI.AI.MIT.EDU  6 Oct 86 17:09:13 EDT
+Date: Mon, 6 Oct 1986  17:04 EDT
+Message-ID: <SRA.12244714215.BABYL@XX.LCS.MIT.EDU>
+From: Rob Austein <SRA@XX.LCS.MIT.EDU>
+To:   "Henry N. Holtzman" <holtzman@MEDIA-LAB.MIT.EDU>
+Cc:   Info-Hosts@AI.AI.MIT.EDU
+Subject: media domain
+In-reply-to: Msg of 5 Oct 1986  15:45-EDT from Henry N. Holtzman <holtzman@MEDIA-LAB.MIT.EDU>
+
+    Date: Sunday, 5 October 1986  15:45-EDT
+    From: Henry N. Holtzman <holtzman@MEDIA-LAB.MIT.EDU>
+
+    	The media-lab is now running about 50 machines in its own
+    domain, named, .media.mit.edu.  Since JIS is no longer responsible for
+    keeping our hosts in the host table, I was wondering if we can get our
+    own file in SYSHST so that I can just ftp over a new copy when we
+    change things (instead of having to edit someone else's file.
+
+Sounds good to me.  How about AI: SYSHST; HSTAMT > as your magic
+filename.  Let me know when you get it set up so I can look it over
+and configure it into the table compiler job.
+
+--Rob
+
+Received: from MC.LCS.MIT.EDU by AI.AI.MIT.EDU via Chaosnet; 3 OCT 86  22:28:49 EDT
+Received: from CAF.MIT.EDU by MC.LCS.MIT.EDU via Chaosnet; 3 OCT 86  22:26:54 EDT
+Return-Path: <mbm@caf>
+Received: by caf.MIT.EDU (5.9/MIT.1x)
+	 on Fri, 3 Oct 86 22:26:12 EDT; User info-hosts@mc; Host mc
+Date: Fri, 3 Oct 86 22:26:12 EDT
+From: Mike McIlrath <mbm@caf>
+To: sra@xx, jtw@xx, info-hosts@mc
+Cc: troxel
+Subject: host table changes
+
+
+I have added some missing chaos hosts to the master host table on AI.
+CIPG-SWITCH is now at 15450, not 15416, as previously indicated.  Diff
+listing with hstg.36 follows.
+
+44a45
+> HOST : CHAOS 6420 : B10SW, BLDG-10-SW, BLDG-10-SWITCH : PDP11 : SWITCH ::
+70a72,75
+> HOST : CHAOS 037304 : CAF-SWITCH-4,CAFSW-4,CAF-SW-4,CAFSW4 : PDP11 : SWITCH ::
+> HOST : CHAOS 037305 : CAF-SWITCH-5,CAFSW-5,CAF-SW-5,CAFSW5 : PDP11 : SWITCH ::
+> HOST : CHAOS 037306 : CAF-SWITCH-6,CAFSW-6,CAF-SW-6,CAFSW6 : PDP11 : SWITCH ::
+> HOST : CHAOS 037307 : CAF-SWITCH-7,CAFSW-7,CAF-SW-7,CAFSW7 : PDP11 : SWITCH ::
+76a82
+> HOST : CHAOS 15450 : CIPG-SWITCH,CIPG-SW, CIPGSW : PDP11 : SWITCH ::
+85c91
+< HOST : 18.27.0.23 : DAFFY-DUCK,DAFFY : SYMBOLICS-3600 : LISPM : TCP/TELNET,TCP/FTP,TCP/SMTP,TCP/TIME,TCP/FINGER,UDP/TIME,UDP/TFTP,UDP/FINGER :
+---
+> HOST : 18.27.0.23, CHAOS 15427 : DAFFY-DUCK,DAFFY : SYMBOLICS-3600 : LISPM : TCP/TELNET,TCP/FTP,TCP/SMTP,TCP/TIME,TCP/FINGER,UDP/TIME,UDP/TFTP,UDP/FINGER :
+90a97
+> HOST : CHAOS 15406 : DSPG-SWITCH, DSPG-SW, DSPGSW : PDP11 : SWITCH ::
+91a99
+> HOST : CHAOS 15451 : ELEVEN, CIPG-11 : PDP11 : UNIX ::
+155c163
+< HOST : 18.27.0.20 : PORKY-PIG,PORKY : VAX-11/750 : UNIX : TCP/TELNET,TCP/FTP,TCP/SMTP,TCP/TIME,TCP/DAYTIME,TCP/FINGER :
+---
+> HOST : 18.27.0.20, CHAOS 15424 : PORKY-PIG,PORKY : VAX-11/750 : UNIX : TCP/TELNET,TCP/FTP,TCP/SMTP,TCP/TIME,TCP/DAYTIME,TCP/FINGER :
+193c201
+< HOST : 18.27.0.21 : YOSEMITE-SAM,SAM : VAX-11/750 : UNIX : TCP/TELNET,TCP/FTP,TCP/SMTP,TCP/TIME,TCP/DAYTIME,TCP/FINGER :
+---
+> HOST : 18.27.0.21, CHAOS 15425 : YOSEMITE-SAM,SAM : VAX-11/750 : UNIX : TCP/TELNET,TCP/FTP,TCP/SMTP,TCP/TIME,TCP/DAYTIME,TCP/FINGER :
+
+
+Received: from MC.LCS.MIT.EDU by AI.AI.MIT.EDU via Chaosnet; 2 OCT 86  10:47:20 EDT
+Received: from MEDIA-LAB.MIT.EDU by MC.LCS.MIT.EDU  2 Oct 86 10:43:56 EDT
+Received: by MEDIA-LAB.MIT.EDU (5.51/4.8)  id AA29979; Thu, 2 Oct 86 10:42:19 EDT
+Date: Thu, 2 Oct 86 10:42:19 EDT
+From: Henry N. Holtzman <holtzman@MEDIA-LAB.MIT.EDU>
+Message-Id: <8610021442.AA29979@MEDIA-LAB.MIT.EDU>
+To: info-hosts@mc.lcs.mit.edu
+Subject: Chaos hostnames
+
+
+Hi.
+
+What's the approved way for getting my lab's machines into the chaos
+host table?
+
+Thanks,
+
+-Henry
+
+Received: from MX.LCS.MIT.EDU by AI.AI.MIT.EDU via Chaosnet; 30 SEP 86  12:42:06 EDT
+Date: Tue, 30 Sep 86 12:40:48 EDT
+From: Stan Zanarotti <SRZ%MX.LCS.MIT.EDU@MC.LCS.MIT.EDU>
+Subject:  Change in MITATH
+To: INFO-HOSTS@MX.LCS.MIT.EDU
+Message-ID: <[MX.LCS.MIT.EDU].950200.860930.SRZ>
+
+Changed charon's chaos address to 50015, to reflect the fact that it can
+be reached thru the Campus Spine.  Changed things to have the chaos entry as
+CHARON-CHAOS, which is what we want.
+
+	-stan
+
+Received: from BITSY.MIT.EDU by AI.AI.MIT.EDU 24 Sep 86 17:02:15 EDT
+Received: by BITSY.MIT.EDU (5.15/4.7)
+	id AA00877; Wed, 24 Sep 86 17:00:48 EDT
+Date: Wed, 24 Sep 86 17:00:48 EDT
+From: jis@BITSY.MIT.EDU (Jeffrey I. Schiller)
+Message-Id: <8609242100.AA00877@BITSY.MIT.EDU>
+To: SRA@XX.LCS.MIT.EDU
+Cc: JSLove@MIT-Multics.ARPA, Info-Hosts@AI.AI.MIT.EDU, ens@athena.mit.edu,
+        rws@zermatt.lcs.mit.edu, ziggy@vx.lcs.mit.edu
+Subject: Re: Host table errors
+
+I will be updating HSTATH > and HSTG > in the next few days to reflect the
+current MIT.EDU domain.
+
+			-Jeff
+
+Received: from XX.LCS.MIT.EDU by AI.AI.MIT.EDU 23 Sep 86 19:20:28 EDT
+Date: Tue, 23 Sep 1986  19:26 EDT
+Message-ID: <SRA.12241332221.BABYL@XX.LCS.MIT.EDU>
+From: Rob Austein <SRA@XX.LCS.MIT.EDU>
+To:   "J. Spencer Love" <JSLove@MULTICS.MIT.EDU>
+Cc:   Info-Hosts@AI.AI.MIT.EDU, ens@ATHENA.MIT.EDU, rws@ZERMATT.LCS.MIT.EDU,
+      ziggy@VX.LCS.MIT.EDU, jis@BITSY.MIT.EDU
+Subject: Host table errors
+In-reply-to: Msg of 23 Sep 1986  12:25-EDT from "J. Spencer Love" <JSLove@MIT-MULTICS.ARPA>
+
+    Date: Tuesday, 23 September 1986  12:25-EDT
+    From: "J. Spencer Love" <JSLove@MIT-MULTICS.ARPA>
+    To:   Info-Hosts@MC.LCS.MIT.EDU
+    Re:   Host table errors
+
+    I hope this is the right place to send this...  If it is, I am not on
+    this list, so replies will have to be sent directly.
+
+It is.
+
+    The host RTS-6.AI.MIT.EDU has an alias LMI/COLOR in AI:SYSHST;HSTLCS >
+    (and AI:SYSHST;HSTMIT >).  The "/" character in this addname seems to
+    be in direct violation of RFC 952 and the obsolete RFC 810, which are
+    the definitions of the widely used host table source format.
+
+You're right.  I'm surprised the HOSTS3 compiler let it go through but
+I guess it allows it because it's an legal character in service names.
+Anyway, this was done by some person ignorant of this problem who fed
+that as a nickname into the LCS Lisp Machine namespace.  I deleted it,
+will percolate through to the AI:SYSNET; tables tonight if nothing
+misfires.  Bob and Ziggy, if you can educate the people down where you
+live not to do this sort of thing it would help.  Bob, we might also
+want to think about making the namespace -> host table dump code check
+for this sort of lossage.
+
+    Recent Multics host table maintenance has turned up the following
+    inaccuracies and inconsistencies between the real world, the host
+    tables in AI:SYSHST; and the Internet host table maintained by
+    SRI-NIC.ARPA:
+
+    1) AGAMEMNON.MIT.EDU is shown as 18.72.0.9 in AI:SYSHST;HSTATH >, but
+    the NIC thinks it is at 18.71.0.16.  I can communicate with it on
+    subnet 72, but the subnet 71 address doesn't respond.  The appropriate
+    authority should notify the NIC.
+
+A lot of machines moved from subnet 71 to subnet 72 some time back
+(six months?).  Project Athena is somewhat absentminded about telling
+the rest of the world about this kind of change.  Eric Starkman
+<ens@athena> was the last person I know of willing to put any work
+into this, I don't know if he's still there.
+
+    2) A number of hosts are shown in HSTATH as being on subnet 80, but in
+    the NIC host table and in a comment in HSTLCS they are shown as being
+    on subnet 58.  I can communicate with most of them from Multics at the
+    subnet 80 address, but PROMETHEUS doesn't respond to either address:
+    APHRODITE 12, APOLLO 10, ARTEMIS 11, ATLAS, 15, CHARON 13 and
+    PROMETHEUS 14.  Not only should the NIC be informed, but perhaps the
+    (mechanically generated?) comments in HSTLCS should be updated as well.
+
+This looks like a side effect of the one remaining subnet conflict in
+the MIT net.  There was a screwup a long time ago and two different
+groups started using the same subnet number, one for IP and one for
+Chaos.  It's in the process of being cleaned up, I don't know what the
+exact status is.  JIS, could you bring us up to date?  Somebody should
+tell the NIC about the changed addresses too, once the dust settles.
+
+    3) POLLUX.MIT.EDU is shown in both HSTATH and the NIC host table as
+    18.71.0.6, but it appears to actually be at 18.72.0.4 (which was
+    obtained from hosttable/hstcamp.txt on BITSY.MIT.EDU).  This is an
+    error in AI:SYSHST;HSTATH >, which should be updated as well as telling
+    the NIC.
+
+I'll take care of this if ens@athena doesn't resurface soon.
+
+--Rob
+
+PS: I believe that either NIC@NIC or Hostmaster@NIC was on this list
+    at one point.  If somebody at the NIC wants to fix the problems
+    Spencer has pointed out, I certainly wouldn't object....
+
+Received: from MC.LCS.MIT.EDU by AI.AI.MIT.EDU via Chaosnet; 23 SEP 86  14:06:57 EDT
+Received: from MIT-MULTICS.ARPA by MC.LCS.MIT.EDU 24 Sep 86 14:06:50 EDT
+Date:  Tue, 23 Sep 86 12:25 EDT
+From:  "J. Spencer Love" <JSLove@MIT-MULTICS.ARPA>
+Subject:  Host table errors
+To:  Info-Hosts@MC.LCS.MIT.EDU
+Message-ID:  <860923162518.892640@MIT-MULTICS.ARPA>
+
+I hope this is the right place to send this...  If it is, I am not on
+this list, so replies will have to be sent directly.
+
+The host RTS-6.AI.MIT.EDU has an alias LMI/COLOR in AI:SYSHST;HSTLCS >
+(and AI:SYSHST;HSTMIT >).  The "/" character in this addname seems to
+be in direct violation of RFC 952 and the obsolete RFC 810, which are
+the definitions of the widely used host table source format.
+
+The sources in that directory cite RFC 810 as the basis for their
+format, but they have been extended to contain CHAOS addresses and
+DOMAIN statements with more data than RFC 952 defines.  We extended the
+Multics host table software in the past to extract the CHAOS addresses
+so our mailer could forward to CHAOS hosts (we were also briefly on the
+CHAOS net).
+
+Is it your position that the "/" character in host names is a similar
+extension?  Since the "/" is a delimiter with syntactic meaning in
+other fields in this file, it is less convenient to change the Multics
+software, which uses a uniform lexical analyzer.  Furthermore, it seems
+like a bad idea.  There are good reasons why host names are restricted
+to such a small character set; for example, operating systems which
+attach special meanings to delimiters like "/".
+
+Would the lords of the LCS name space please speak on this matter?
+
+Recent Multics host table maintenance has turned up the following
+inaccuracies and inconsistencies between the real world, the host
+tables in AI:SYSHST; and the Internet host table maintained by
+SRI-NIC.ARPA:
+
+1) AGAMEMNON.MIT.EDU is shown as 18.72.0.9 in AI:SYSHST;HSTATH >, but
+the NIC thinks it is at 18.71.0.16.  I can communicate with it on
+subnet 72, but the subnet 71 address doesn't respond.  The appropriate
+authority should notify the NIC.
+
+2) A number of hosts are shown in HSTATH as being on subnet 80, but in
+the NIC host table and in a comment in HSTLCS they are shown as being
+on subnet 58.  I can communicate with most of them from Multics at the
+subnet 80 address, but PROMETHEUS doesn't respond to either address:
+APHRODITE 12, APOLLO 10, ARTEMIS 11, ATLAS, 15, CHARON 13 and
+PROMETHEUS 14.  Not only should the NIC be informed, but perhaps the
+(mechanically generated?) comments in HSTLCS should be updated as well.
+
+3) POLLUX.MIT.EDU is shown in both HSTATH and the NIC host table as
+18.71.0.6, but it appears to actually be at 18.72.0.4 (which was
+obtained from hosttable/hstcamp.txt on BITSY.MIT.EDU).  This is an
+error in AI:SYSHST;HSTATH >, which should be updated as well as telling
+the NIC.
+
+Received: from MC.LCS.MIT.EDU by AI.AI.MIT.EDU via Chaosnet; 18 SEP 86  17:31:05 EDT
+Received: from XX.LCS.MIT.EDU by MC.LCS.MIT.EDU 18 Sep 86 17:07:14 EDT
+Date: Thu, 18 Sep 1986  17:11 EDT
+Message-ID: <SRA.12239997049.BABYL@XX.LCS.MIT.EDU>
+From: Rob Austein <SRA@XX.LCS.MIT.EDU>
+To:   "Mark R. London" <MRL%PFC-VAX%XX.LCS.MIT.EDU@MIT-XX.ARPA>
+cc:   INFO-HOSTS@MC.LCS.MIT.EDU
+In-reply-to: Msg of 18 Sep 1986  15:24-EDT from Mark R. London                  <MRL@MIT-PFC-VAX>
+
+    Date: Thursday, 18 September 1986  15:24-EDT
+    From: Mark R. London <MRL@MIT-PFC-VAX>
+    To:   INFO-HOSTS@MC
+
+    	I'd appreciate it mucho if someone can help me.  Can someone tell
+    me where I can find a file containing the list of all the arpanet hosts?
+    If not, does anyone know of arpanet hosts at Lincoln labs?  Thanks.
+
+There isn't really a list of all Arpanet hosts anymore (welcome to the
+future).  For your purposes the file XX:<SYSTEM>HOSTS.TXT will do.
+
+--Rob
+
+Received: from MC.LCS.MIT.EDU by AI.AI.MIT.EDU via Chaosnet; 18 SEP 86  16:18:42 EDT
+Received: from PFC-VAX.MIT.EDU by MC.LCS.MIT.EDU via Chaosnet; 18 SEP 86  15:26:42 EDT
+Date: 18 Sep 86 15:24:02 EDT
+From: Mark R. London                  <MRL@MIT-PFC-VAX>
+To: INFO-HOSTS@MC
+
+Hi
+	I'd appreciate it mucho if someone can help me.  Can someone tell
+me where I can find a file containing the list of all the arpanet hosts?
+If not, does anyone know of arpanet hosts at Lincoln labs?  Thanks.
+							Mark London
+
+Received: from MC.LCS.MIT.EDU by AI.AI.MIT.EDU via Chaosnet; 29 AUG 86  12:42:15 EDT
+Received: from DEEP-THOUGHT.MIT.EDU by MC.LCS.MIT.EDU via Chaosnet; 29 AUG 86  12:40:42 EDT
+Date: Fri 29 Aug 86 12:38:17-EDT
+From: Clifford Neuman <BCN@DEEP-THOUGHT.MIT.EDU>
+Subject: Chaos subnet 025(21) is now 076(62)
+To: INFO-HOSTS@MC.LCS.MIT.EDU
+cc: jis@ATHENA.MIT.EDU, shep@DEEP-THOUGHT.MIT.EDU, mbm@DEEP-THOUGHT.MIT.EDU
+Message-ID: <12234704357.25.BCN@DEEP-THOUGHT.MIT.EDU>
+
+Someone should make sure that all the chaos-only hosts on the subnet
+have the corresponding internet addresses reserved.  My list is:
+
+franky-mouse		37040	18.62.0.32
+benji-mouse		37020   18.62.0.16
+heart-of-gold		37042	18.62.0.34
+micro-heart-of-gold	37044	18.62.0.36
+bypass			37130	18.62.0.88
+eecs-11			37142	18.62.0.98
+cafsw0			37300   18.62.0.192
+-
+cafsw7			37307   18.62.0.199
+waif			37351   18.62.0.233	
+bogart			37352   18.62.0.234	
+cagney			37353   18.62.0.235
+-------
+
+Received: from MC.LCS.MIT.EDU by AI.AI.MIT.EDU via Chaosnet; 29 AUG 86  09:49:40 EDT
+Received: from DEEP-THOUGHT.MIT.EDU by MC.LCS.MIT.EDU via Chaosnet; 29 AUG 86  09:45:49 EDT
+Date: Fri 29 Aug 86 09:43:24-EDT
+From: Clifford Neuman <BCN@DEEP-THOUGHT.MIT.EDU>
+Subject: CHaos subnet 025 changing to 076
+To: BBOARD@MC.LCS.MIT.EDU, INFO-HOSTS@MC.LCS.MIT.EDU
+cc: Staff@DEEP-THOUGHT.MIT.EDU, shep@DEEP-THOUGHT.MIT.EDU, mbm@CAF.MIT.EDU
+Message-ID: <12234672518.18.BCN@DEEP-THOUGHT.MIT.EDU>
+
+Sometime around 1130 this morning, chaos subnet 025 will be renumberd
+to 076.  This is being done to fix the discrepancy between the chaos
+and the internet subnet numbers for this network.  The host tables on
+AI and XX already have the new addresses for the appropriate hosts.
+The hosts affected will be: trillian slarty eddie franky benji hog
+u-hog bypass ee-11 cafsw0-7 caf waif bogart and cagney.
+
+	~ Cliff
+
+-------
+
+Received: from MC.LCS.MIT.EDU by AI.AI.MIT.EDU via Chaosnet; 26 AUG 86  12:21:39 EDT
+Received: from DEEP-THOUGHT.MIT.EDU by MC.LCS.MIT.EDU via Chaosnet; 26 AUG 86  12:20:28 EDT
+Date: Tue 26 Aug 86 12:18:35-EDT
+From: Clifford Neuman <BCN@DEEP-THOUGHT.MIT.EDU>
+Subject: Chaos 25 <--> 76
+To: INFO-HOSTS@MC.LCS.MIT.EDU
+cc: mbm@CAF.MIT.EDU, SHEP@DEEP-THOUGHT.MIT.EDU
+Message-ID: <12233914338.13.BCN@DEEP-THOUGHT.MIT.EDU>
+
+On Friday the 29th, chaos subnet 025 will be renumbered.  The new
+subnet number will be 076 which corresponds to the decimal internet
+subnet number 18.62 which is currently assigned to it.  Chos subnet 025
+and the corresponding internet subnet (18.21) will at that point be
+reserved for a separate ethernet in building 38, which at this point
+is running, but disconnected.  
+
+	~ Cliff
+-------
+
+Received: from XX.LCS.MIT.EDU by AI.AI.MIT.EDU 20 Aug 86 00:43:47 EDT
+Date: Wed, 20 Aug 1986  00:48 EDT
+Message-ID: <SRA.12232215818.BABYL@XX.LCS.MIT.EDU>
+From: Rob Austein <SRA@XX.LCS.MIT.EDU>
+To:   Info-Hosts@AI.AI.MIT.EDU
+cc:   Postmaster@OZ.AI.MIT.EDU, Postmaster@SPEECH.MIT.EDU,
+      Postmaster@DEEP-THOUGHT.MIT.EDU, Postmaster@MC.LCS.MIT.EDU
+Subject: WARNING -- All hosts become SERVERs, service fields go west
+
+If you don't use the HOSTS3 binary tables or anything generated from
+them, you can stop reading this message now.  This is primarily of
+interest to PDP-10s and any VAXen that get chaosnet host tables from a
+PDP-10.
+
+The HOSTS3 compiler went over the address space limit again today.
+The next most expendable thing in the tables was the services list.
+
+Last week I discovered (rather painfully) that there are still ITS and
+20X programs which believes the STFSRV bit in the binary HOSTS3 table
+(indicating that HOSTS3 thinks a site is a server).  For some time the
+only hosts in the tables have been ones that pass this test one way or
+another (this is not true for data internal to MIT, but the bulk of
+the offending hosts are from the NIC table).  So I added a switch to
+the HOSTS3 compiler that tells it to turn on the STFSRV bit for all
+entries in the table.  The binary table is now compiled with this
+switch turned on, from sources which don't have any service listings.
+
+This cut the size of the compiled HOSTS3.BIN file by about 30%.
+
+The following programs look at the STFSRV bit:
+
+ITS:	(Q)MAIL, probably (Q)SEND.  COMSAT does -not-.
+20X:	ARPA-HOSTS, MAIL, SEND, OZ's gateway-FTP.
+	MMAILR & MM also affected (via ARPA-HOSTS), except on XX.
+
+There may be others.  I don't think there's any program silly enough
+to look at the services field directly.  There is some small loss of
+functionality (MAIL will no longer warn you if you try to send mail to
+a LispM with no services or to a PC).  Life's rough.  Internet data in
+HOSTS3 tables degenerated to the gross kludge state some time ago.
+
+XX:<HOSTS>HSTNIC.TXT and XX:<HOSTS>HSTMIT.TXT will continue to have
+service data so that you can look things up if you really care.
+HOSTS3 now has its own private input file (XX:<HOSTS>HOSTS3.TXT).
+
+If you think that this is a desperation measure, you're right.
+
+Constructive comments are welcome.  Serious bug reports also.  Flames
+about how you can't list out all the services of FOO.RICE.EDU anymore
+with the HOST program should be sent to the nearest NUL: device.
+
+--Rob
+
+Received: from MC.LCS.MIT.EDU by AI.AI.MIT.EDU via Chaosnet; 18 AUG 86  20:48:10 EDT
+Received: from brubeck.proteon.com by MC.LCS.MIT.EDU 18 Aug 86 20:42:57 EDT
+Date: Mon, 18 Aug 86 20:39:23 EDT
+From: jnc@brubeck.proteon.com
+Reply-to: jnc@proteon.com
+Subject: Symbolics IR link
+To: info-hosts@mc
+CC: jnc
+
+	The Symbolics IR link (which used to have an MIT subnet
+number back in the days when Symbolics only had a single classs C
+number allowed in the routing tables) has turned into a subnet of
+the new Symbolics class B net number. That being the case, I have
+recycled its MIT subnet number.
+	That removes the last traces of Symbolics in the MIT address
+space. If the number czar ever gets around to giving Proteon its
+class B number, we will also vacate, leaving Harris, LMI and TMI
+as the main encroachers on the MIT address space.
+
+	Noel
+
+-------
+
+
+Received: from XX.LCS.MIT.EDU by AI.AI.MIT.EDU 18 Aug 86 12:31:45 EDT
+Date: Mon 18 Aug 86 12:37:01-EDT
+From: Timothy J. Shepard <SHEP@XX.LCS.MIT.EDU>
+Subject: HSTATH updates: AGAMEMNON, HELEN, MENELAUS
+To: info-hosts@AI.AI.MIT.EDU
+Message-ID: <12231820540.34.SHEP@XX.LCS.MIT.EDU>
+
+SRZ asked me to fix the addresses for the above machines.  They now
+have 18.72.foo.foo addresses instead of 18.71.foo.foo (according to
+the nameservers on TRILLIAN and BITSY).  I edited HSTATH appropriately.
+
+-------
+
+Received: from XX.LCS.MIT.EDU by AI.AI.MIT.EDU 13 Aug 86 15:58:57 EDT
+Date: Wed, 13 Aug 1986  16:03 EDT
+Message-ID: <SRA.12230547455.BABYL@XX.LCS.MIT.EDU>
+From: Rob Austein <SRA@XX.LCS.MIT.EDU>
+To:   "Eric Sven Ristad" <RISTAD%OZ.AI.MIT.EDU@XX.LCS.MIT.EDU>
+Cc:   bug-oz%OZ.AI.MIT.EDU@XX.LCS.MIT.EDU, info-hosts@AI.AI.MIT.EDU
+Subject: [The Mailer Daemon <Mailer@OZ.AI.MIT.EDU>: Message of 13-Aug-86 15:17:01]
+In-reply-to: Msg of 13 Aug 1986  15:18-EDT from "Eric Sven Ristad" <RISTAD%OZ.AI.MIT.EDU@XX.LCS.MIT.EDU>
+
+    Date: Wednesday, 13 August 1986  15:18-EDT
+    From: "Eric Sven Ristad" <RISTAD%OZ.AI.MIT.EDU@XX.LCS.MIT.EDU>
+    To:   bug-oz%OZ.AI.MIT.EDU@XX.LCS.MIT.EDU
+    Re:   [The Mailer Daemon <Mailer@OZ.AI.MIT.EDU>: Message of 13-Aug-86 15:17:01]
+
+    Where should this BUG-FTP message be sent?
+                    ---------------
+
+    Date: Wed 13 Aug 86 15:17:19-EDT
+    From: The Mailer Daemon <Mailer@OZ.AI.MIT.EDU>
+    To: RISTAD@OZ.AI.MIT.EDU
+    Subject: Message of 13-Aug-86 15:17:01
+
+    Message failed for the following:
+    Ian@OZ.AI.MIT.EDU.#Chaos: Can't forward - unknown host "SRI-NIC"
+    	    ------------
+    Date: Wed 13 Aug 86 15:17-EDT
+    From: Eric Sven Ristad <RISTAD@OZ.AI.MIT.EDU>
+    To: bug-ftp@OZ.AI.MIT.EDU
+
+    Whenever I try connecting to a machine, I get
+
+    ?Does not match switch or keyword
+
+    instead of the desired connection.
+
+    Thanks,
+    Eric
+
+This is my fault.  I generated a HOSTS3.BIN file yesterday that didn't
+have any service entries in it (because the compiler ran out of
+address space again, I couldn't find anything obviously useless in the
+pruned table, and services seemed the next most expendable thing).
+
+Unfortunately, ARPA-HOSTS (the thing that conses up the host list for
+MM and MMAILR) and FTP and probably other programs look at the
+"this-machine-is-a-server" bit (generated from the services field) to
+determine whether or not a host is worth talking to.
+
+I punted OZ:<MAIL>ARPA-HOSTS.BIN.738, so mail should work again.  I
+will install the latest-but-one HOSTS3.BIN on XX as a new, higher
+generation, so that it will propegate to OZ and the ITS machines
+tonight.  Speech and Deep-Thought, beware.
+
+In the long run, ARPA-HOSTS and FTP and friends are going to have to
+stop believing that server bit.  It is hopelessly unreliable in any
+case, because there are a lot of sites that don't furnish correct data
+to the NIC.  As things now stand, nothing except TACs and server hosts
+even make it into the HOSTS3 table from the NIC table, so there really
+isn't much point to pruning the table a second time.  (The TECO
+pre-filter has some additional hair to detect things like IBM-PCs that
+claim to be server hosts, so it's a little more reliable than just the
+services field).
+
+Sorry about this, folks.  I didn't realize that there was anybody who
+trusted that server bit enough to use it for anything.
+
+--Rob
+
+Received: from BITSY.MIT.EDU by AI.AI.MIT.EDU  7 Aug 86 14:43:43 EDT
+Received: by BITSY.MIT.EDU (5.15/4.7)
+	id AA15225; Thu, 7 Aug 86 14:40:51 EDT
+Date: Thu, 7 Aug 86 14:40:51 EDT
+From: jis@BITSY.MIT.EDU (Jeffrey I. Schiller)
+Message-Id: <8608071840.AA15225@BITSY.MIT.EDU>
+To: JNC@XX.LCS.MIT.EDU
+Cc: shep@xx.lcs.mit.edu, sipb-staff@charon.mit.edu, rdz@mc.lcs.mit.edu,
+        info-hosts@ai.ai.mit.edu, sra@xx.lcs.mit.edu, dab@borax.lcs.mit.edu,
+        bcn@athena.mit.edu
+Subject: Re: chaos subnet 104 renumbered to chaos subnet 71
+
+18.58 is currently the building 1 and building 11 combined Ethernet. Sometime
+this month this network will be split into to physical networks. At that time
+BOTH halves will get new addresses and 18.58 will be put to rest.
+
+			-Jeff
+
+Received: from XX.LCS.MIT.EDU by AI.AI.MIT.EDU  7 Aug 86 01:34:24 EDT
+Date: Thu 7 Aug 86 01:36:04-EDT
+From: "J. Noel Chiappa" <JNC@XX.LCS.MIT.EDU>
+Subject: Re: chaos subnet 104 renumbered to chaos subnet 71
+To: SHEP@XX.LCS.MIT.EDU, sipb-staff@CHARON.MIT.EDU, rdz@MC.LCS.MIT.EDU,
+    info-hosts@AI.AI.MIT.EDU, jis@BITSY.MIT.EDU
+cc: sra@XX.LCS.MIT.EDU, dab@BORAX.LCS.MIT.EDU, bcn@DEEP-THOUGHT.MIT.EDU,
+    JNC@XX.LCS.MIT.EDU
+In-Reply-To: <12228461464.27.SHEP@XX.LCS.MIT.EDU>
+Message-ID: <12228816635.22.JNC@XX.LCS.MIT.EDU>
+
+	I advise that at some point in the future the IP address of that
+wire be changed to be 071 so that it matches the CHAOS number; i.e. the
+wire would become 18.57.0.0. I don't know how many hosts would be affected
+by this, but it would finally clear up this problem for good (modulo the
+CHAOS wrapped IP subnet, but who cares about that anyway).
+-------
+
+Received: from XX.LCS.MIT.EDU by AI.AI.MIT.EDU  5 Aug 86 17:36:34 EDT
+Date: Tue 5 Aug 86 17:32:56-EDT
+From: Timothy J. Shepard <SHEP@XX.LCS.MIT.EDU>
+Subject: CHARON,SIPB-11,ATHENA,APHRODITE
+To: info-hosts@AI.AI.MIT.EDU
+Message-ID: <12228466538.27.SHEP@XX.LCS.MIT.EDU>
+
+I changed the following:
+	In SYSHST;HSTG >
+		SIPB-11 is now at 34415 instead of 42015
+
+	In SYSHST;HSTATH >
+		ATHENA-CHAOS is now at 34401 instead of 42001
+		; The comments next to CHARON' and APRHRODITE's
+		; entries have been updated appropriately
+-------
+
+Received: from XX.LCS.MIT.EDU by AI.AI.MIT.EDU  5 Aug 86 17:02:47 EDT
+Date: Tue 5 Aug 86 17:05:03-EDT
+From: Timothy J. Shepard <SHEP@XX.LCS.MIT.EDU>
+Subject: chaos subnet 104 renumbered to chaos subnet 71
+To: sipb-staff@CHARON.MIT.EDU, rdz@MC.LCS.MIT.EDU, info-hosts@AI.AI.MIT.EDU,
+    jis@BITSY.MIT.EDU
+cc: sra@XX.LCS.MIT.EDU, dab@BORAX.LCS.MIT.EDU, bcn@DEEP-THOUGHT.MIT.EDU
+Message-ID: <12228461464.27.SHEP@XX.LCS.MIT.EDU>
+
+Dave Bridgham (dab@borax.lcs.mit.edu) wants chaos subnet 104 allocated
+to the campus spine so that he can experiment with getting chaosnet
+working on the campus spine.  (18.68.0.0 currently allocated to the
+campus spine and corresponds to chaos subnet 104.)
+
+Chaos subnet 104 is currently allocated to the same piece of cable
+which currently has 18.58.0.0 on it.  This corresponds with chaos
+subnet 72 which is unfortunately already in use by a chaosnet-only
+subnet in NE43 which cannot be easily renumbered (it would require
+reburning proms).
+
+Chaos subnet 71 octal (18.57.0.0 decimal) was a completely unallocated
+subnet.  It is now allocated to the bldg. 1 and bldg. 11 ethernet.
+
+SIPB-11 is currently down (It has apparently been broken for some time
+now) which leaves the old chaos subnet 104 completely isolated
+(chaosnet wise) for the moment.
+
+Cliff Neuman and I (Tim Shepard) are renumbering the bldg. 11 ethernet
+to be Chaos subnet 71 as of now.  I will take care changing the code
+for SIPB-11 so that next time it boots it will be on subnet 71 instead
+of 104.  Cliff will take care of changing the chaosnet addresses of
+CHARON, APHRODITE, and ATHENA to the corresponding subnet 71
+addresses.  Note that none of CHARON, APHRODITE, or ATHENA have
+chaosnet address in the current chaosnet host tables.
+
+Machine		New Chaosnet address	IP Address
+-------		--------------------	----------
+CHARON		34415			18.58.0.13
+ATHENA		34401			18.58.0.1
+APHRODITE	34414			18.58.0.12
+SIPB-11		34440		      [ 18.58.0.64 ] (not IP live)
+
+The above address should correspond in the usual manner except that
+the subnet number in the chaosnet address appear to correspond to
+18.57.0.0 addresses.
+
+In summary:
+The bldg. 11 ethernet will carry IP subnet 18.58.0.0 packets (as it
+currently does) and chaos subnet 71 packets.
+
+The campus spine will be carry 18.68.0.0 packets (as it currently
+does) and will be free to carry chaos packets as subnet 104 if its
+maintainers so desire.
+
+			-Tim
+-------
+
+Date: Tue,  5 Aug 86 15:31:12 EDT
+From: Rob Austein <SRA@AI.AI.MIT.EDU>
+Subject:  Subnet 71 octal (57 decimal)
+To: INFO-HOSTS@AI.AI.MIT.EDU
+Message-ID: <[AI.AI.MIT.EDU].79751.860805.SRA>
+
+Is hereby reserved (and marked in the HSTNET file).
+
+It will eventually be used to fix one of the chaos<->IP subnet
+conflicts (building 11 chaos ethernet).
+
+Talk to me <SRA@XX>, Tim Shepard <SHEP@XX>, or Dave Bridgham
+<dab@borax> if you need more information about this.
+
+Date: Thu, 17 Jul 86 16:09:31 EDT
+From: Stan Zanarotti <SRZ@AI.AI.MIT.EDU>
+To: INFO-HOSTS@AI.AI.MIT.EDU
+Message-ID: <[AI.AI.MIT.EDU].71885.860717.SRZ>
+
+Changed priam's internet to 18.72.0.6 (changed subnets a while ago)
+
+Received: from XX.LCS.MIT.EDU by AI.AI.MIT.EDU 13 Jul 86 18:15:58 EDT
+Date: Sun, 13 Jul 1986  14:18 EDT
+Message-ID: <SRA.12222401871.BABYL@XX.LCS.MIT.EDU>
+From: Rob Austein <SRA@XX.LCS.MIT.EDU>
+To:   Info-Hosts@AI.AI.MIT.EDU
+Subject: HOSTS3 compiler running again
+
+I got a host table to compile again this morning, by flushing more
+stuff from the NIC tables.
+
+I was already flushing any host that didn't speak TCP/SMTP or
+TCP/TELNET.  Unfortunately there are a lot of workstations in the
+tables that advertise these services.  So the latest crock is to
+remove all but the primary name from anything that looks like a
+workstation (can't remove the entry entirely because it might be the
+machine-type data that's bogus instead of the services data).
+
+So you can't telnet to ISI-POSTEL.ARPA anymore, you have to call it
+POSTEL.ISI.EDU.  Life's rough.
+
+I dunno how long this will hold things together.  It only managed to
+gc five (twenex) pages of string space.  Sigh.  Of course I can always
+add more machine/opsys types to the hit list....
+
+--Rob
+
+Received: from XX.LCS.MIT.EDU by AI.AI.MIT.EDU 12 Jul 86 12:58:46 EDT
+Date: Sat, 12 Jul 1986  05:20 EDT
+Message-ID: <SRA.12222041666.BABYL@XX.LCS.MIT.EDU>
+From: Rob Austein <SRA@XX.LCS.MIT.EDU>
+To:   Info-Hosts@AI.AI.MIT.EDU, Namecallers@MC.LCS.MIT.EDU
+Subject: Name conflicts, table breakage, inconsistancies, version numbers
+
+First the short item.  The HOSTS3 compiler has stopped working again
+(undoubtably somebody on the West Coast added another 200 SUN
+workstations to the NIC tables).  I'll fix as soon as I decide what
+new class of machines to punt.  Files in XX:<HOSTS> will continue to
+be updated, but ones in XX:<SYSTEM> will freeze until this is fixed.
+
+Next.  I happened to compare a dump of Jeff's MIT.EDU domain with the
+host tables on AI.  I did a number of minor updates to the AI tables.
+I also discovered a few questionable items.
+
+	It doesn't appear that the SOA version number is getting
+	updated for the MIT.EDU domain or the non-delegated subnets.
+	This potentially a serious problem, since it screws anybody
+	who wants to do zone transfers.
+
+	Is PARIS.MIT.EDU a VAX-11/750 or a VAX-11/785?
+	Is PROMETHEUS.MIT.EDU running UNIX or DOS?
+	Is ATRP.MIT.EDU a VAX-11/785 or a VAX-11/750?
+	Is SAILOR.MIT.EDU a MASSCOMP or a SUN?
+	None of this major, but it'd be nice if it were correct.
+
+	There are some machines in the MIT.EDU domain with names of
+	the form MIT-foo.MIT.EDU which are also listed in the AI
+	tables (where they get names of the form foo.MIT.EDU):
+	CEZANNE, DEGAS, EMS, GOLDILOCKS, TWEETY-PIE, XEVIOUS, ZAXXON.
+	Not life or death but it'd be nice if we could agree.
+
+	POLYHYMNIA was listed in both MIT.EDU and LCS.MIT.EDU.  I
+	flushed the copy in LCS.MIT.EDU since I have a hard time
+	picturing LCS owning a machine in building 66.
+
+	Everybody thinks they own the MIT TAC.  The NIC calls it
+	MIT-TAC.ARPA and refuses to change it.  Jeff calls it
+	TAC.MIT.EDU, I calls it TAC.LCS.MIT.EDU.  Who cares.
+
+	And lastly, we have two full fledged name conflicts:
+
+	KOALA.MIT.EDU:
+		Chaos	15435,  Lispm,		RLE (Speech Ethernet)
+		IP 18.72.0.79,  Vaxstation,	Project Athena (E40)
+
+	RENOIR.MIT.EDU:
+		Chaos	15415,  Lispm,		RLE (Speech Ethernet)
+		IP 18.72.0.108, Vaxstation,	Project Athena (E40)
+
+	I'm pretty sure the Lispms have seniority.  Good thing they
+	aren't choosing to talk IP this week.
+
+Watch this space for further cruft.
+
+--Rob
+
+Received: from XX.LCS.MIT.EDU by AI.AI.MIT.EDU 10 Jul 86 18:18:49 EDT
+Date: Thu, 10 Jul 1986  18:16 EDT
+Message-ID: <SRA.12221658700.BABYL@XX.LCS.MIT.EDU>
+From: Rob Austein <SRA@XX.LCS.MIT.EDU>
+To:   "John Wroclawski" <JTW%MIT-SPEECH@XX.LCS.MIT.EDU>
+Cc:   Info-Hosts@AI.AI.MIT.EDU
+Subject: New list -- Info-Hosts-Update@AI
+In-reply-to: Msg of 10 Jul 1986  18:07-EDT from "John Wroclawski" <JTW%MIT-SPEECH@XX.LCS.MIT.EDU>
+
+    Date: Thursday, 10 July 1986  18:07-EDT
+    From: "John Wroclawski" <JTW%MIT-SPEECH@XX.LCS.MIT.EDU>
+
+    It might be better tojust have the generator batch job send a quick
+    note to info-hosts..
+
+I thought about that, but decided against it.  I expect that there are
+people who would like to be informed of major changes but who don't
+want to be bothered every time somebody adds a nickname for their PC.
+
+Received: from SPEECH.MIT.EDU by AI.AI.MIT.EDU via Chaosnet; 10 JUL 86  18:09:32 EDT
+Date: Thu 10 Jul 86 18:07:31-EDT
+From: "John Wroclawski" <JTW%MIT-SPEECH@XX.LCS.MIT.EDU>
+Subject: Re: New list -- Info-Hosts-Update@AI
+To: SRA@XX.LCS.MIT.EDU, Info-Hosts@AI.AI.MIT.EDU
+In-Reply-To: <SRA.12221653033.BABYL@XX.LCS.MIT.EDU>
+Message-ID: <12221657090.8.JTW@MIT-SPEECH>
+
+It might be better tojust have the generator batch job send a quick
+note to info-hosts..
+-------
+
+Received: from XX.LCS.MIT.EDU by AI.AI.MIT.EDU 10 Jul 86 17:50:19 EDT
+Date: Thu, 10 Jul 1986  17:45 EDT
+Message-ID: <SRA.12221653033.BABYL@XX.LCS.MIT.EDU>
+From: Rob Austein <SRA@XX.LCS.MIT.EDU>
+To:   Info-Hosts@AI.AI.MIT.EDU
+Subject: New list -- Info-Hosts-Update@AI
+
+In response to complaints from several people who like to snarf new
+host tables by hand but who never know when to do it, I have set up a
+new mailing list on AI, called INFO-HOSTS-UPDATE.  The XX compiler job
+will send a SRCCOM listing of differences in the HSTMIT table to this
+list, if there are any.
+
+Send mail to me or add yourself if you want to recieve this.  It'll
+probably be fairly high volume, be warned.
+
+--Rob
+
+Received: from MC.LCS.MIT.EDU by AI.AI.MIT.EDU via Chaosnet; 8 JUL 86  23:53:43 EDT
+Received: from OZ.AI.MIT.EDU by MC.LCS.MIT.EDU via Chaosnet; 8 JUL 86  23:52:22 EDT
+Date: 8 Jul 1986  23:49 EDT (Tue)
+Message-ID: <FONER.12221195101.BABYL@MIT-OZ>
+From: "Leonard N. Foner" <FONER%OZ.AI.MIT.EDU@XX.LCS.MIT.EDU>
+Subject: Antique programs and firing squads
+To:   Rob Austein <SRA@XX.LCS.MIT.EDU>
+Cc:   Info-Hosts%OZ.AI.MIT.EDU@XX.LCS.MIT.EDU,
+      Foner%OZ.AI.MIT.EDU@XX.LCS.MIT.EDU
+
+    Date: Tuesday, 3 June 1986  13:08-EDT
+    From: Rob Austein <SRA at XX.LCS.MIT.EDU>
+    To:   MUSE
+    cc:   info-hosts at AI.AI.MIT.EDU, bug-system
+    In-reply-to: Msg of 3 Jun 1986  12:47-EDT from MUSE%OZ.AI.MIT.EDU@XX.LCS.MIT.EDU
+
+        Date: Tuesday, 3 June 1986  12:47-EDT
+        From: MUSE%OZ.AI.MIT.EDU@XX.LCS.MIT.EDU
+        To:   info-hosts%OZ.AI.MIT.EDU@XX.LCS.MIT.EDU
+
+        MIT-SARAH has been replaced by MIT-AMOEBA at the same address
+        (chaos 4150).  Although this change has been reflected in
+        oz:oz:<system>hostnc.txt and ai:syshst;hstlcs, it does not seem to
+        have reached oz:oz:<system>hosts.mit.  Could someone please modify
+        the appropriate file(s)?
+
+    If you check the write date on OZ:<SYSTEM>HOSTS.MIT you will notice
+    that it was last written in June 1985.  In other words it is obsolete.
+
+    Unfortunately, the fact that it is still online after all this time
+    probably indicates that some antique programs are reading it.
+    Somebody should figure out which programs these are and take them out
+    and shoot them.
+
+Here's a reply to a somewhat-antique request for a firing squad.
+OZ:<SYSTEM>HOSTS.MIT is still online because the NIGHTLY batch job
+copies OZ:<SYSTEM>*.*.* to KANSAS:<SYSTEM>*.*.* every night for safe
+keeping.
+
+Maybe we should just set HOST.MIT invisible and see what breaks.  If
+that's not a good idea, I can watch the file to see what else, if
+anything, tries to open it over a day or two.
+
+I wonder how much other trash is being kept online by this batch job?
+
+						<LNF>
+
+Date: Mon,  7 Jul 86 10:36:54 EDT
+From: Patrick A O'Donnell <PAO@AI.AI.MIT.EDU>
+To: INFO-HOSTS@AI.AI.MIT.EDU
+Message-ID: <[AI.AI.MIT.EDU].66348.860707.PAO>
+
+Added MICRO-HEART-OF-GOLD to AI: SYSHST; HSTEE 3 a Microvax-II at CHAOS 12444.
+
+Received: from XX.LCS.MIT.EDU by AI.AI.MIT.EDU  3 Jul 86 12:10:57 EDT
+Date: Thu, 3 Jul 1986  12:11 EDT
+Message-ID: <SRA.12219757326.BABYL@XX.LCS.MIT.EDU>
+From: Rob Austein <SRA@XX.LCS.MIT.EDU>
+To:   Info-Hosts@AI.AI.MIT.EDU
+Subject: GRETCHEN.AI.MIT.EDU and GABRIELLE.AI.MIT.EDU
+
+Somebody added these two hosts to the AI namespace yesterday and gave
+them the same net address (18.26.0.177).  This caused the nightly
+table compiler to bomb out (correctly).
+
+I changed GRETCHEN's address to 18.26.0.178.  There doesn't seem to be
+anything at all answering that address at the moment, so this
+shouldn't break the world too badly.  If I got it backwards, well, fix
+it.
+
+I'd contact the culprit directly rather than telling the entire list,
+but the culprit didn't bother to fill out any of the nifty namespace
+fields that help people figure out where the machines really are.
+
+--Rob
+
+Received: from XX.LCS.MIT.EDU by AI.AI.MIT.EDU 26 Jun 86 21:52:15 EDT
+Date: Thu 26 Jun 86 21:49-EDT
+From: Rob Austein <SRA@XX.LCS.MIT.EDU>
+Subject: /etc/chaoshosts files
+To: info-hosts@AI.AI.MIT.EDU, vax-wizards@MILO.LCS.MIT.EDU
+
+XX is now generating two new tables as part of the nightly compilation
+process.  These are of interest to Unix machines.  They are listings
+of the MIT chaosnet, in form suitable for feeding to sendmail as
+/etc/chaoshosts (not to be confused with the binary Chaosnet host
+table for Unix).
+
+The two files are CHAOSHOSTS.CHAOS-ONLY and CHAOSHOSTS.CHAOS-ALL, both
+in XX:<HOSTS>.  The difference between them is that hosts on both
+Chaosnet and Internet will be in the second file but not in the first.
+If your unix host is only on the Internet you want the first file
+(only send mail via chaosnet relay if you can't send via Internet), if
+your unix host is only on the chaosnet you want the second file (only
+send via Internet relay if you can't send via the Chaosnet).  If your
+unix machine is on both it's up to you, depending on which net you
+prefer to use.
+
+I made no attempt to filter out non-mail hosts (bridges, etc), since
+there is no way to do it without risking removing real hosts as well.
+Life's rough.  If a bridge answers to SMTP or MAIL as a contact name
+you have problems anyway.
+
+Note that there -are- dots in these files.  Thus sendmail will now be
+able to deduce that "OZ.AI.MIT.EDU" is a chaosnet host, if you care.
+
+Source code for the filter is in XX:<HOSTS>CHAOSH.C.  I see no reason
+why anybody should ever need to run this themselves, but it's
+available if you disagree.
+
+Bug reports to me and/or Info-Hosts, as appropriate.  I don't read
+vax-wizards, so don't bother sending things there.
+
+--Rob
+
+Received: from EMACK-AND-BOLIOS.LCS.MIT.EDU by AI.AI.MIT.EDU via Chaosnet; 17 JUN 86  00:32:04 EDT
+Date: Tue, 17 Jun 86 00:30 EDT
+From: Rob Austein <SRA@MIT-AI.ARPA>
+Subject: LCS goes Lispm based
+To: Info-Hosts@MIT-AI.ARPA
+Message-ID: <"860617003056.1.sra@AI"@EMACK-AND-BOLIOS.LCS.MIT.EDU>
+
+Starting sometime in the next few days the HSTLCS table will start being
+generated by Zermatt from the LCS namespace.  Kudos to a certain hacker
+(who probably wants to remain unsung) for merging the HSTLCS file and
+the namespace.
+
+The preferred method for updating the namespace is to find a Lispm and
+use the namespace editor (carefully).  There is also a non-mouse
+oriented namespace editor available for people who can't/won't use
+Lispms directly.  Contact me if you think you need to use this.  I may
+write up some documentation if this method becomes popular.
+
+Most of the name collisions were trivial to deal with.  There is one
+that is not.  MUL is in use as a nickname by both MULTICS.MIT.EDU and
+MULBERRY.LCS.MIT.EDU.  Due to the respective ages of the machines, the
+MULLBERY nickname pretty much has to go (too many people use MUL to mean
+MULTICS in mail forwardings).  MULLBERRY hackers, you have been
+warned....
+
+Bug reports to the usual places.
+
+--Rob
+
+Received: from XX.LCS.MIT.EDU by AI.AI.MIT.EDU 12 Jun 86 22:12:25 EDT
+Date: Thu, 12 Jun 1986  21:13 EDT
+Message-ID: <SRA.12214350916.BABYL@XX.LCS.MIT.EDU>
+From: Rob Austein <SRA@XX.LCS.MIT.EDU>
+To:   Info-Hosts@AI.AI.MIT.EDU
+Subject: [HOSTMASTER: Nicknames?]
+
+For them as were asking me about this and wondering if the MIT table
+compiler was barfing out....
+
+--Rob
+
+Date: Thursday, 12 June 1986  19:17-EDT
+From: HOSTMASTER@SRI-NIC.ARPA
+Sender: SUE@SRI-NIC.ARPA
+Reply-To: HOSTMASTER@SRI-NIC.ARPA
+To:   sra@XX.LCS.MIT.EDU
+cc:   Hostmaster@SRI-NIC.ARPA
+Re:   Nicknames?
+
+Rob,
+
+Think and Seismo did not disappear from the host table.  They have just
+opted to do away with those aliases.  Here are the current entries for
+both hosts from the latest version of HOSTS.TXT:
+
+HOST : 10.4.0.6, 192.5.104.218 : ZARATHUSTRA.THINK.COM,THINK.COM,THINK.ARPA :
+VAX-11/750 : UNIX : TCP/NAME,TCP/FTP,TCP/TELNET,TCP/SMTP,TCP/SUPDUP,ICMP,EGP,
+UDP/DOMAIN :
+
+HOST : 10.0.0.25, 192.5.11.5, 192.12.25.5 : seismo.CSS.GOV,SEISMO.ARPA :
+VAX-11/780 : UNIX : TCP/TELNET,TCP/FTP,TCP/SMTP,UDP,ICMP,EGP,UDP/DOMAIN :
+
+Sue
+
+Received: from XX.LCS.MIT.EDU by AI.AI.MIT.EDU  4 Jun 86 17:05:44 EDT
+Date: Wed, 4 Jun 1986  17:08 EDT
+Message-ID: <SRA.12212209244.BABYL@XX.LCS.MIT.EDU>
+From: Rob Austein <SRA@XX.LCS.MIT.EDU>
+To:   Hostmaster@SRI-NIC.ARPA
+cc:   Info-Hosts@AI.AI.MIT.EDU
+Reply-To: Info-Hosts@AI.AI.MIT.EDU
+Subject: Nicknames?
+
+Some nicknames seem to have been disappearing lately.
+
+THINK (aka THINK.COM) and SEISMO (aka SEISMO.CSS.GOV) disappeared
+recently with no warning.  This broke a lot of mail forwardings.
+
+Is this a new policy or just coincidence?
+
+--Rob
+
+Received: from XX.LCS.MIT.EDU by AI.AI.MIT.EDU  3 Jun 86 13:05:04 EDT
+Date: Tue, 3 Jun 1986  13:08 EDT
+Message-ID: <SRA.12211903338.BABYL@XX.LCS.MIT.EDU>
+From: Rob Austein <SRA@XX.LCS.MIT.EDU>
+To:   MUSE%OZ.AI.MIT.EDU@XX.LCS.MIT.EDU
+Cc:   info-hosts@AI.AI.MIT.EDU, bug-system@OZ.AI.MIT.EDU
+In-reply-to: Msg of 3 Jun 1986  12:47-EDT from MUSE%OZ.AI.MIT.EDU@XX.LCS.MIT.EDU
+
+    Date: Tuesday, 3 June 1986  12:47-EDT
+    From: MUSE%OZ.AI.MIT.EDU@XX.LCS.MIT.EDU
+    To:   info-hosts%OZ.AI.MIT.EDU@XX.LCS.MIT.EDU
+
+    MIT-SARAH has been replaced by MIT-AMOEBA at the same address
+    (chaos 4150).  Although this change has been reflected in
+    oz:oz:<system>hostnc.txt and ai:syshst;hstlcs, it does not seem to
+    have reached oz:oz:<system>hosts.mit.  Could someone please modify
+    the appropriate file(s)?
+
+If you check the write date on OZ:<SYSTEM>HOSTS.MIT you will notice
+that it was last written in June 1985.  In other words it is obsolete.
+
+Unfortunately, the fact that it is still online after all this time
+probably indicates that some antique programs are reading it.
+Somebody should figure out which programs these are and take them out
+and shoot them.
+
+Received: from MC.LCS.MIT.EDU by AI.AI.MIT.EDU via Chaosnet; 3 JUN 86  13:04:43 EDT
+Received: from OZ.AI.MIT.EDU by MC.LCS.MIT.EDU via Chaosnet; 3 JUN 86  13:04:25 EDT
+Date: Tue, 3 Jun 1986  13:03 EDT
+Message-ID: <MUSE.12211902441.BABYL@MIT-OZ>
+From: MUSE%OZ.AI.MIT.EDU@XX.LCS.MIT.EDU
+To:   info-hosts@MC.LCS.MIT.EDU
+
+MIT-SARAH has been replaced by MIT-AMOEBA at the same address (chaos 4150).
+Although this change has been reflected in oz:oz:<system>hostnc.txt and
+ai:syshst;hstlcs,  it does not seem to have reached oz:oz:<system>hosts.mit.
+Could someone please modify the appropriate file(s)?
+
+Received: from MC.LCS.MIT.EDU by AI.AI.MIT.EDU via Chaosnet; 3 JUN 86  12:49:05 EDT
+Received: from OZ.AI.MIT.EDU by MC.LCS.MIT.EDU via Chaosnet; 3 JUN 86  12:48:52 EDT
+Date: Tue, 3 Jun 1986  12:47 EDT
+Message-ID: <MUSE.12211899588.BABYL@MIT-OZ>
+From: MUSE%OZ.AI.MIT.EDU@XX.LCS.MIT.EDU
+To:   info-hosts%OZ.AI.MIT.EDU@XX.LCS.MIT.EDU
+
+MIT-SARAH has been replaced by MIT-AMOEBA at the same address (chaos 4150).
+Although this change has been reflected in oz:oz:<system>hostnc.txt and
+ai:syshst;hstlcs,  it does not seem to have reached oz:oz:<system>hosts.mit.
+Could someone please modify the appropriate file(s)?
+
+
+Received: from MC.LCS.MIT.EDU by AI.AI.MIT.EDU via Chaosnet; 29 MAY 86  00:20:49 EDT
+Received: from XX.LCS.MIT.EDU by MC.LCS.MIT.EDU 29 May 86 00:20:30 EDT
+Date: Thu, 29 May 1986  00:19 EDT
+Message-ID: <SRA.12210452653.BABYL@XX.LCS.MIT.EDU>
+From: Rob Austein <SRA@XX.LCS.MIT.EDU>
+To:   Info-Hosts@MC.LCS.MIT.EDU
+Subject: Host tables repaired... for now
+
+Host tables are being generated again.  I frobbed the compiler job to
+punt any non-MIT host that doesn't speak TCP/SMTP or TCP/TELNET.  This
+shrunk the table size enough for HOSTS3 to generate a table.
+
+This is not a long term fix.  Anybody still using the HOSTS3 binary
+file should move to some other lookup mechanism as soon as possible.
+Support for this table will probably evaporate as soon as ITS is free
+of it.  Discussion invited, on NAMECALLERS@MC.
+
+HOST3C and chaos-only HOSTS2 text files aren't a problem, I can
+generate them fairly trivially with TECO.  An MIT-only HOSTS3 file
+wouldn't be hard either.  It's the NIC data that's the killer.
+
+--Rob
+
+Received: from MC.LCS.MIT.EDU by AI.AI.MIT.EDU via Chaosnet; 28 MAY 86  00:20:24 EDT
+Received: from XX.LCS.MIT.EDU by MC.LCS.MIT.EDU 28 May 86 00:20:03 EDT
+Date: Wed 28 May 86 00:18:49-EDT
+From: Rob Austein <SRA@XX.LCS.MIT.EDU>
+Subject: Lispms and host tables
+To: MUSE@OZ.AI.MIT.EDU
+cc: info-hosts@MC.LCS.MIT.EDU
+In-Reply-To: <MUSE.12210114236.BABYL@MIT-OZ>
+Message-ID: <12210190348.63.SRA@XX.LCS.MIT.EDU>
+
+    Date: Tue, 27 May 1986 17:20 EDT
+    From: MUSE%OZ.AI.MIT.EDU@XX.LCS.MIT.EDU
+    To: info-hosts@MC.LCS.MIT.EDU
+
+    Lisp Machine MIT-SARAH has been changed to MIT-AMOEBA at the same
+    chaos address.  I don't know where MC:SYSENG;HSTMIT has gone or if
+    it is still used. Please notify me if it needs to be changed.
+
+The correct file these days would be in AI: SYSHST; HSTxxx >, where
+xxx is one of AI, LCS, G, ATH, or EE, depending on who owns your LispM
+(we divided Gaul into five parts about a year ago).  The machine is
+currently listed in HSTLCS, because somebody claimed it belonged to
+LCS back when we did the division.
+
+I am unable to find either SARAH or AMOEBA in the LispM namespace.
+Who, what, where are you, anyway?
+-------
+
+Received: from MC.LCS.MIT.EDU by AI.AI.MIT.EDU via Chaosnet; 27 MAY 86  17:26:53 EDT
+Received: from OZ.AI.MIT.EDU by MC.LCS.MIT.EDU via Chaosnet; 27 MAY 86  17:26:23 EDT
+Date: Tue, 27 May 1986  17:20 EDT
+Message-ID: <MUSE.12210114236.BABYL@MIT-OZ>
+From: MUSE%OZ.AI.MIT.EDU@XX.LCS.MIT.EDU
+To:   info-hosts@MC.LCS.MIT.EDU
+
+Lisp Machine MIT-SARAH has been changed to MIT-AMOEBA at the same chaos address.
+I don't know where MC:SYSENG;HSTMIT has gone or if it is still used. Please notify
+me if it needs to be changed.
+
+
+Received: from XX.LCS.MIT.EDU by AI.AI.MIT.EDU 21 May 86 15:39:41 EDT
+Date: Wed, 21 May 1986  15:40 EDT
+Message-ID: <SRA.12208523100.BABYL@XX.LCS.MIT.EDU>
+From: Rob Austein <SRA@XX.LCS.MIT.EDU>
+To:   Info-Hosts@AI.AI.MIT.EDU
+Subject: MC <-> MX brain transplant
+
+As of this morning MC and MX have swapped names and IMP ports.  This
+manifests itself in the host tables as the two machines exchanging
+chaosnet addresses and CPU types.
+
+All Chaosnet machines should obtain new host tables immediately.  The
+KL (old MC, new MX) is not long for this world and in fact may have
+already bought it as I type this.  The KS (old MX, new MC) is healthy
+and is handling the MC mail load.
+
+Host tables are going to be sporadic for the next little while.  The
+NIC has increased the table size yet again, and I'm going to have to
+figure out some new way to shrink the table back down.  The table
+currently installed on XX and the ITSs does not know about any SUN,
+IBM-PC, or LispM outside of MIT and Symbolics.  (We needed to punt
+something, in a hurry, and these seemed least likely to be missed).
+
+--Rob
+
+Received: from MC.LCS.MIT.EDU by AI.AI.MIT.EDU via Chaosnet; 15 MAY 86  17:42:58 EDT
+Received: from ATHENA by MC.LCS.MIT.EDU 15 May 86 17:41:02 EDT
+Received: by ATHENA (5.45/4.7)
+	id AA01726; Thu, 15 May 86 17:39:22 EDT
+From: <alix@ATHENA.MIT.EDU>
+Received: by HECTOR (5.45/4.7)
+	id AA19425; Thu, 15 May 86 17:39:09 EDT
+Date: Thu, 15 May 86 17:39:09 EDT
+Message-Id: <8605152139.AA19425@HECTOR>
+To: karen
+Subject: Re: trillian
+Cc: info-hosts@mc.LCS.MIT.EDU
+
+Sorry, Karen.  We've now changed our minds and I am going to try to
+put trillian back on chaosnet; we did not know that people were using
+it so much.  Even so, I can only try.
+
+Alix
+
+Received: from MC.LCS.MIT.EDU by AI.AI.MIT.EDU via Chaosnet; 15 MAY 86  16:49:16 EDT
+Received: from ATHENA by MC.LCS.MIT.EDU 15 May 86 16:45:40 EDT
+Received: by ATHENA (5.45/4.7)
+	id AA01388; Thu, 15 May 86 16:34:55 EDT
+From: <alix@ATHENA.MIT.EDU>
+Received: by HECTOR (5.45/4.7)
+	id AA18967; Thu, 15 May 86 16:34:56 EDT
+Date: Thu, 15 May 86 16:34:56 EDT
+Message-Id: <8605152034.AA18967@HECTOR>
+To: info-hosts@mc.LCS.MIT.EDU
+Subject: trillian.MIT.EDU
+Cc: bcn
+
+Could trillian please be removed from the chaosnet host tables?
+We are unable to reinstall the software.
+
+Thank you,
+Alix Vasilatos
+
+Received: from XX.LCS.MIT.EDU by AI.AI.MIT.EDU 25 Apr 86 17:51:42 EST
+Date: Fri, 25 Apr 1986  17:50 EST
+Message-ID: <SRA.12201742004.BABYL@XX.LCS.MIT.EDU>
+From: Rob Austein <SRA@XX.LCS.MIT.EDU>
+To:   Mike McIlrath <mbm@CAF.MIT.EDU>
+cc:   info-hosts@AI.AI.MIT.EDU, jis@BITSY.MIT.EDU, boning@CAF.MIT.EDU
+Subject: please add host
+In-reply-to: Msg of 25 Apr 1986  17:31-EST from Mike McIlrath <mbm@caf>
+
+Sending mail to INFO-HOSTS still works, I suppose, if you are -very-
+patient.  Allow a month or two for delivery....
+
+If you want a single program to "add a host", I suggest you write one.
+Contact me (offline) for pointers to relevant documentation.
+
+Received: from CAF.MIT.EDU by AI.AI.MIT.EDU via Chaosnet; 25 APR 86  17:32:11 EST
+Return-Path: <mbm@caf>
+Received: by caf.MIT.EDU (5.9/MIT.1x)
+	 on Fri, 25 Apr 86 17:31:30 EST; User info-hosts@AI; Host AI
+Date: Fri, 25 Apr 86 17:31:30 EST
+From: Mike McIlrath <mbm@caf>
+To: SRA@XX
+Cc: info-hosts@AI, @caf:jis@BITSY.MIT.EDU, boning@caf
+In-Reply-To: Rob Austein's message of Fri, 25 Apr 1986  16:49 EST
+Subject: please add host
+
+
+Sorry, I just cannot keep up with where the host table is this month.
+The one constant in all this host business has been that if you sent
+mail to info-hosts, eventually someone who knew what was up took care
+of it.  
+
+Jeff -- do you read info-hosts and use it to update your database?
+
+Really, folks:  there should be ONE (count 'em) "operations" required
+to "add a host".  I dont care if its sending mail, editing a file, 
+running a program, or what.  
+--mike
+
+
+
+Received: from XX.LCS.MIT.EDU by AI.AI.MIT.EDU 25 Apr 86 16:50:12 EST
+Date: Fri, 25 Apr 1986  16:49 EST
+Message-ID: <SRA.12201730846.BABYL@XX.LCS.MIT.EDU>
+From: Rob Austein <SRA@XX.LCS.MIT.EDU>
+To:   Mike McIlrath <mbm@CAF.MIT.EDU>
+cc:   info-hosts@AI.AI.MIT.EDU, jis@BITSY.MIT.EDU, boning@CAF.MIT.EDU
+Subject: please add host
+In-reply-to: Msg of 24 Apr 1986  11:28-EST from Mike McIlrath <mbm@caf>
+
+Mike,
+
+You don't need to ask somebody to do this.  Just telnet or supdup to
+AI and add the appropriate entry to the appropriate file (in your case
+this would be AI: SYSHST; HSTG >).  That's why we put the tables on a
+machine where you don't need to log in to edit files!
+
+--Rob
+
+Received: from MC.LCS.MIT.EDU by AI.AI.MIT.EDU via Chaosnet; 24 APR 86  20:51:09 EST
+Received: from CAF.MIT.EDU by MC.LCS.MIT.EDU via Chaosnet; 24 APR 86  20:35:16 EST
+Return-Path: <mbm>
+Received: by caf.MIT.EDU (5.9/MIT.1x)
+	 on Thu, 24 Apr 86 11:28:23 EST; User dsb@mit-waif; Host mit-waif
+Date: Thu, 24 Apr 86 11:28:23 EST
+From: Mike McIlrath <mbm@caf>
+To: info-hosts@mc, @caf:jis@athena, @caf:jis@bitsy
+Cc: boning@caf
+Subject: please add host
+
+
+Cagney (cag, dirty-rat), a microvaxII running Unix.
+IP: 18.62.0.235
+Chaos: 12753 (octal)
+
+Thanks.
+--mike
+
+
+
+Received: from MC.LCS.MIT.EDU by AI.AI.MIT.EDU via Chaosnet; 11 APR 86  09:25:45 EST
+Received: from 40700015362 by MC.LCS.MIT.EDU via Chaosnet; 11 APR 86  09:24:18 EST
+Date: Fri, 11 Apr 86 09:23 EST
+From: Jeff Arnold <jma@MIT-VAX.ARPA>
+Subject: Changes in hstlcs
+To: info-hosts@MIT-MC.ARPA
+Message-ID: <860411092325.4.JMA@STOWE.LCS.MIT.EDU>
+
+I've added the new ML site lispms:
+	Interlaken, Kazoo, Oboe, Stowe, Trumpet, Vail
+
+and deleted the Nu machines:
+	NU-9 through NU-29
+which are no longer powered up.  Interlaken, Kazoo, Oboe, and Trumpet
+are re-using old Nu machine addresses.
+
+
+Received: from XX.LCS.MIT.EDU by AI.AI.MIT.EDU 28 Mar 86 20:41:53 EST
+Date: Fri, 28 Mar 1986  20:46 EST
+Message-ID: <SRA.12194434031.BABYL@XX.LCS.MIT.EDU>
+From: Rob Austein <SRA@XX.LCS.MIT.EDU>
+To:   Info-Hosts@AI.AI.MIT.EDU
+cc:   knight@SRI-NIC.ARPA
+Subject: [KNIGHT: The NIC and FTPing host tables]
+
+People,
+
+I just turned off the frob that was retrieving new copies of HSTNIC on
+MC.  Anybody at MIT who needs the NIC host table should get it from XX
+(via anonymous FTP or CFTP).  Please -don't- get it from the NIC (see
+enclosed message).  There are two files of interest on XX:
+
+    XX:<HOSTS>HOSTS.NIC is the raw NIC host table; version numbers
+    track those at the NIC.
+
+    XX:<SYSTEM>HOSTS.TXT is a merge of the TCP/IP data from the MIT
+    tables with the NIC table.  This is the same data that goes into
+    the HOSTS3 table, but with all the Chaosnet stuff filtered out.
+
+I enclose the following for people on this list who aren't on TCP-IP.
+
+--Rob
+
+Date: Tuesday, 25 March 1986  23:12-EST
+From: Bob Knight <KNIGHT@SRI-NIC.ARPA>
+To:   tcp-ip@SRI-NIC.ARPA
+cc:   cf-staff@SRI-NIC.ARPA, feinler@SRI-NIC.ARPA, stjohns@SRI-NIC.ARPA
+Re:   The NIC and FTPing host tables
+
+Hi - it's taken me quite a while to draft this message.  However, things
+are getting intolerable, and I feel that it's appropriate to broach the
+subject.
+
+Quite frankly, we're experiencing tremendous network load from people
+(automatically) FTPing the host tables when we release one.  There are
+several modes of behaviour which are most offensive:
+
+	o  Many people choose a convenient time, such as midnight.  The
+	   consequences are that we get about 10 FTP server jobs running
+	   simultaneously.  
+
+	o  Some sites with multiple hosts in close proximity have their
+	   hosts get their tables from us, rather than having a single
+	   host at the site get it and propagate it.  A sample site had
+	   THREE FTP's going from distinct hosts, all getting the host
+	   table.
+
+	o  Some sites simply FTP the host table every day, whether it
+	   needs it or not.  This is anti-social.
+
+     I feel that a simple and workable solution is for some major sites
+(BBN, ISI, Stanford, MIT - this is by no means a request or finger point)
+to serve as "host table servers", thus relieving the load on the NIC.
+Perhaps a policy implementation modelled after domains is in order.  I do
+know that if things don't change, we'll cut back on the frequency of host
+table releases from sheer necessity.
+
+     Discussion?
+
+Bob
+
+Received: from MC.LCS.MIT.EDU by AI.AI.MIT.EDU via Chaosnet; 27 MAR 86  22:00:43 EST
+Received: from ATHENA by MC.LCS.MIT.EDU 27 Mar 86 22:01:34 EST
+Received: by ATHENA (5.45/4.7)
+	id AA05942; Thu, 27 Mar 86 21:51:22 EST
+Received: by ACHILLES (5.15/4.7)
+	id AA08828; Thu, 27 Mar 86 21:51:15 EST
+Received: from MITMS1-E52: by XV.MIT.EDU; 27-Mar-86 21:54:01
+Message-Id: <542331594.17114614@XV.MIT.EDU>
+To: Kevin_Crowston@XV.MIT.EDU, info-hosts@mc.LCS.MIT.EDU
+Subject: Services supported by XV
+From: Kevin_Crowston@XV.MIT.EDU
+Date: 27 Mar 86 21:51
+
+Not that it likely makes much difference to anyone, but,
+xv.mit.edu supports TCP/FINGER and TCP/TELNET
+in addition to TCP/SMTP.  I'd make the change myself,
+except I don't really know how, and don't have an account
+on xx anyway.  If it matters, perhaps someone can either
+make the change or tell me how to.
+
+Kevin Crowston
+Postmaster, xv.mit.edu
+MIT Sloan School of Management
+
+kevin@xv.mit.edu
+
+
+
+
+Date: Thu, 27 Mar 86 12:55:10 EST
+From: Rob Austein <SRA@AI.AI.MIT.EDU>
+Subject:  Host tables now automaticly compiled on XX
+To: INFO-HOSTS@AI.AI.MIT.EDU
+Message-ID: <[AI.AI.MIT.EDU].21858.860327.SRA>
+
+Binary HOSTS3 files for the ITS machines are now being compiled by
+XX's nightly batch job.  This means that it should no longer be
+necessary to run the HOSTS XFILE script on AI.  HOSTS XFILE is still
+around, in case it is needed in an emergency.
+
+XX should probably be considered the cannonical source of binary
+HOSTS2 and HOSTS3 files, as well as HOSTS2 format text files.  The
+RFC810 format source (text) files will continue to reside on AI for
+ease of access.  If you prefer to continue to get binary files from an
+ITS, it won't hurt.
+
+If you weren't ever running the HOSTS XFILE script before, this change
+shouldn't affect you.
+
+If you want to be added to the (small) list of people who get bug
+messages from the XX compiler job if something appears to have gone
+seriously wrong, send mail to me.  If you are curious about the
+current automated procedure, look in XX: HOSTS;.
+
+--Rob
+
+Received: from MC.LCS.MIT.EDU by AI.AI.MIT.EDU via Chaosnet; 25 MAR 86  03:59:45 EST
+Date: Tue, 25 Mar 86 03:58:12 EST
+From: Rob Austein <SRA@MC.LCS.MIT.EDU>
+Subject: Host tables now live on AI.AI.MIT.EDU
+To: info-hosts@AI.AI.MIT.EDU
+Message-ID: <[MC.LCS.MIT.EDU].861020.860325.SRA>
+
+The MIT host tables have now been moved to AI.  Update procedures are
+as they have been on MC since December.  All the tables live in the
+AI: SYSHST; directory.  The INFO-HOSTS mailing list has also moved to
+AI.  Nobody should make any further changes to the tables on MC, as
+these changes will be lost (really lost, the first time MC has a head
+crash, since it will no longer have backup service).
+
+The location change again when we have the other KS-10s up and running
+ITS, but at the moment AI is the best choice.
+
+Sorry for whatever confusion this generates, but it seemed better than
+keeping the master tables on an unsupported machine.
+
+--Rob
+
+Date: Mon, 24 Mar 86 16:44:57 EST
+From: Rob Austein <SRA@MC.LCS.MIT.EDU>
+Subject: Host tables moving to AI
+To: INFO-HOSTS@MC.LCS.MIT.EDU
+Message-ID: <[MC.LCS.MIT.EDU].860651.860324.SRA>
+
+The MIT host tables are being moved from MC to AI, since after the end
+of this week MC will no longer have regular backup service or hardware
+maintainence.  I will send another message to INFO-HOSTS when the
+transition is complete.  ANY CHANGES YOU MAKE IN THE MEANTIME WILL BE LOST.
+
+The new location will be AI: SYSHST;, files will be as they now are on MC.
+
+--Rob
+
+Date: Fri, 14 Mar 86 16:15:02 EST
+From: Rob Austein <SRA@MC.LCS.MIT.EDU>
+Subject: Athena chaos address fakeout, HOSTS3 compiler broken.
+To: INFO-HOSTS@MC.LCS.MIT.EDU
+Message-ID: <[MC.LCS.MIT.EDU].851075.860314.SRA>
+
+1) The chaosnet address of ATHENA in the newest HSTMIT is a lie.
+   The address listed is really a different project athena machine.
+   ENS@ATHENA and I did this because Athena itself is off the chaosnet
+   for an indefinite time due to hardware lossage beyond their control.
+   So this way mail will get through without having to go via MC, but
+   trying to SUPDUP or TELNET to Athena via chaos will lose.  Sorry.
+
+2) The HOSTS3 compiler has run out of address space again, so it won't
+   be possible to generate new HOSTS3 binary files until I figure out
+   some new class of hosts or nicknames that can be safely pruned from
+   HSTNIC.  PDP10s (and vaxen who port HOSTS2.TXT files from XX or OZ)
+   beware.
+
+Received: from CAF.MIT.EDU by MC.LCS.MIT.EDU via Chaosnet; 14 MAR 86  16:09:27 EST
+Return-Path: <mbm@mit-caf>
+Received: by mit-caf.MIT.EDU (5.9/MIT.1x)
+	 on Fri, 14 Mar 86 16:08:57 EST; User info-hosts@mc; Host mc
+Date: Fri, 14 Mar 86 16:08:57 EST
+From: Mike McIlrath <mbm@mit-caf>
+To: info-hosts@mc, jis@athena
+Cc: kmware@mit-caf
+Subject: please add host
+
+
+Please add host "bogart", a microvaxII running unix (with the usual 
+accoutrements).
+	
+	IP 	18.62.0.234
+	CHAOS	12752
+
+Thanks.
+
+Received: from AI.AI.MIT.EDU by MC.LCS.MIT.EDU via Chaosnet; 22 FEB 86  00:33:19 EST
+Date: Sat, 22 Feb 86 00:34:55 EST
+From: "Pandora B. Berman" <CENT@AI.AI.MIT.EDU>
+Subject: Re: bad address
+To: jis@BITSY.MIT.EDU
+cc: kevin%harvard@HARVARD.HARVARD.EDU, info-hosts@MC.LCS.MIT.EDU
+Message-ID: <[AI.AI.MIT.EDU].15545.860222.CENT>
+
+    Date: Fri, 21 Feb 86 22:44:14 EST
+    From: jis@BITSY.MIT.EDU (Jeffrey I. Schiller)
+    To: "Pandora B. Berman" <CENT@AI.AI.MIT.EDU>
+    Cc: kevin%harvard@HARVARD.HARVARD.EDU, info-hosts@mc.lcs.mit.edu
+    In-Reply-To: "Pandora B. Berman"'s message of Fri, 21 Feb 86 21:27:08 EST
+    Subject: Re: bad address
+    Whose host tables were those... the NIC's is correct.
+			    -Jeff
+
+the line
+
+HOST : 18.86.0.4 : SLOAN.MIT.EDU,MIT-SLOAN.ARPA,MIT-SLOAN,SLOAN,XV.MIT.EDU,MIT-XV.ARPA,MIT-XV,XV : DANDELION : INTERLISP ::
+
+in my previous msg was from MC:SYSHST;HSTMIT >. indeed, the following are in
+MC:SYSHST;HSTNIC > :
+
+HOST : 18.86.0.4 : XV.MIT.EDU,MIT-XV.ARPA,MIT-XV : DANDELION : INTERLISP : TCP/SMTP :
+HOST : 18.86.0.6 : SLOAN.MIT.EDU,MIT-SLOAN.ARPA,MIT-SLOAN : IBM-4341 : VM : TCP/TELNET,TCP/SMTP,TCP/FTP :
+
+but the host-finding, given the evidence, is running off HSTMIT.
+
+Received: from BITSY.MIT.EDU by MC.LCS.MIT.EDU 21 Feb 86 22:56:35 EST
+Received: by BITSY.MIT.EDU (5.15/4.7)
+	id AA04021; Fri, 21 Feb 86 22:44:14 EST
+Date: Fri, 21 Feb 86 22:44:14 EST
+From: jis@BITSY.MIT.EDU (Jeffrey I. Schiller)
+Message-Id: <8602220344.AA04021@BITSY.MIT.EDU>
+To: "Pandora B. Berman" <CENT@AI.AI.MIT.EDU>
+Cc: kevin%harvard@HARVARD.HARVARD.EDU, info-hosts@mc.lcs.mit.edu
+In-Reply-To: "Pandora B. Berman"'s message of Fri, 21 Feb 86 21:27:08 EST
+Subject: Re: bad address
+
+Whose host tables were those... the NIC's is correct.
+
+			-Jeff
+
+Received: from AI.AI.MIT.EDU by MC.LCS.MIT.EDU via Chaosnet; 21 FEB 86  21:42:04 EST
+Date: Fri, 21 Feb 86 21:27:08 EST
+From: "Pandora B. Berman" <CENT@AI.AI.MIT.EDU>
+Subject: Re: bad address
+To: kevin%harvard@HARVARD.HARVARD.EDU
+cc: HEADER-PEOPLE-REQUEST@AI.AI.MIT.EDU, info-hosts@MC.LCS.MIT.EDU
+Message-ID: <[AI.AI.MIT.EDU].15471.860221.CENT>
+
+    To: "Pandora B. Berman" <CENT@ai.ai.mit.edu>
+    Cc: HEADER-PEOPLE-REQUEST@ai.ai.mit.edu
+    Subject: Re: bad address
+    Date: 20 Feb 86 11:54:35 EST (Thu)
+    From: kevin%harvard@harvard.HARVARD.EDU
+    The problem is that the message is addressed to sloan.mit.edu, not to
+    xv.mit.edu.  Please fix the list so that you're really mailing to
+    header-people-incoming@xv.mit.edu.
+    Kevin Crowston
+    Postmaster, xv.mit.edu
+
+a couple days ago i sent you this mail indicating that i had just done so:
+    Date: Mon, 17 Feb 86 05:03:25 EST
+    From: "Pandora B. Berman" <CENT@AI.AI.MIT.EDU>
+    Subject: Changing the name of mit-sloan.mit.edu, take 2 
+    To: kevin@HARVARD.HARVARD.EDU
+    cc: HEADER-PEOPLE-REQUEST@AI.AI.MIT.EDU
+	Date: Tue, 31 Dec 85 15:22:51 EST
+	From: kevin@harvard.HARVARD.EDU (Kevin Crowston)
+	To: header-people-request@mit-mc.arpa 
+	Subject: Changing the name of mit-sloan.mit.edu, take 2 
+	Sorry about the previous confusion....  Anyway, here's our hoped
+	for schedule for the change over:
+	 immediately the host "mit-sloan.mit.edu", internet address
+	[18.86.0.4] will be identifying itself as "xv.mit.edu".
+	 This weekend, I hope, the MIT name server will be updated to know
+	that "xv.mit.edu" is really [18.86.0.4].  (It turns out that the
+	only person in the universe who can make this change has been on
+	vacation all this time, so this hasn't happened yet.)  I will mail
+	another letter as soon as I hear that the nameserver is up-to-date.
+	 The current time table says that by 15 January,
+	"mit-sloan.mit.edu" will be the name of a different machine, so I
+	hope that the changes in the various mailing list will have been
+	made by then.
+	 Once again, sorry for the confusion; I hope the too hasty change
+	hasn't started mail bouncing all over the net.
+	kevin@harvard.arpa
+	kevin%xv.mit.edu@mit-mc.arpa (soon)
+	kevin%mit-sloan.mit.edu@mit-mc.arpa (now)
+    i recently noticed that SLOAN has aqcuired XV as an alternate name, or
+    nickname, or whatever, so have just implemented your above request for
+    address change. it took me -this long- to grasp the pun; i must be slowing
+    down.
+
+at that time i had in fact changed your entry; until i commented it out
+yesterday, this is how it read:
+(header-people-incoming @XV)	; req. of Kevin@SLOAN Crowston 1sep85
+
+now, this is what the host table says about the host in question:
+HOST : 18.86.0.4 : SLOAN.MIT.EDU,MIT-SLOAN.ARPA,MIT-SLOAN,SLOAN,XV.MIT.EDU,MIT-XV.ARPA,MIT-XV,XV : DANDELION : INTERLISP ::
+
+the host table thinks XV and SLOAN are the same thing. clearly the host
+table, not the Header-People list, is what is confused.  i suggest that you
+arrange to have the host table fixed with respect to the Sloan host(s).
+
+Received: from XX.LCS.MIT.EDU by MC.LCS.MIT.EDU 18 Feb 86 13:56:21 EST
+Date: Tue, 18 Feb 1986  13:55 EST
+Message-ID: <SRA.12184397767.BABYL@XX.LCS.MIT.EDU>
+From: Rob Austein <SRA@XX.LCS.MIT.EDU>
+To:   cjl@OZ.AI.MIT.EDU
+cc:   info-hosts@MC.LCS.MIT.EDU
+Subject: tables broken again
+
+NEWTON is now listed in both HSTAI and HSTG.  Massive lossage.
+
+Received: from XX.LCS.MIT.EDU by MC.LCS.MIT.EDU 13 Feb 86 05:02:45 EST
+Date: Thu, 13 Feb 1986  05:03 EST
+Message-ID: <SRA.12182990201.BABYL@XX.LCS.MIT.EDU>
+From: Rob Austein <SRA@XX.LCS.MIT.EDU>
+To:   info-hosts@MC.LCS.MIT.EDU
+cc:   sra@XX.LCS.MIT.EDU, cjl@OZ.AI.MIT.EDU
+Subject: Cretinous lossage
+
+Some pinhead put a bunch of EECS hosts into the HSTAI table
+(presumably by putting them into Reagan's namespace).  This causes the
+host table compiler to barf, since the culprit didn't get all the
+names right and there are primary name mismatches.
+
+Host tables will be disfunctional until this is fixed at the source,
+since I am not about to start a namespace war with a Lisp Machine.
+
+Chris, you might want to install a filter in Reagan's table dump
+program so that it won't propagate this kind of lossage.
+
+--Rob
+
+Received: from XX.LCS.MIT.EDU by MC.LCS.MIT.EDU  4 Feb 86 21:13:37 EST
+Date: Tue, 4 Feb 1986  21:14 EST
+Message-ID: <SRA.12180807532.BABYL@XX.LCS.MIT.EDU>
+From: Rob Austein <SRA@XX.LCS.MIT.EDU>
+To:   info-hosts@MC.LCS.MIT.EDU, postmaster@VAX.LCS.MIT.EDU
+Subject: VAX.LCS.MIT.EDU now listed as Chaos-only host
+
+I commented out the IP address for VAX.LCS.MIT.EDU (VX).  As the
+person responsible for keeping the LCS tables in some state that
+vaugely reflects reality, I just went ahead and did this by fiat
+without waiting for VX's owners to give me permission (or more
+accurately, I timed out while waiting for a useful answer to my
+queries).  This change will affect the MIT HOSTS3 and HSTMIT files
+(and anything that is generated from them) and the LCS.MIT.EDU domain.
+It will *not* affect the NIC tables, so we can change things back
+quietly if/when VX's TCP/IP code becomes reliable enough to use for
+mail on a regular basis.
+
+Anybody who wants to change this back please talk to me first.  There
+are some issues involved that are not readily apparent.
+
+Received: from XX.LCS.MIT.EDU by MC.LCS.MIT.EDU 31 Jan 86 22:55:44 EST
+Date: Fri 31 Jan 86 22:56:40-EST
+From: Michael B McIlrath <MBM@XX.LCS.MIT.EDU>
+Subject: [Communications Satellite <COMSAT@MC.LCS.MIT.EDU>: Msg of Thursday, 30 January 1986 16:21-EST]
+To: info-hosts@MC.LCS.MIT.EDU
+Message-ID: <12179777611.35.MBM@XX.LCS.MIT.EDU>
+
+Received: from MC.LCS.MIT.EDU by XX.LCS.MIT.EDU via Chaosnet; 30 Jan 86 16:21-EST
+Date: Thu, 30 Jan 86 16:21:31 EST
+From: Communications Satellite <COMSAT@MC.LCS.MIT.EDU>
+Subject: Msg of Thursday, 30 January 1986 16:21-EST
+To: "MBM@XX.LCS.MIT.EDU"@XX.LCS.MIT.EDU
+Message-ID: <[MC.LCS.MIT.EDU].801937.860130>
+
+============ A copy of your message is being returned, because: ============
+"INFO-HOST" at MC.LCS.MIT.EDU is an unknown recipient.
+============ Failed message follows: ============
+Received: from XX.LCS.MIT.EDU by MC.LCS.MIT.EDU 30 Jan 86 15:05:56 EST
+Date: Thu 30 Jan 86 13:04:36-EST
+From: Michael B McIlrath <MBM@XX.LCS.MIT.EDU>
+Subject: mit-caf
+To: info-host@MC.LCS.MIT.EDU
+Message-ID: <12179407684.24.MBM@XX.LCS.MIT.EDU>
+
+MIT-CAF's internet address is 18.62.0.232, not 18.21.  Thanks.
+--mike
+-------
+-------
+
+Received: from AI.AI.MIT.EDU by MC.LCS.MIT.EDU via Chaosnet; 28 JAN 86  21:55:59 EST
+Date: Tue, 28 Jan 86 21:55:35 EST
+From: "Pandora B. Berman" <CENT%AI.AI.MIT.EDU@MC.LCS.MIT.EDU>
+Subject:  SYSNET;HSTMIT ?
+To: Mills@CISL-SERVICE-MULTICS.MIT.EDU
+cc: INFO-Hosts@MC.LCS.MIT.EDU
+Message-ID: <[AI.AI.MIT.EDU].12019.860128.CENT>
+
+    Date:  Tue, 28 Jan 86 11:29 EST
+    From:  Mills@CISL-SERVICE-MULTICS.ARPA
+    Subject:  sysnet;hstmit
+    To:  info-hosts@MIT-MC.ARPA
+    I have been using the file sysnet;hstmit off of mc for some time in
+    generating my host table.  It seems as this file is no longer to be
+    found in the same location on mc.  This is not surprizing considering
+    that mc is sort of going away.  Where is this file currently?  Is it
+    going to be updated any longer?  If you don't know about this, do you
+    know anyone who does?
+
+the file has been moved in the SYSHST; directory -- SYSHST;HSTMIT is what
+you should now look for.  SRA@XX is doing most of the work here on
+host-table related things now, so you should direct questions about its
+status to him.
+
+Received: from CISL-SERVICE-MULTICS.ARPA by MC.LCS.MIT.EDU 28 Jan 86 11:30:43 EST
+Date:  Tue, 28 Jan 86 11:29 EST
+From:  Mills@CISL-SERVICE-MULTICS.ARPA
+Subject:  sysnet;hstmit
+To:  info-hosts@MIT-MC.ARPA
+Message-ID:  <860128162939.998026@CISL-SERVICE-MULTICS.ARPA>
+
+Hi there,
+          I have been using the file sysnet;hstmit off of mc for some
+time in generating my host table.  It seems as this file is no longer to
+be found in the same location on mc.  This is not surprizing considering
+that mc is sort of going away.  Where is this file currently?  Is it
+going to be updated any longer?  If you don't know about this, do you
+know anyone who does?
+
+Thanks, John Mills
+
+Date: Thu, 16 Jan 86 18:52:50 EST
+From: Rob Austein <SRA@MC.LCS.MIT.EDU>
+Subject:  MC binary host table
+To: INFO-HOSTS@MC.LCS.MIT.EDU, NAMECALLERS@MC.LCS.MIT.EDU
+Message-ID: <[MC.LCS.MIT.EDU].786028.860116.SRA>
+
+I turned off the code that was generating the names like
+MIT-foo.MIT.EDU and foo.MIT.EDU (for hosts that are in some other
+domain, ie, AI or LCS).  This was necessary because COMSAT was
+completely out of address space and I needed the few K this freed up
+just to keep COMSAT running.
+
+This means that (1) host tables will be a little smaller, and that (2)
+it is possible that you will be unable to reply to hosts that are
+still using these names (nobody should be, but they still linger in
+some dark corners).  If you need a table that has all this cruft, you
+can get the binary from XX:<SYSTEM>HOSTS3.BIN and the text form of
+HSTMIT from XX:<HOSTS>HSTMIT.TXT.
+
+Sorry for the short (one might even say negative) notice, but this was
+an emergency fix.
+
+--Rob
+
+Received: from XX.LCS.MIT.EDU by MC.LCS.MIT.EDU 18 Dec 85 07:16:06 EST
+Date: Wed, 18 Dec 1985  07:14 EST
+Message-ID: <SRA.12168071706.BABYL@XX.LCS.MIT.EDU>
+From: Rob Austein <SRA@XX.LCS.MIT.EDU>
+To:   info-hosts@MC.LCS.MIT.EDU, namecallers@MC.LCS.MIT.EDU
+cc:   sra@XX.LCS.MIT.EDU
+Subject: New host tables installed on MC.
+
+The new tables that have been running on XX on an experimental basis
+have now been installed on MC and AI.  A few things to note:
+
+At CSTACY's request, the tables no longer live in MC: SYSNET; because
+the directory got too crowded.  All the text files have been moved to
+MC: SYSHST;.  The old versions of the host tables are still present in
+SYSNET; on the off chance that we have to back out of this, but they
+will be going away soon.  The binary host table of course is still in
+SYSBIN;.
+
+There is a little bit of documentation in some of the files in SYSHST;
+ask me if you need help, I would much rather have to answer a lot of
+silly questions than have to pick up the pieces if somebody breaks all
+this.
+
+For those who deleted my last warning on this subject, the new host
+table is significantly larger than the old one.  Some programs on your
+machine will probably barf and need to be recompiled.  Sorry.
+
+Problems, flames, etc to me and NAMECALLERS.
+
+--Rob
+
+Date: Tue, 17 Dec 85 16:30:06 EST
+From: Rob Austein <SRA@MIT-MC.ARPA>
+Subject:  WARNING: host tables changing tonight
+To: INFO-HOSTS@MIT-MC.ARPA
+Reply-To: sra@mc
+Message-ID: <[MIT-MC.ARPA].758370.851217.SRA>
+
+I am going to try installing the new domain-style host tables on MC
+(and possibly AI) tonight.  I will send out another message when this
+is done.  In the meantime, anybody who is automaticly snarfing tables
+off of MC should beware, since various weird things may happen.
+
+Received: from MIT-XX.ARPA by MIT-MC.ARPA  2 Dec 85 20:39:00 EST
+Date: Mon 2 Dec 85 14:49:53-EST
+From: "J. Noel Chiappa" <JNC@MIT-XX.ARPA>
+Subject: Re: Impending host table format change
+To: Namecallers@MIT-MC.ARPA, Info-Hosts@MIT-MC.ARPA
+cc: JNC@MIT-XX.ARPA
+In-Reply-To: <SRA.12162783491.BABYL@MIT-XX.ARPA>
+Message-ID: <12163960357.23.JNC@MIT-XX.ARPA>
+
+	One other thing we should try and tackle in an organised
+fashion is allocation of host numbers on wires. Right now, it's
+done by looking through the host tables, which aren't organized in
+any useful fashion for this; in addition, some people chose a number,
+look to see if anyone has that number in protocol family X, and
+don't check to see if anyone is using it in family Y, with the
+result that a single host number winds up on two machines, with
+all the attendant hassle.
+	Shawn keeps files for the LCS Ring and Ether, but they aren't
+publicy known about. It would be good if we had files for all the
+wires which random people hang new things on somewhere. Any ideas?
+
+	Noel
+-------
+
+Received: from MIT-XX.ARPA by MIT-MC.ARPA 28 Nov 85 03:07:47 EST
+Date: Thu, 28 Nov 1985  03:05 EST
+Message-ID: <SRA.12162783491.BABYL@MIT-XX.ARPA>
+From: Rob Austein <SRA@MIT-XX.ARPA>
+To:   Info-Hosts@MIT-MC.ARPA, Namecallers@MIT-MC.ARPA
+Reply-To: Namecallers@MC
+Subject: Impending host table format change
+
+I am in the final stages of debugging the various filters, etc to
+implement the compartmentalization of the MIT host tables.  For those
+who aren't in on this already, HSTMIT is being split up into several
+smaller files that map one to one with Internet domains (AI.MIT.EDU,
+LCS.MIT.EDU, ATHENA.MIT.EDU, etc).  The new host tables are actually
+complete right now, and reside in MC: SYSNET;.  Don't anybody try to
+use them yet though (you would have to work very hard to do so
+anyway).  There is even a little documentation for them as wants it,
+in MC: SYSNET; HSTNEW README.  I'll be testing this for a little while
+on XX before mucking with the MC binaries, but that will happen fairly
+soon (within two weeks) if nothing major goes wrong.
+
+Anyone who uses the MC host tables at all is hereby warned that
+something is almost certain to break on your machine when this change
+goes into effect.  The most probably cause is the sheer size of the
+new table.  The complete HOSTS3 table (HSTNIC + all the things that
+used to be in HSTMIT) will be significantly bigger (how much depends
+on what measure you use; the big change is a lot more nicknames for
+MIT hosts, some fairly long).  A lot of this is temporary; far too
+many existing programs have assumptions about primary hostnames
+hardwired into them, so this part of the changeover has to be done in
+stages.  Obviously there are a lot of tradeoffs here; questions or
+suggestions on this should go to NAMECALLERS@MC rather than all of
+INFO-HOSTS.
+
+For now, anybody who edits MC: SYSNET; HSTMIT > should also edit the
+appropriate subdomain file.  If you aren't sure what to do, just make
+sure to tell me what changes you made and I'll update the appropriate
+file.
+
+I will send another message to INFO-HOSTS when I start the actual
+changeover on MC, but I wanted to make sure that people had some
+advance warning about this.
+
+--Rob
+
+Date: Wed, 13 Nov 85 23:41:20 EST
+From: Rob Austein <SRA@MIT-MC.ARPA>
+Subject:  HSTMIT table fixed (again)
+To: INFO-HOSTS@MIT-MC.ARPA
+Message-ID: <[MIT-MC.ARPA].717323.851113.SRA>
+
+I changed the primary name of MIT-MORRISON to MIT-MORRISON.ARPA.
+
+People, please note that the primary hostname in HSTMIT *must* match
+the primary hostname in HSTNIC (if the machine is in HSTNIC at all, of
+course).  If you break this rule you will also break the HOSTS3
+compiler and thus all six PDP10s.
+
+Also, if anybody edits HSTMIT in the near future, please send me mail
+even if you don't send any to INFO-HOSTS for some reason.  I am going
+to be bringing up a current set of tables for the brave new world of
+domains and if you make changes without telling me they won't show up
+in the new tables.
+
+--Rob
+
+Received: from MIT-EECS by MIT-MC.ARPA via Chaosnet; 30 OCT 85  23:06:53 EST
+Date: Wed 30 Oct 85 23:08:16-EST
+From: Clifford Neuman <BCN%MIT-EECS@MIT-MC.ARPA>
+Subject: Re: HSTMIT 458 and HOSTS 878
+To: INFO-HOSTS@MIT-MC
+cc: staff%MIT-EECS@MIT-MC.ARPA, JIS@ATHENA.MIT.EDU
+In-Reply-To: Message from "Clifford Neuman <BCN%MIT-EECS@MIT-MC.ARPA>" of Wed 30 Oct 85 22:23:14-EST
+
+Correction to previous message.
+
+  . The primary name for MIT-EECS is not MIT-DEEP-THOUGHT.
+
+should be:
+
+  . The primary name for MIT-EECS is now MIT-DEEP-THOUGHT.
+                                       ^
+-------
+
+Received: from MIT-EECS by MIT-MC.ARPA via Chaosnet; 30 OCT 85  21:49:06 EST
+Date: Wed 30 Oct 85 21:50:20-EST
+From: Clifford Neuman <BCN%MIT-EECS@MIT-MC.ARPA>
+Subject: HSTMIT 458 and HOSTS 878
+To: INFO-HOSTS@MIT-MC
+cc: staff%MIT-EECS@MIT-MC.ARPA, JIS@ATHENA.MIT.EDU
+
+Have been updated to reflect the following changes:
+
+  . The primary name for MIT-EECS is not MIT-DEEP-THOUGHT.
+  . The nicknames MIT-DT and DT have been added.
+
+  . ZARQUON, HACTAR, PRAK, and SLARTIBARTFAST have been commented out
+    since they have not been speaking chaos for quite some time and
+    the continued existence in the host table as chaos hosts was 
+    causing mail queued for them to go undelivered.
+
+Chris: You should consider adding service entries to some of the hosts
+       in HSTFIX.  In particular, MIT-SPEAKER, and a few others.  Gail's
+       FTP checks this entry.
+
+	~ Cliff
+-------
+
+Received: from MIT-XX.ARPA by MIT-MC.ARPA 22 Oct 85 16:02:07 EDT
+Date: Tue 22 Oct 85 16:04:03-EDT
+From: William B. Ackerman <WBA@MIT-XX.ARPA>
+Subject: sysnet;hstmit >
+To: info-hosts@MIT-MC.ARPA
+Message-ID: <12153215031.33.WBA@MIT-XX.ARPA>
+
+I made a few minor changes to 2nd floor Explorers in SYSNET;HSTMIT >.
+-------
+
+Date: Mon, 30 Sep 85 10:34:30 EDT
+From: Patrick G. Sobalvarro <PGS@MIT-MC.ARPA>
+To: INFO-HOSTS@MIT-MC.ARPA
+Message-ID: <[MIT-MC.ARPA].663271.850930.PGS>
+
+Does anyone know of an internet path either to inria or mcvax?
+
+Received: from MIT-BORAX by MIT-MC.ARPA 13 Sep 85 11:59:48 EDT
+Received: by MIT-BORAX.MIT.EDU (4.12/4.7)
+	id AA19554; Fri, 13 Sep 85 12:01:06 edt
+Date: Fri, 13 Sep 85 12:01:06 edt
+From: romkey@MIT-BORAX.MIT.EDU (John Romkey)
+Message-Id: <8509131601.AA19554@MIT-BORAX.MIT.EDU>
+To: info-hosts@mc
+Subject: "new" host
+
+I've added a "new" host, MIT-BORAX-CHAOS, address 15101, temporarily
+while I'm bringing up chaosnet on borax. Once I'm sure the chaos code
+is stable I'll punt this name and just add a chaos address for BORAX.
+						- john
+
+Date: Tue, 10 Sep 85 20:46:58 EDT
+From: Thye-Lai Tung <TLTUNG@MIT-MC.ARPA>
+Subject: Change in Net Address
+To: INFO-HOSTS@MIT-MC.ARPA
+Message-ID: <[MIT-MC.ARPA].640485.850910.TLTUNG>
+
+I changed the Chaosnet address of MIT-WAIF from 6420 to 12751.
+
+- Thye-Lai Tung
+
+Received: from MIT-OZ by MIT-MC.ARPA via Chaosnet; 6 SEP 85  03:53:57 EDT
+Date: Fri, 6 Sep 1985  03:55 EDT
+Message-ID: <PGS.12141023798.BABYL@MIT-OZ>
+From: PGS%MIT-OZ@MIT-MC.ARPA
+To:   Rob Austein <SRA@MIT-XX.ARPA>
+cc:   info-hosts@MIT-MC.ARPA
+Subject: Have you seen these machines?
+
+Alcator is a Vax at Alcator; it runs VMS.  The last time I heard of someone
+using it was a couple of years ago.  PFC-VAX is another VMS VAX; it's at the
+Plasma Fusion Center.  PFC-Versatec is presumably a MINITS 11 running DCP's
+Versatec code at Plasma Fusion Center.  Cougar is the wrist controller for
+the Puma robot arm; like Puma, it's an 11 running MINITS.  It's in 905
+(Robotics Group, of course).  Golem is a 750 running VMS; it controls Ken
+Salisbury's tendon hand; it's in the Lisp Machine corral.  Robotics Group
+again.
+
+Received: from MIT-XX.ARPA by MIT-MC.ARPA  5 Sep 85 16:41:57 EDT
+Date: Thu, 5 Sep 1985  16:04 EDT
+Message-ID: <SRA.12140894256.BABYL@MIT-XX>
+From: Rob Austein <SRA@MIT-XX>
+To:   info-hosts@mc
+Subject: have you seen these machines
+
+Thanks to everybody who responded.  I now have all the machines pegged
+except for ARMSTRONG and SARAH, and all that really matters in this
+case is knowing that they don't belong to LCS, AI, Athena, EECS, or
+Speech (of course, if somebody *does* know about these two I'd like to
+hear it...).
+
+--Rob
+
+Received: from MIT-VAX.ARPA by MIT-MC.ARPA via Chaosnet; 3 SEP 85  21:55:05 EDT
+Received: by mit-vax.Mit-chaos.Arpa (4.12/4.8) id AA08083; Tue, 3 Sep 85 21:50:00 edt
+Date: Tue, 3 Sep 85 21:50:00 edt
+From: Jeff Arnold <jma@mit-vax>
+To: SRA@MIT-XX, info-hosts@mc
+Subject: Re:  Have you seen these machines?
+
+PI is Ron Rivest's (original) 3600 and lives on the third floor
+of Tech Sq.  HARRIS-BRIDGE is a minits box dedicated to the
+chaos link with Harris Corp. in Fla.   It lives in the second
+floor machine room and is tended by Rich Zippel and Bert Halstead.
+
+
+Received: from mit-ems.ARPA by MIT-MC.ARPA  3 Sep 85 19:32:32 EDT
+Received: by mit-ems.ARPA (4.12/4.8)  id AA23824; Tue, 3 Sep 85 19:33:03 edt
+Date: Tue, 3 Sep 85 19:33:03 edt
+From: Steven Haflich <smh@mit-ems.ARPA>
+Message-Id: <8509032333.AA23824@mit-ems.ARPA>
+To: info-hosts@mc
+Subject: Re:  Have you seen these machines?
+
+INFINITE is the building 8 chaos bridge, and is named after a certain
+corridor.  It connects subnets 017, 021, and 023(?).  Most recently,
+bcn@ee has maintained it.
+
+WAIF is a VMS 750 belonging to Prof Antoniadis' group on the 3rd floor
+of bldg 10.  Contact tung@{waif,eddie} for details.
+
+Received: from MIT-XX.ARPA by MIT-MC.ARPA  3 Sep 85 19:13:53 EDT
+Date: Tue, 3 Sep 1985  19:13 EDT
+Message-ID: <SRA.12140404499.BABYL@MIT-XX>
+From: Rob Austein <SRA@MIT-XX>
+To:   info-hosts@mc
+Subject: Have you seen these machines?
+
+I've been sorting through the MIT and NIC host tables to figure out
+which labs/departments own which machines.  Here's the last few that
+nobody seems to recognize.  If you know who these machines belong to,
+please send me mail.  Thanks....
+
+ALCATOR		ARMSTRONG	COUGAR		GOLEM
+HARRIS-BRIDGE	INFINITE	MERLIN		PFC-TEST
+PFC-VAX		PFC-VERSATEC	PI		SARAH
+WAIF
+
+Date: Tue, 27 Aug 85 00:03:43 EDT
+From: J. Noel Chiappa <JNC@MIT-MC.ARPA>
+To: INFO-HOSTS@MIT-MC.ARPA
+cc: MIT SUBNETS@MIT-MC.ARPA, JNC@MIT-MC.ARPA, jis@MIT-ATHENA.ARPA
+Message-ID: <[MIT-MC.ARPA].624989.850827.JNC>
+
+	Not having heard any loud complaints, I moved the three unused
+nets (LCS 4th Ether, WHOI nets) out of the area of conflict with
+Athena. The LCS 4th Ether became 061/49. and the WHOI nets became
+0160/0161 respectively. The leaves only the Building 11 Ethernet to
+fix; it's CHAOS address of 0104 conflicts with the Main Campus Spine,
+and it's IP address of 58. conflicts with the 7AI-2LCS link (!).
+	I also edited in some more information that Jeff Schiller
+provided.
+
+Received: from MIT-CCC by MIT-MC.ARPA via Chaosnet; 25 AUG 85  01:47:58 EDT
+Date: 25 Aug 1985 01:47:51-EDT
+From: gill@MIT-CCC
+To: CSTACY@MIT-MC.ARPA, gill@MIT-CCC, jma@MIT-VAX.ARPA,
+    jon@MIT-VAX.ARPA, saj@MIT-PREP.ARPA
+Subject: Re:  host2 tables
+Cc: INFO-HOSTS@MIT-MC.ARPA
+
+Based on the old one in syseng; the host2 table you generated had one small
+error:
+
+	NET CHAOS   7,
+
+should be
+
+	NET CHAOS,  7
+
+Other than that, it went down smoothly. Although my host table parser
+also deals with the so-called host3 format, I would like to switch over 
+to a domain system in the near future. What references are there on how
+one should, and how others have already, implemented domain naming?
+
+	- Gill
+
+Date: Sat, 24 Aug 85 22:43:30 EDT
+From: Christopher C. Stacy <CSTACY@MIT-MC.ARPA>
+Subject:  host2 tables
+To: jma@MIT-VAX.ARPA, jon@MIT-VAX.ARPA, saj@MIT-PREP.ARPA,
+    gill@MIT-CCC
+cc: INFO-HOSTS@MIT-MC.ARPA
+In-reply-to: Msg of Sat 24 Aug 85 21:54:28 EDT from Christopher C. Stacy <CSTACY at MIT-MC.ARPA>
+Message-ID: <[MIT-MC.ARPA].623378.850824.CSTACY>
+
+SYSNET;HSTCHA HOSTS2 contains a sample HOSTS2 file generated by my
+hack from HSTMIT.  It contains only Chaosnet hosts. I am putting this
+here in case you need it and want to pick it up right away before
+learning how to create such files yourself.
+
+Date: Sat, 24 Aug 85 19:40:41 EDT
+From: Christopher C. Stacy <CSTACY@MIT-MC.ARPA>
+Subject:  New Host tables
+To: JNC@MIT-MC.ARPA
+cc: INFO-HOSTS@MIT-MC.ARPA, BUG-MAIL@MIT-MC.ARPA
+Message-ID: <[MIT-MC.ARPA].623329.850824.CSTACY>
+
+As I said, I don't think backing out of the binary was the right thing,
+since only the QMAIL program uses that information, it's usually wrong,
+and all it does is warn you that the site doesn't claim to support mail.
+In fact, the system will send mail to sites which don't claim to support
+the service. Since the information has not been used by anyone, I don't
+think there has been a great effort to keep it correct.  Backing up to
+an older binary means that some valid hosts will be compeltely unknown,
+and mail to hosts which have moved will be permanently lost.  Moreover,
+QMAIL is an ITS-only program (and hence an ITS bug) but the binary table
+is used by some other sites (such as OZ.)
+
+Anyway, I just went in and added the service lists to the dozen or so
+sites which I think support mail but which didn't claim to, and created
+a new binary table.
+
+I stuck the subnet stuff back into the HSTMIT host table source file
+where it has always been; it was an oversight that I forgot to include
+it in that one version.
+
+Date: Fri, 23 Aug 85 11:51:28 EDT
+From: J. Noel Chiappa <JNC@MIT-MC.ARPA>
+Subject: New Host tables
+To: INFO-HOSTS@MIT-MC.ARPA
+cc: JNC@MIT-MC.ARPA
+Message-ID: <[MIT-MC.ARPA].622549.850823.JNC>
+
+	The switch to the new host tables introduced a slight
+problem in that CHAOS only hosts are now using an RFC810 format
+instead of the old HOSTS format; the new format allows services
+to be listed, and the old one did not. So, all CHAOS only hosts
+are now listed without any services! This is causing some programs
+(e.g. :MAIL) to complain. We have temporarily backed out of the
+binary (*not* the source) of the new tables; someone will have
+to go in and edit all the right services onto OZ, PYG, etc.
+
+	Noel
+
+Date: Fri, 23 Aug 85 11:21:31 EDT
+From: J. Noel Chiappa <JNC@MIT-MC.ARPA>
+Subject: Subnet number info
+To: INFO-HOSTS@MIT-MC.ARPA
+cc: JNC@MIT-MC.ARPA
+Message-ID: <[MIT-MC.ARPA].622522.850823.JNC>
+
+	I retrieved the subnet number information which used to
+reside at the end of HSTMIT > and placed it in MITSN > in SYSNET.
+
+Date: Fri, 23 Aug 85 09:48:50 EDT
+From: Christopher C. Stacy <CSTACY@MIT-MC.ARPA>
+To: INFO-HOSTS@MIT-MC.ARPA
+Message-ID: <[MIT-MC.ARPA].622460.850823.CSTACY>
+
+The MIT host table is now consolidated into a single file again.
+HSTMIT contains both Internet and Chaosnet hosts in extended RFC810 format.
+Anyone needing a table in HOSTS2 format can contact me about a Common-lisp
+hack I wrote to produce such things.
+
+(There are still other files required to make a binary host table for
+MIT-MC, and you should still not attempt to do that unless you really
+know what you are doing.)
+
+
+Date: Thu, 22 Aug 85 23:08:53 EDT
+From: J. Noel Chiappa <JNC@MIT-MC.ARPA>
+Subject: Symbolics subnets removed
+To: MIT-IP-PEOPLE@MIT-MC.ARPA, INFO-HOSTS@MIT-MC.ARPA
+cc: JNC@MIT-MC.ARPA
+Message-ID: <[MIT-MC.ARPA].622091.850822.JNC>
+
+	As I mentioned doing a while back, the Symbolics subnets have
+been removed from the HSTMIT file. Also, a subnet was allocated to
+the MIT<->YoyoDyne serial link.
+	Finally, would anyone object if I renumbered the 'LCS 4th
+floor Ethernet' (which doesn't seem to have any hosts on it) away from
+its current number (59.), since the range of subnet numbers from 58.
+to 67. is occupied in the IP address space by some Athena networks
+placed there by a beano in octal->decimal conversion (don't ask).
+
+	Noel
+
+Received: from MIT-ZERMATT.ARPA by MIT-MC.ARPA via Chaosnet; 5 AUG 85  22:57:30 EDT
+Date: Mon, 5 Aug 85 22:56 EDT
+From: Richard E. Zippel <RZ@MIT-ZERMATT.ARPA>
+Subject: MIT-VAX
+To: info-hosts@MIT-MC.ARPA
+Message-ID: <850805225603.2.RZ@ZERMATT>
+
+This entry has been moved to HSTMIB now that it speaks both Chaos and
+TCP/IP
+
+HOST : 18.26.0.95, CHAOS 4120 : MIT-VAX.ARPA,MIT-VAX,MIT-VX,VX : VAX-11/750 : UNIX : TCP/TELNET,TCP/FTP,TCP/SMTP,TCP/FINGER,TCP/SUPDUP,CHAOS/NAME,CHAOS/TIME,CHAOS/TELNET,CHAOS/SUPDUP,CHAOS/MAIL,CHAOS/CFTP :
+
+Received: from MIT-ZERMATT.ARPA by MIT-MC.ARPA via Chaosnet; 2 AUG 85  17:10:22 EDT
+Date: Fri, 2 Aug 85 17:09 EDT
+From: Richard E. Zippel <RZ@MIT-ZERMATT.ARPA>
+Subject: New Lisp machines
+To: info-hosts@MIT-MC.ARPA
+Message-ID: <850802170919.8.RZ@ZERMATT>
+
+
+The following entries were added both to SYSNET;HOSTS and HSTMIT
+
+HOST MIT-CHAMROUSSE,	CHAOS 15326,USER,LISPM,SYMBOLICS-3600,[CHAMROUSSE]
+HOST MIT-FLUTE,		CHAOS 15330,USER,LISPM,SYMBOLICS-3600,[FLUTE]
+HOST MIT-RTS-0,		CHAOS 15331,USER,LISPM,EXPLORER,[MIT-RTS]
+HOST MIT-RTS-1,		CHAOS 15332,USER,LISPM,EXPLORER,[WARD,RTS-1]
+HOST MIT-RTS-2,		CHAOS 15333,USER,LISPM,EXPLORER,[CJT,RTS-2]
+HOST MIT-RTS-3,		CHAOS 15334,USER,LISPM,EXPLORER,[JMA,RTS-3]
+HOST MIT-SARAJEVO,	CHAOS 15325,USER,LISPM,SYMBOLICS-3600,[SARAJEVO]
+HOST MIT-VIOLIN,	CHAOS 15327,USER,LISPM,SYMBOLICS-3600,[VIOLIN]
+
+Some other small changes were made to the NU entries.  In particular,
+TERMAN, WARD and JMA nicknames were moved to TERMAN-NU, WARD-NU and
+JMA-NU.  RZ nickname was deleted.
+
+Received: from SCRC-QUABBIN.ARPA by MIT-MC.ARPA 23 Jul 85 08:18:20 EDT
+Received: from NEPONSET.SCRC.Symbolics.COM by SCRC-QUABBIN.ARPA via CHAOS with CHAOS-MAIL id 185013; Tue 23-Jul-85 07:07:28-EDT
+Date: Tue, 23 Jul 85 07:09 EDT
+From: David C. Plummer in disguise <DCP@SCRC-QUABBIN.ARPA>
+Subject: Symbolics subnets
+To: J. Noel Chiappa <JNC@MIT-MC.ARPA>, MIT-IP-PEOPLE@MIT-MC.ARPA
+cc: Info-hosts@MIT-MC.ARPA
+In-Reply-To: <[MIT-MC.ARPA].585023.850722.JNC>
+Message-ID: <850723070907.2.NFEP@NEPONSET.SCRC.Symbolics.COM>
+
+    Date: Mon, 22 Jul 85 23:49:13 EDT
+    From: J. Noel Chiappa <JNC@MIT-MC.ARPA>
+
+[Info-hosts added.]
+
+	    Unless I hear some complaints from the Symbolics people on
+    this list, since the CHAOS link to Symbolics is completely gone (and
+    the address spaces no longer even partially congruent) I'd like to
+    think about recycling the Symbolics subnets from the MIT subnet
+    table. How about it, guys, is this OK?
+
+I believe all the namespaces involved have not communicated chaos
+information for months.  I know of no technical reasons not to reuse
+subnets.
+
+
+Date: Mon, 22 Jul 85 22:37:34 EDT
+From: J. Noel Chiappa <JNC@MIT-MC.ARPA>
+Subject: Allocated MIT subnet
+To: INFO-HOSTS@MIT-MC.ARPA
+cc: JNC@MIT-MC.ARPA
+Message-ID: <[MIT-MC.ARPA].584942.850722.JNC>
+
+	The IP only subnet 124. is the Ethernet a Proteon.
+
+Date: Fri, 19 Jul 85 12:01:27 EDT
+From: Richard Mlynarik <MLY@MIT-MC.ARPA>
+Subject: removed mit-pigpen from sysnet;hstmic and sysnet;hstmit
+To: INFO-HOSTS@MIT-MC.ARPA
+Message-ID: <[MIT-MC.ARPA].581655.850719.MLY>
+
+This machine (really at Symbolix, Inc) no longer exists.
+
+Received: from MIT-XX.ARPA by MIT-MC.ARPA 17 Jul 85 13:17:49 EDT
+Date: Wed 17 Jul 85 13:13:57-EDT
+From: Michael B McIlrath <MBM@MIT-XX.ARPA>
+Subject: new host table entries
+To: info-hosts@MIT-MC.ARPA
+
+In HSTMIC, MIT-CAF-SWITCH-{0-3}, CHAOS 01270{0-3}
+
+In HSTMIB, MIT-CAF.ARPA, CHAOS 12750, IP 18.21.0.232
+
+I just edited the files.  I did not compile the tables; I dont know how.
+--mike
+-------
+
+Date: Tue, 25 Jun 85 19:12:56 EDT
+From: Christopher C. Stacy <CSTACY@MIT-MC.ARPA>
+Subject: **** New Files ***
+To: INFO-HOSTS@MIT-MC.ARPA
+Message-ID: <[MIT-MC.ARPA].555778.850625.CSTACY>
+
+The host tables have been slightly rearranged as follows.
+
+SYSNET;HSTNIC - The official Internet host table from the NIC.
+		This is retrieved automatically from SRI-NIC each
+		evening. No one ever edits this file.
+		Hackers note: this file contains domain-style names
+		such as "MIT-MC.ARPA" and "PURDUE.EDU", which is
+		what everyone is (supposed to be) using now.
+		--- This is in RFC810 format (of course.)
+
+SYSNET;HSTMIC - Hosts which are ONLY on the Chaosnet and no other
+		networks. This file does NOT include Chaosnet hosts
+		which are also on the Internet.
+		--- HSTMIC is currently in HOSTS2 format, although it will
+		    probably be converted to modified RFC810* soon.
+
+SYSNET;HSTMIB - Hosts which are on both the Internet and the Chaosnet.
+		The hosts in here are basically copies of certain HSTNIC
+		entries, but with Chaosnet addresses added.
+		Note that sites which are Chaosnet-only need HSTMIB also!
+		--- HSTMIB is in modified RFC810* format.
+
+SYSNET;HSTMII - Hosts which are only on the Internet but which the NIC
+		does not know about.  Since there probably shouldn't be
+		any such hosts, this file may disappear in the future.
+		The dozen hosts currently listed in here are being contacted
+		to see what they think is going on with their host names.
+		--- HSTMII is in HOSTS2 format.
+
+* (Modified RFC810 format means that the address field may contain
+   keyword network specs.  Example: "HOST : CHAOS 1440 : MIT-MC ...".
+   The HOSTS3 compiler understands this format.)
+
+The file SYSNET;HSTMIT is now obsolete and outdated.  Host additions
+and changes should be made in the HSTMIC and HSTMIB files instead.
+The new files are up to date (from HSTMIT 405 written this evening).
+
+When you edit one of the files, be sure to send a note to everybody at
+INFO-HOSTS describing your change.  Do not try to compile the files
+for MC; this will be done periodically by an ITS hacker.
+
+Cheers,
+Chris
+
+
+PS. New host tables compiled and installed on MC.
+
+Received: from MIT-SPEECH by MIT-MC.ARPA via Chaosnet; 25 JUN 85  17:42:36 EDT
+Date: Tue 25 Jun 85 17:43:31-EDT
+From: John Wroclawski <JTW%MIT-SPEECH@MIT-MC.ARPA>
+To: info-hosts@MIT-MC
+
+Added MIT-GAUGUIN @ chaos 15414. Whoever put MIT-GEEK after MIT-GOOFY,
+please remember there are some programs around that care about
+slphabetization.
+-------
+
+Received: from MIT-BITSY.MIT.EDU by MIT-MC.ARPA 18 Jun 85 18:19:25 EST
+Received: by MIT-BITSY.MIT.EDU (4.12/4.7)
+	id AA20323; Tue, 18 Jun 85 18:17:26 edt
+Date: Tue, 18 Jun 85 18:17:26 edt
+From: jis@MIT-BITSY.MIT.EDU (Jeffrey I. Schiller)
+Message-Id: <8506182217.AA20323@MIT-BITSY.MIT.EDU>
+To: CSTACY@MIT-MC.ARPA
+Cc: INFO-HOSTS@MIT-MC.ARPA
+In-Reply-To: Christopher C. Stacy's message of Mon, 17 Jun 85 16:14:17 EDT
+
+Yes this is really true. They are located in building E15 which has
+Internet service but no chaosnet service.
+
+			-Jeff
+
+Received: from MIT-BITSY.MIT.EDU by MIT-MC.ARPA 18 Jun 85 18:19:25 EST
+Received: by MIT-BITSY.MIT.EDU (4.12/4.7)
+	id AA20323; Tue, 18 Jun 85 18:17:26 edt
+Date: Tue, 18 Jun 85 18:17:26 edt
+From: jis@MIT-BITSY.MIT.EDU (Jeffrey I. Schiller)
+Message-Id: <8506182217.AA20323@MIT-BITSY.MIT.EDU>
+To: CSTACY@MIT-MC.ARPA
+Cc: INFO-HOSTS@MIT-MC.ARPA
+In-Reply-To: Christopher C. Stacy's message of Mon, 17 Jun 85 16:14:17 EDT
+
+Yes this is really true. They are located in building E15 which has
+Internet service but no chaosnet service.
+
+			-Jeff
+
+Received: from mit-ems.ARPA by MIT-MC.ARPA 17 Jun 85 22:49:17 EST
+Received: by mit-ems.ARPA (4.12/4.8)  id AA00540; Mon, 17 Jun 85 22:48:00 edt
+Date: Mon, 17 Jun 85 22:48:00 edt
+From: Steven Haflich <smh@mit-ems.ARPA>
+Message-Id: <8506180248.AA00540@mit-ems.ARPA>
+To: CSTACY@MIT-MC.ARPA, INFO-HOSTS@MIT-MC.ARPA
+Subject: ZAXXON and XEVIOUS
+
+These machines are 3600's in E15, the new Media Lab.  The building
+connects to the campus spine, thus is Internet.  There are a couple
+Chaos hosts in the building which can (and occasionally do)
+communicate, but there is no Chaos connection to the outside world.
+
+It may be in the future that the MINITS bridge ARCMAC-HUB will get
+reconstituted in order to connect the ARCMAC Magic-6 hosts to
+the real world again.  If so, it might be necessary to boot it from
+MIT-EMS, which is also in the building, and if so, MIT-EMS might
+then assume MIT-MC's chaos address -- it's easier than cutting a
+new rom for ARCMAC-HUB.  For this and other reasons, we chose not
+to publicise chaos hackery within E15.  No one outside should ever
+see any of it.
+
+Date: Mon, 17 Jun 85 17:16:58 EDT
+From: Christopher C. Stacy <CSTACY@MIT-MC.ARPA>
+Subject:  Mailer lossage was due to vandalized host table
+To: BUG-COMSAT@MIT-MC.ARPA, MEYER@MIT-MC.ARPA, PSZ@MIT-MC.ARPA,
+    RAY@MIT-MC.ARPA, GSB@MIT-MC.ARPA, SRA@MIT-XX.ARPA,
+    smh@MIT-EMS, bandy@LLL-CRG.ARPA, kmp@SCRC-STONY-BROOK.ARPA,
+    Postmaster@SCRC-STONY-BROOK.ARPA
+cc: INFO-HOSTS@MIT-MC.ARPA
+Message-ID: <[MIT-MC.ARPA].547207.850617.CSTACY>
+
+
+Disregarding my previous warnings that MC uses a special host table,
+someone on 6/16 installed a bogus host table which broke the mail
+system.  (I believe the exact breakage was that the host table forgot
+all about any hosts which are on both the Internet and the Chaosnet,
+including MIT-MC.)  I have de-installed the broken table, and mail is
+flowing again.  I resubmitted about 40 incorrectly failed messages
+which the mail system had retained copies of, but an indetermintent
+number of messags were mis-delivered or completely lost. I have
+removed the command file used to create new host tables.
+
+     PLEASE DO NOT ATTEMPT TO INSTALL ANY HOST TABLES ON MIT-MC.
+
+Chris
+
+Date: Mon, 17 Jun 85 16:14:17 EDT
+From: Christopher C. Stacy <CSTACY@MIT-MC.ARPA>
+To: INFO-HOSTS@MIT-MC.ARPA
+Message-ID: <[MIT-MC.ARPA].547045.850617.CSTACY>
+
+I wonder why ZAXXON and XEVIOUS have Internet addresses but no Chaosnet
+addresses?  Is this really true?
+
+Received: from mit-borax.ARPA by MIT-MC.ARPA 17 Jun 85 11:29:59 EST
+Received: by mit-borax.ARPA (4.12/4.7)
+	id AA12548; Mon, 17 Jun 85 11:29:49 edt
+From: romkey@mit-borax (John L. Romkey)
+Message-Id: <8506171529.AA12548@mit-borax.ARPA>
+Date: Jun 17, 1985 10:38am
+Subject: new hosts
+To: info-hosts@mc
+
+I added the following hosts to HSTMIT >: MIT-LECTROID (YOYODYNE-GW,
+MIT-EIGHTH-DIMENSION), MIT-LORD-JOHN-WHORFIN (LORD-JOHN-WHORFIN,
+JOHN-WHORFIN), MIT-JOHN-BIGBOOTE (JOHN-BIGBOOTE, BIGBOOTE), MIT-JOHN-YAYA
+(JOHN-YAYA, YAYA) and MIT-JOHN-SMALLBERRIES (JOHN-SMALLBERRIES, SMALLBERRIES).
+These machines are all on the yoyodyne subnet, of course.
+							- John Romkey
+"Laugha while you can, monkey boy." - Lord John Whorfin
+
+
+Received: from MIT-VAX by MIT-MC via Chaosnet; 6 JUN 85  15:45:07 EDT
+Received: by mit-vax.Mit-chaos.Arpa (4.12/4.8) id AA02628; Thu, 6 Jun 85 15:43:01 edt
+Date: Thu, 6 Jun 85 15:43:01 edt
+From: Jeff Arnold <jma@mit-vax>
+To: info-hosts@mc
+
+Added CONCERT-0 through CONCERT-7, changed the address of CONCERT-TEST
+
+Received: from MIT-ZERMATT by MIT-MC via Chaosnet; 4 JUN 85  12:02:19 EDT
+Date: Tue, 4 Jun 85 12:00 EDT
+From: Richard E. Zippel <RZ@MIT-ZERMATT.ARPA>
+To: info-hosts@MIT-MC.ARPA
+Message-ID: <850604120026.9.RZ@ZERMATT>
+
+I renamed MIT-OVAL to MIT-CORNCOB, but did not recompile the
+host tables.  MIT-CORNCOB is now in the Lispm namespace
+and OVAL has been deleted.
+
+Date: Tue, 28 May 85 10:39:54 EST
+From: Christopher C. Stacy <CSTACY@MIT-MC.ARPA>
+Subject: note that MC is running with a funny HOSTS3 table
+To: INFO-HOSTS@MIT-MC.ARPA
+Message-ID: <[MIT-MC.ARPA].521491.850528.CSTACY>
+
+MIT-MC is running an experimental version of our mail system and
+certain other programs.  This stuff uses a host table containing
+domain-style names and is not generated from the usual files.  
+
+This means if you make any changes, compile and install them, they
+will not take effect on MC.  Assuming everything works, at the end of
+the week the experimental stuff on MC will become the normal stuff.
+The procedure for hacking the host tables will be a little different
+at that time.
+
+(Also, I am working on getting a domain name resolver/server going on
+MC, and when that's up things will change yet again. Stay tuned!)
+
+Date: Mon, 27 May 85 20:43:42 EST
+From: J. Noel Chiappa <JNC@MIT-MC>
+Subject: New HOST, tables not recompiled
+To: INFO-HOSTS@MIT-MC
+cc: JNC@MIT-MC
+Message-ID: <[MIT-MC].521097.850527.JNC>
+
+	Added MIT-AI-GW, 26/10, the MIT-AI ARPANet gateway.
+
+Date: Tue, 21 May 85 11:21:17 EST
+From: S. Robert Austein <SRA@MIT-MC>
+To: INFO-HOSTS@MIT-MC
+Message-ID: <[MIT-MC].512587.850521.SRA>
+
+Added MIT-OVAL (Imagen 12/300 printer) so that I don't have to type
+the address in octal every time the unix spooler flakes out.
+
+Received: from mit-borax.ARPA by MIT-MC.ARPA; 15 May 85 20:57:34 EST
+Received: by mit-borax.ARPA (4.12/4.7)
+	id AA06477; Wed, 15 May 85 20:57:55 edt
+Date: Wed, 15 May 85 20:57:55 edt
+From: romkey@mit-borax (John L. Romkey)
+Message-Id: <8505160057.AA06477@mit-borax.ARPA>
+To: info-hosts@mc
+Subject: new host
+
+I added MIT-DB (MIT-DBS, DBS) to the tables.
+							- John
+
+Received: from MIT-ZERMATT by MIT-MC via Chaosnet; 13 MAY 85  10:25:23 EDT
+Date: Mon, 13 May 85 10:23 EDT
+From: Richard E. Zippel <RZ@MIT-ZERMATT.ARPA>
+Subject: Telluride
+To: info-hosts@MIT-MC.ARPA
+cc: darth@OZ.MIT
+Message-ID: <850513102328.8.RZ@ZERMATT.MIT>
+
+Has been moved to Chaos 15322, so its internet address wouldn't conflict
+with Blue-Jeans (had been 15030).
+
+Date: Sat, 11 May 85 08:46:35 EST
+From: Gail Zacharias <GZ@MIT-MC>
+Sender: ___013@MIT-MC
+To: INFO-HOSTS@MIT-MC
+Message-ID: <[MIT-MC].497408.850511.___013>
+
+I commented out mit-devmultics from hstmit, because it conflicts seriously (per
+hosts3 compiler) with info in the nic table.
+
+Received: from MIT-SPEECH by MIT-MC via Chaosnet; 10 MAY 85  23:59:31 EDT
+Date: Sat 11 May 85 00:00:49-EDT
+From: John Wroclawski <JTW%MIT-SPEECH@MIT-MC.ARPA>
+To: info-hosts@MIT-MC
+
+Added MIT-MONET, a lispm, at chaos 16230. Changed CADR26, etc., from
+nicknames for MIT-POLAR to nicknames for monet, which is the real
+cadr-26, polar being a symbolix LM2.
+-------
+
+Date: Thu,  2 May 85 19:20:02 EDT
+From: J. Noel Chiappa <JNC@MIT-MC>
+Subject: New HSTMIT
+To: INFO-HOSTS@MIT-MC
+cc: JNC@MIT-MC
+Message-ID: <[MIT-MC].482449.850502.JNC>
+
+	Someone had typed in all the Student Center machines' subnet
+number in decimal when of course it needs to be in octal.
+
+Date: Tue, 30 Apr 85 23:52:28 EDT
+From: Jeffrey I. Schiller <JIS@MIT-MC>
+To: INFO-HOSTS@MIT-MC
+Message-ID: <[MIT-MC].478647.850430.JIS>
+
+Added the AMT Ethernet and its hosts (subnet 125 octal 85 decimal).
+
+			-Jeff
+
+Received: from MIT-APIARY-7 by MIT-MC via Chaosnet; 29 APR 85  14:01:08 EDT
+Date: Mon, 29 Apr 85 14:00 EDT
+From: Christopher C. Stacy <CStacy@MIT-MC.ARPA>
+Subject: Wait, it gets better.
+To: Alan Bawden <ALAN@MIT-MC.ARPA>
+cc: BUG-MAIL@MIT-MC.ARPA, INFO-HOSTS@MIT-MC.ARPA
+In-Reply-To: <[MIT-MC].473710.850429.ALAN>
+Message-ID: <850429140021.2.CSTACY@APIARY-7>
+
+    Date: Mon, 29 Apr 85 01:26:25 EDT
+    From: Alan Bawden <ALAN@MIT-MC>
+
+    I hope MIT-POSEIDON is ready to handle all the mail addressed to people who
+    use the Foonly (POS) at Symbolics...
+
+This is because on 4/26/85 someone munged the HOSTS MASTER file and
+then compiled a new host table.
+
+Received: from STONY-BROOK.SCRC.Symbolics.COM by MIT-MC.ARPA; 24 APR 85 16:44:33 EST
+Received: from PEACE.SCRC.Symbolics.COM by STONY-BROOK.SCRC.Symbolics.COM via CHAOS with CHAOS-MAIL id 222818; Wed 24-Apr-85 11:20:01-EST
+Date: Wed, 24 Apr 85 11:19 EST
+From: Charles Hornig <Hornig@STONY-BROOK.SCRC.Symbolics.COM>
+Subject: Symbolics host tables
+To: info-hosts@MIT-MC.ARPA, comp-fac@STONY-BROOK.SCRC.Symbolics.COM
+Message-ID: <850424111949.7.HORNIG@PEACE.SCRC.Symbolics.COM>
+
+The files HSTSYM and HSTSYI which contain information about Symbolics
+hosts should be deleted and references to them removed.  Access to
+Symbolics hosts from now on should be through the Internet.
+
+
+Date: Fri,12 Apr 85 01:44:37 EST
+From: Christopher C. Stacy <CSTACY@MIT-MC>
+Sender: CSTAC0@MIT-MC
+Subject:  REAGAN
+To: MLY@MIT-MC
+cc: INFO-HOSTS@MIT-MC
+In-reply-to: Msg of Fri12 Apr 85 01:36:37 EST from Richard Mlynarik <MLY>
+Message-ID: <[MIT-MC].452451.850412.CSTAC0>
+
+    Date: Fri,12 Apr 85 01:36:37 EST
+    From: Richard Mlynarik <MLY>
+    Sender: MLY0
+    To:   BUG-HOSTS
+    Message-ID: <[MIT-MC].452440.850412.MLY0>
+
+    reagan, amonst many other machines, is not believed to have a chaos
+    address by mc.
+
+REAGAN was put into the NIC's host table in a manner which collided
+with and supusersede its entry in the chaosnet hosts table.
+I "fixed" this. It will be really fixed in the domain system.
+
+Received: from MIT-VAX by MIT-MC via Chaosnet; 11 APR 85  17:00:48 EST
+Received: by mit-vax.Mit-chaos.Arpa (4.12/4.8) id AA19807; Thu, 11 Apr 85 17:00:02 est
+Date: Thu, 11 Apr 85 17:00:02 est
+From: Jeff Arnold <jma@mit-vax>
+To: info-hosts@mc
+Subject: mit-concert-test added
+
+I've added MIT-CONCERT-TEST (015375) to sysnet;hosts > and hstmit >
+
+Date: Mon, 8 Apr 85 15:50:42 EST
+From: S. Robert Austein <SRA@MIT-MC>
+To: INFO-HOSTS@MIT-MC
+Message-ID: <[MIT-MC].447170.850408155233.SRA>
+
+Got rid of extraneous space in HSTMIT that broke compilation (grrr).
+
+Date: Mon, 8 Apr 85 01:58:55 EST
+From: Christopher C. Stacy <CSTACY@MIT-MC>
+To: INFO-HOSTS@MIT-MC
+cc: GILDEA@MIT-MC
+Message-ID: <[MIT-MC].446299.850408020021.CSTACY>
+
+I gobbled subnet 54 (44.) for the ERL people in building E-34,
+whose ethernet will probably be connected to the rest of the
+world someday.
+
+Date: Sun, 7 Apr 85 16:48:51 EST
+From: Ramin D. Zabih <RDZ@MIT-MC>
+To: INFO-HOSTS@MIT-MC
+cc: staff@MIT-CHARON
+Message-ID: <[MIT-MC].445849.850407164937.RDZ>
+
+
+I have removed MIT-CHARON's chaosnet address until such time as the
+chaos net to building 11 gets fixed.
+
+Date: Sat, 6 Apr 85 22:47:49 EST
+From: Jeffrey I. Schiller <JIS@MIT-MC>
+Subject: SYSNET;HSTMIT 368
+To: INFO-HOSTS@MIT-MC
+Message-ID: <[MIT-MC].445261.850406225213.JIS>
+
+Removed MIT-ATHENA's chaosnet address as that portion of the
+ChaosNet is currently broken. This will force mail to go via the Internet.
+
+		-Jeff
+
+Date: Sat, 6 Apr 85 22:46:16 EST
+From: Jeffrey I. Schiller <JIS@MIT-MC>
+To: INFO-HOSTS@MIT-MC
+Message-ID: <[MIT-MC].445257.850406224628.JIS>
+
+
+
+Date: 27 March 1985 00:05-EST
+From: Richard E. Zippel <RZ @ MIT-MC>
+To: INFO-HOSTS @ MIT-MC
+
+I added two new 3600's Breckenridge and Starling, deleted Tahoe.
+Please check to see if MIT-FRANK-SINATRA is in the right place.
+I thought the names were supposed to be alphabetical,and MIT-F-S is
+in the MIT-S's.
+
+Date: 17 March 1985 00:07-EST
+From: Richard E. Zippel <RZ @ MIT-MC>
+To: INFO-HOSTS @ MIT-MC
+
+I added two harris hosts to the table, Harris-1 (a lisp machine)
+and Harris-Trantor a vax.
+
+Received: from MIT-SMOKEY by MIT-MC via Chaosnet; 15 MAR 85  23:00:08 EST
+Date: Fri, 15 Mar 85 22:59 EST
+From: Scott Cyphers <sr.ehpyc%MIT-SPEECH@MIT-MC.ARPA>
+Subject: Booboo
+To: info-hosts@MIT-MC.ARPA
+Message-ID: <850315225931.5.CYPHER@MIT-SMOKEY.MIT>
+
+I changed its address and ran XFILE.
+
+Date: 15 March 1985 16:55-EST
+From: S. Robert Austein <SRA @ MIT-MC>
+To: INFO-HOSTS @ MIT-MC
+
+Added HQ as alias for MIT-LCS-HQ (on request of MBJ).
+
+Received: from mit-borax.ARPA by MIT-MC.ARPA;  7 MAR 85 22:47:12 EST
+Received: by mit-borax.ARPA (4.12/4.7)
+	id AA06259; Thu, 7 Mar 85 22:48:00 est
+Date: Thu, 7 Mar 85 22:48:00 est
+From: romkey@mit-borax (John L. Romkey)
+Message-Id: <8503080348.AA06259@mit-borax.ARPA>
+To: info-hosts@mc
+Subject: new hosts
+
+I added MIT-GEEK, MIT-NERD and MIT-WIMP, a trio of Sun workstations at
+LCS 32/221 through LCS 32/223. I also added MIT-SAURON at LCS 12/304.
+						- John
+
+Received: from MIT-SMOKEY by MIT-MC via Chaosnet; 03/06/85 21:35:12
+Date: Wed, 6 Mar 85 21:33 EST
+From: Scott Cyphers <sr.ehpyc%MIT-SPEECH@MIT-MC.ARPA>
+To: info-hosts@MIT-MC.ARPA
+Message-ID: <850306213354.1.CYPHER@MIT-SMOKEY.MIT>
+
+I added MIT-RENOIR and MIT-KOALA to HOSTS and HSTMIT, took away KOALA as
+a nickname for LM12, and changed addresses for Yogi and Panda, and ran
+XFILE.  I also fixed the comment to say to do :XFILE SYSNET;HOSTS XFILE
+instead of SYSENG;.
+
+Date: 5 March 1985 17:42-EST
+From: S. Robert Austein <SRA @ MIT-MC>
+To: INFO-HOSTS @ MIT-MC
+
+Removed LCS entry for MIT-VAX, since it is now Chaos-only.
+
+Date: 4 March 1985 18:05-EST
+From: Christopher C. Stacy <CSTACY @ MIT-MC>
+To: INFO-HOSTS @ MIT-MC
+
+Is everyone on this list really interested in tracking the changes
+in MIT's own private host tables?  There is no problem if you are,
+but I just noticed that the list is quite large and contains mostly
+people on hosts which don't use our tables.
+
+Received:  from  by MIT-MC;4 March 1985 17:48-EST
+Date: Mon 4 Mar 85 11:15:59-EST
+From: Rob Austein <SRA@MIT-XX.ARPA>
+Subject: Current HOSTS2 format files
+To: info-hosts@MIT-MC.ARPA
+Office: [NE43-502] 545 Technology Square, Cambridge MA 02139; (617) 253-7341
+
+For those machines that still need HOSTS2 format files, you can get up
+to date versions from SYSTEM:HOSTS2.TXT and SYSTEM:HOSTS2.BIN (source
+and binary, respectively) by FTPing to XX and logging in as ANONYMOUS
+with any password.  These files get generated automaticly by a batch
+job from our HOSTS3 table.  Any host that doesn't fit into the HOSTS2
+format is omitted, but otherwise this contains all the hosts and nets
+in HSTMIT, HSTSYM, HSTSYI, and HSTNIC.
+
+Right now these are in the old format, with no ".ARPA" on the ends of
+Internet hostnames.  When the MC source files change format, so will
+these.
+				--Rob
+-------
+
+Date: 20 February 1985 02:34-EST
+From: Christopher C. Stacy <CSTACY @ MIT-MC>
+Subject:  NIC Host Tables
+To: INFO-HOSTS @ MIT-MC
+
+Since I no longer need to hand-edit our version of the NIC host
+table (the HSTNIC file) to get local fixes, I have written and
+installed a system demon which will run on MC each day to keep our
+copy up to date automagically.
+
+So, if you compile the host tables here, be aware that the NIC table
+will be updated without human intervention and inspection.  If the NIC
+table is broken or something (bad versions have been known to be
+released in the past) you may encounter errors.  You should report
+these things to me, and I'll fix them (of course if if you are plenty
+damn sure you know what's going on you can fix it yourself.)
+
+Cheers,
+Chris
+
+Received: from MIT-GSTAAD by MIT-OZ via Chaosnet; 19 Feb 85 14:13-EST
+Date: Tue, 19 Feb 85 14:06 EST
+From: "Richard E. Zippel" <RZ@MIT-MC.ARPA>
+Subject: Concert
+To: INFO-HOSTS@MIT-MC.ARPA
+Message-ID: <850219140629.1.RZ@GSTAAD.MIT>
+
+I've added the address of Concert, Halstead's multiprocessor system, to
+the host tables:
+HOST MIT-CONCERT,	CHAOS 15376,SERVER,CONCERT,CONCERT,[CONCERT]
+
+Date: 13 February 1985 13:19-EST
+From: Richard Mark Soley <SOLEY @ MIT-MC>
+Subject: SYSNET;HOSTS XFILE
+To: CSTACY @ MIT-MC
+cc: INFO-HOSTS @ MIT-MC
+
+Chris - the host table installation xfile failed attempting to parse CSTACY;NEWHST 3
+at lines 59, 61, and 63.  If you could fix whatever you're doing & install the
+new tables, I'd appreciate it.
+
+Changed MIT-NEWTOWNE-VARIETY to be internet-only host (removed chaos addresses).
+
+	-- Richard
+
+Date: 7 February 1985 16:46-EST
+From: Christopher C. Stacy <CSTACY @ MIT-MC>
+To: INFO-HOSTS @ MIT-MC
+cc: BCN @ MIT-MC, GILDEA @ MIT-MC
+
+New host tables generated, including latest NIC table.
+
+There is now a kludge for getting around host nickname
+collisions.  The only host which I have fixed this way
+is MIT-EDDIE, which will now get the nickname EDDIE instead
+of giving it to UW-EDDIE.  If you have a host with this problem,
+let me know and I'll fix it for you.
+
+Chris
+
+Date: 4 February 1985 08:53-EST
+From: Christopher C. Stacy <CSTACY @ MIT-MC>
+Subject:  new host tables
+To: BCN @ MIT-EECS
+cc: RZ @ MIT-MC, CSTACY @ MIT-MC, INFO-HOSTS @ MIT-MC
+In-reply-to: Msg of Mon 4 Feb 85 08:46:05-EST from Clifford Neuman <BCN%MIT-EECS at MIT-MC.ARPA>
+
+You should switch over to the HSTMIT file; the HOSTS file is
+hopelessly out of date and has been for about two years.
+(There isn't any SU-TAHOE in the HSTNIC or HSTMIT files.)
+
+Chris
+
+Date: Mon 4 Feb 85 08:46:05-EST
+From: Clifford Neuman <BCN%MIT-EECS@MIT-MC.ARPA>
+Subject: Re: new host tables
+To: CSTACY@MIT-MC
+cc: INFO-HOSTS@MIT-MC, RZ@MIT-MC
+In-Reply-To: Message from "Christopher C. Stacy <CSTACY @ MIT-MC>" of Mon 4 Feb 85 07:52:43-EST
+
+It seems that in the new host table (HOSTS 834), the name TAHOE was a
+nickname for both MIT-TAHOE, and SU-TAHOE.  This was causing problems
+compiling the table on EE.  I removed the nicname TAHOE from SU-TAHOE
+in HOSTS 835.  SU-TAHOE is the name of Stanford's dover.
+
+	~ Cliff
+ 
+-------
+
+Date: 4 February 1985 07:43-EST
+From: Christopher C. Stacy <CSTACY @ MIT-MC>
+Subject: new host tables
+To: INFO-HOSTS @ MIT-MC
+cc: RZ @ MIT-MC
+
+New host tables generated on MC.
+Someone added a LispM named GARY-COOPER at the same Chaosnet address
+as NU-29, so I commented out NU-29.  Someone should go and resolve
+this if they want NU-27 back on the network.
+
+
+Received: from MIT-GSTAAD by MIT-OZ via Chaosnet; 15 Jan 85 23:57-EST
+Date: Tue, 15 Jan 85 23:55 EST
+From: "Richard E. Zippel" <RZ@MIT-MC.ARPA>
+Subject: Gary Cooper
+To: info-hosts@MIT-MC.ARPA
+cc: Soley@MIT-MC.ARPA, ward@MIT-VAX.ARPA
+Message-ID: <850115235553.5.RZ@GSTAAD.MIT>
+
+I deleted NU-29 from the host table and replaced it with
+MIT-GARY-COOPER at the same address, with nicknames GARY and
+GARY-COOPER. 
+
+Received: by mit-borax.ARPA (4.12/4.7)
+	id AA09164; Mon, 14 Jan 85 15:02:03 est
+Date: Mon, 14 Jan 85 15:02:03 est
+From: romkey@mit-borax (John L. Romkey)
+Message-Id: <8501142002.AA09164@mit-borax.ARPA>
+To: info-hosts@mc
+Subject: MIT-SLUSH
+
+I added MIT-SLUSH (18.26.0.130) to HSTMIT > and HOSTS >. I also added
+MIT-SLUDGE to HOSTS >. Before, it was only listed in HSTMIT.
+					- John
+
+Date: Sat 12 Jan 85 16:04:49-EST
+From: Clifford Neuman <BCN%MIT-EECS@MIT-MC.ARPA>
+Subject: New address for MIT-EDDIE
+To: INFO-HOSTS@MIT-MC
+
+CHAOS 12404 has been added for MIT-EDDIE in
+HSTMIT(339) and HOSTS(831).  
+
+	~ Cliff
+ 
+-------
+
+Received: by mit-borax.ARPA (4.12/4.7)
+	id AA08091; Tue, 1 Jan 85 20:53:26 est
+Date: Tue, 1 Jan 85 20:53:26 est
+From: romkey@mit-borax (John L. Romkey)
+Message-Id: <8501020153.AA08091@mit-borax.ARPA>
+To: info-hosts@mc
+Subject: two new hosts
+
+I added MIT-STORMWATCH and PROTEON to HSTMIT and HOSTS.
+					- John
+
+Date: 30 December 1984 17:04-EST
+From: Christopher C. Stacy <CSTACY @ MIT-MC>
+To: INFO-HOSTS @ MIT-MC
+
+Added MIT-ZAXXON (LispM at arcmac or something like that).
+
+Date: 21 December 1984 22:27-EST
+From: Christopher C. Stacy <CSTACY @ MIT-MC>
+To: INFO-HOSTS @ MIT-MC
+
+New host tables installed on MC.
+
+Date: Wed 12 Dec 84 13:45:30-EST
+From: Rob Austein <SRA@MIT-XX.ARPA>
+Subject: Re: Host table formats changing soon!
+To: CSTACY@MIT-MC.ARPA
+cc: INFO-HOSTS@MIT-MC.ARPA
+In-Reply-To: Message from "Christopher C. Stacy <CSTACY @ MIT-MC>" of Sun 9 Dec 84 23:51:00-EST
+Office: [NE43-502] 545 Technology Square, Cambridge MA 02139; (617) 253-7341
+
+	I'm afraid XX is still using HOSTS > too, unless I am very
+	confused.
+-------
+
+Date: 10 Dec 1984 16:25:34-EST
+From: smh@mit-ems
+To: CSTACY@mit-mc, INFO-HOSTS@mit-mc
+Subject: Host table formats changing soon!
+
+	Also, does anyone still use the old "HOSTS >" format file?  
+	You probably shouldn't be.  The data in there is far from 
+	complete or accurate.  Also, since HSTMIT will be in a different
+	format from HOSTS, updating HOSTS will be painful and people will
+	probably stop doing it very much (if they are now.)
+
+Alas, HOST2 and the old "HOSTS >" format is still used by
+{several,many,most,all} Unix chaos systems.  I'm not sure which of
+those adjective is accurate, but I know from personal inspection that
+at least one of them is true.  If proper Unix hosts3 support exists,
+I'd like to know about it.  If it has to be created, any volunteers?
+
+Steve Haflich, smh@mit-ems
+
+Date: Mon 10 Dec 84 04:59:31-EST
+From: John Wroclawski <JTW%MIT-SPEECH@MIT-MC.ARPA>
+To: info-hosts@MIT-MC
+
+New HSTMIT, HOSTS > - moved MIT-AI to chaos 3130
+-------
+
+Date: 9 December 1984 23:51-EST
+From: Christopher C. Stacy <CSTACY @ MIT-MC>
+Subject:  Host table formats changing soon!
+To: INFO-HOSTS @ MIT-MC
+
+
+In the near future, the format of the HSTNIC and HSTMIT host table
+files will be changing as part of the transition to the Internet name
+domain system.
+
+The HSTNIC file will reflect the official Internet host table at the
+NIC, which these days has hosts with domain names like "MIT-AI.ARPA".  
+The hosts also have nicknames like "MIT-AI" (their pre-domain official
+global name).
+
+The HSTMIT file will become a HOSTS3 (extended RFC810) format file,
+Internet hosts listed in this file will be renamed to correspond to
+their names in the HSTNIC file (ie., they will have ".ARPA" tacked on
+to them.
+
+Note: Collisions between nicknames in the HSTNIC and HSTMIT file
+(e.g., MIT's EDDIE vs. UW's EDDIE) will probably not be solved by
+these changes, since their is no real domain name system underneath.
+
+If you are using the HOSTS3 compiler, you can at least compile the new
+files.  You may have some trouble with software which thinks it knows
+about name domains.  Of course, eventually a great deal of the world
+will have to be rewritten to use the name domain stuff in a fully
+general way, but that headache is still a little while off.
+
+Also, does anyone still use the old "HOSTS >" format file?  
+You probably shouldn't be.  The data in there is far from 
+complete or accurate.  Also, since HSTMIT will be in a different
+format from HOSTS, updating HOSTS will be painful and people will
+probably stop doing it very much (if they are now.)
+
+Please direct any questions and problems to me.
+
+Chris
+
+Date: 6 December 1984 00:02-EST
+From: Christopher C. Stacy <CSTACY @ MIT-MC>
+To: INFO-HOSTS @ MIT-MC
+
+New host tables installed on MC.
+
+Date: Wednesday, 5 December 1984, 14:13-EST
+From: Tom Cloney <Muse at MIT-OZ>
+To: INFO-HOSTS at MC
+
+CADR-19 has been given the additional nickname SARAH (Sarah Bernhardt).
+The appropriate files have been updated on OZ and MC. 
+HSTNIC has not been altered.
+
+        
+
+Date: 25 November 1984 21:43-EST
+From: Richard Mark Soley <SOLEY @ MIT-MC>
+Subject: NEWT
+To: INFO-HOSTS @ MIT-MC
+cc: RDZ @ MIT-MC, greg @ MIT-XX, iannucci @ MIT-XX
+
+Put MIT-NEWTOWNE-VARIETY on the CHAOSnet at 15113 and 30330.
+
+	-- Richard
+
+Date: 17 November 1984 15:44-EST
+From: Christopher C. Stacy <CSTACY @ MIT-MC>
+To: INFO-HOSTS @ MIT-MC
+
+Latest host tables installed on MC.
+
+Date: Thu 15 Nov 84 18:07:16-EST
+From: George A. Boughton <GAB@MIT-XX.ARPA>
+Subject: subnet 10
+To: info-hosts@MIT-MC.ARPA
+
+	Mit-vax, cadr-9, cadr-12, cadr-16, cadr-19, cadr-20, and
+cadr-29 have been removed from subnet 6 and placed on subnet 10.
+Their new addresses can be found in mc:sysnet;hstmit >.
+-------
+
+Received: from MIT-BUGS-BUNNY by MIT-OZ via Chaosnet; 15 Nov 84 10:23-EST
+Received: by bugs-bunny.mit.arpa (4.12/4.8) id AA18320; Thu, 15 Nov 84 10:20:33 est
+Date: Thu, 15 Nov 84 10:20:33 est
+From: Web Dove <dove@bugs-bunny>
+To: Bug-HOSTS3@MIT-OZ, INFO-HOSTS@MIT-OZ, MARTY@MIT-OZ,
+        OZ-HOSTS-HACKERS@MIT-OZ
+Subject: Re:  Number assignment conflict?
+
+
+  From: Martin David Connor <MARTY@MIT-OZ>
+  Subject: Number assignment conflict?
+  
+  
+  I was running HOSTS3 asking for HOSTS2 output:
+  
+      Reading text file OZ:<SYSTEM>HOSTS.MASTER.2
+         Inserting file OZ:<SYSTEM>HOSTS.NIC.394
+         Inserting file OZ:<SYSTEM>HOSTS.SYI.15
+         Inserting file OZ:<SYSTEM>HOSTS.MIT.326
+         Inserting file OZ:<SYSTEM>HOSTS.SYM.59
+      Processing tables...
+      Flushing duplicate net def "CHAOS" = 1:7.0.0.0
+  
+  I got the following error:
+  
+      Duplicate address 18.20.41.21 = MIT-YOSEMITE-SAM, SCRC-RIVERSIDE
+  	.....
+      180 nets, 1497 sites, 3174 names; length 21180
+      1 "serious" errors, so not writing binary file.
+  
+  Here are the NIC host table entries for the hosts in question:
+  
+  HOST : 18.20.41.21, 192.10.41.21 : SCRC-RIVERSIDE : ....
+  
+  HOST : 18.20.27.21, 18.27.0.21 : MIT-YOSEMITE-SAM,SAM ....
+  
+  Now, I always thought the 3rd digit in the net 18 scheme was always 0
+  for some reason.  In any case, I think HOSTS3 also believes this as it
+  seems to be ignoring it.
+  
+  Since I am not sure who is out of step here, I am sending to all the
+  probable parties, in hopes someone will know the right fix.
+  
+The arpa numeric address standard calls for decimal numbers separated
+by dots.  My understanding is that the numbers 18.20.subnet.host are
+used at mit to signify those host addresses which support chaos wrapped
+internet packets and can unwrap them.  For those hosts, "subnet"
+corresponds to the chaos subnet number and "host" to the chaos host
+number.  I directly translated chaos octal subnet 033 to decimal number
+27. in order to arrive at the addresses for bugs-bunny (18.20.27.17)
+and yosemite-sam (18.20.27.21).  Both hosts also have raw internet
+packet addresses (18.27.0.17, 18.27.0.21).
+
+The HOSTS3 program must treat the first two numbers of addresses of the
+form 18.x as determining the subnet and the last two as determining the
+host.  This will work for both addresses of the form 18.x.0.y and
+18.20.x.y.
+
+In fact, I think it was an error for me to send the 18.20.27.y addresses
+to sri-nic as they do not need to know them.  Those addresses are only
+significant for the wrapping gateways around mit.
+
+P.S.
+Please send mail to me direct as I am not on any of the hosts mailing lists.
+
+Date: 14 November 1984 20:16-EST
+From: Christopher C. Stacy <CSTACY @ MIT-MC>
+To: INFO-HOSTS @ MIT-MC
+
+Latest host tables installed on MC.
+
+Received: from MIT-XX by MIT-OZ via Chaosnet; 14 Nov 84 13:18-EST
+Date: Wed 14 Nov 84 13:18:37-EST
+From: J. Noel Chiappa <JNC@MIT-XX>
+Subject: Re: Number assignment conflict?
+To: MARTY@MIT-OZ, Bug-HOSTS3@MIT-OZ, INFO-HOSTS@MIT-OZ, OZ-HOSTS-HACKERS@MIT-OZ
+cc: JNC@MIT-XX
+In-Reply-To: Message from "Martin David Connor <MARTY@MIT-OZ>" of Wed 14 Nov 84 11:57:00-EST
+
+	The problem here is that with the 'new' CHAOS wrapping scheme
+in use the third byte is in fact in use. HOSTS3 is incorrect in ignoring
+this. Yosemite and Riverside have addresses that are identical except
+in the third byte.
+	The number of hosts that have that byte non-zero should be very
+small; they are the wrapping/unwrapping gateways. The only ones I know
+of that are actually running are Bugs, Gross, Riverside and Trillian.
+You could probably deleete the offending address for Sam without much
+problem.
+		Noel
+-------
+
+Date: 14 Nov 1984  11:57 EST (Wed)
+Message-ID: <MARTY.12063527815.BABYL@MIT-OZ>
+From: Martin David Connor <MARTY%MIT-OZ@MIT-MC.ARPA>
+To:   Bug-HOSTS3%MIT-OZ@MIT-MC.ARPA, INFO-HOSTS%MIT-OZ@MIT-MC.ARPA,
+      OZ-HOSTS-HACKERS%MIT-OZ@MIT-MC.ARPA
+Subject: Number assignment conflict?
+
+
+I was running HOSTS3 asking for HOSTS2 output:
+
+    Reading text file OZ:<SYSTEM>HOSTS.MASTER.2
+       Inserting file OZ:<SYSTEM>HOSTS.NIC.394
+       Inserting file OZ:<SYSTEM>HOSTS.SYI.15
+       Inserting file OZ:<SYSTEM>HOSTS.MIT.326
+       Inserting file OZ:<SYSTEM>HOSTS.SYM.59
+    Processing tables...
+    Flushing duplicate net def "CHAOS" = 1:7.0.0.0
+
+I got the following error:
+
+    Duplicate address 18.20.41.21 = MIT-YOSEMITE-SAM, SCRC-RIVERSIDE
+	.....
+    180 nets, 1497 sites, 3174 names; length 21180
+    1 "serious" errors, so not writing binary file.
+
+Here are the NIC host table entries for the hosts in question:
+
+HOST : 18.20.41.21, 192.10.41.21 : SCRC-RIVERSIDE : SYMBOLICS-3600 : LISPM : UDP/TIME,UDP/TFTP,TCP/FINGER,TCP/SMTP,TCP/TELNET,TCP/TIME,UDP/FINGER,TCP/FTP :
+
+HOST : 18.20.27.21, 18.27.0.21 : MIT-YOSEMITE-SAM,SAM,YOSEMITE-SAM : VAX-11/750 : UNIX : TCP/TELNET,TCP/FTP,TCP/SMTP,TCP/TIME,TCP/DAYTIME,TCP/FINGER :
+
+Now, I always thought the 3rd digit in the net 18 scheme was always 0
+for some reason.  In any case, I think HOSTS3 also believes this as it
+seems to be ignoring it.
+
+Since I am not sure who is out of step here, I am sending to all the
+probable parties, in hopes someone will know the right fix.
+
+
+Date: 13 November 1984 14:52-EST
+From: Richard Mark Soley <SOLEY @ MIT-MC>
+To: INFO-HOSTS @ MIT-MC
+
+Moved all Tanglewood Lispmachines to subnet 60.
+Deleted FLAME-OF-THE-FOREST.
+Added BLUE-SPRUCE.
+
+	-- Richard
+
+Date: 9 November 1984 13:26-EST
+From: Christopher C. Stacy <CSTACY @ MIT-MC>
+To: INFO-HOSTS @ MIT-MC
+
+New host table installed, including NIC and local changes.
+
+Received: from MIT-ZERMAT by MIT-OZ via Chaosnet; 8 Nov 84 22:41-EST
+Date: Thu, 8 Nov 84 22:38 EST
+From: "Richard E. Zippel" <RZ@MIT-MC.ARPA>
+To: info-hosts@MIT-MC.ARPA
+
+mc:sysnet;hstmit 321 and mc:sysnet;hosts 818  have the new chaosnet
+address of Aspen (15315) and the correct spelling of Zermatt.
+
+Date: 6 November 1984 15:01-EST
+From: Richard E. Zippel <RZ @ MIT-MC>
+To: INFO-HOSTS @ MIT-MC
+
+I've added two lisp machnes, zermatt and gstaad at 15316 and 15317.
+I didn't compile the table.
+
+Received: by mit-borax.ARPA (4.12/4.7)
+	id AA07961; Sun, 4 Nov 84 20:42:07 est
+Date: Sun, 4 Nov 84 20:42:07 est
+From: romkey@mit-borax (John L. Romkey)
+Message-Id: <8411050142.AA07961@mit-borax.ARPA>
+To: info-hosts@mc
+Subject: a free subnet
+
+I've freed up subnet 152 since I wasn't using it. First come, first
+serve.
+						- John
+
+Date: 4 November 1984 13:19-EST
+From: David C. Plummer <DCP @ MIT-MC>
+To: INFO-HOSTS @ MIT-MC, RZ @ MIT-MC
+
+MIT-HARRIS-BRIDGE was moved from subnet 32 to 72, thus giving its
+address an non-lethal injection of 20000 units of octal number.
+
+Date: 4 November 1984 13:05-EST
+From: David C. Plummer <DCP @ MIT-MC>
+To: INFO-HOSTS @ MIT-MC
+cc: RZ @ MIT-MC
+
+I took subnets 156 and 157 for Harris and defined the following
+hosts in HSTMIT and HOSTS.  The first is the Harris end, the
+second the MIT end.  I probably won't compile the host tables
+unless I find a great need to.
+
+HOST HARRIS-MIT-BRIDGE,	[CHAOS 67402,CHAOS 67002],USER,MINITS,PDP11
+HOST MIT-HARRIS-BRIDGE,	[CHAOS 15040,CHAOS 67001],USER,MINITS,PDP11
+
+Date: 4 November 1984 12:51-EST
+From: David C. Plummer <DCP @ MIT-MC>
+To: LWA @ MIT-MC, DCLARK @ MIT-MC
+cc: INFO-HOSTS @ MIT-MC
+
+We are running very short of "unused" Chaos subnets.  For that
+matter, the last two "unused" subnets will be snarfed in a few
+minutes.  The "Reserved for project Athena" subnets have been
+reserved for over a year now.  As far as I can tell, only one of
+them has become real.  Can we recycle some of them?
+
+Date: 1 November 1984 15:36-EST
+From: Richard Mark Soley <SOLEY @ MIT-MC>
+Subject: HSTMIT/HOSTS change
+To: INFO-HOSTS @ MIT-MC
+
+Added Lisp Machine Forest host MIT-JULGRAN (a Swedish tree) at CHAOS 15307.
+
+Date: 31 October 1984 19:24-EST
+From: Christopher C. Stacy <CSTACY @ MIT-MC>
+To: INFO-HOSTS @ MIT-MC
+
+Latest host tables installed on MC.
+
+Date: 25 October 1984 14:20-EDT
+From: Ramesh S. Patil <RAMESH @ MIT-MC>
+Subject: new host table generated
+To: INFO-HOSTS @ MIT-MC
+
+The sysnet;hosts > and hstmit were edited but the xfile was not run when
+I added LM-12 to subnet-6.  I just ran the :xfile to make the change happen.
+ - ramesh
+
+Date: 22 October 1984 17:19-EDT
+From: Richard Mark Soley <SOLEY @ MIT-MC>
+Subject: Latest host table change
+To: INFO-HOSTS @ MIT-MC
+
+Added Pomegranate (new Lisp Machine Forest 3670).
+Moved Oak, Flame, & Cherry to subnet 32.
+
+	-- Richard
+
+Received: by mit-borax.ARPA (4.12/4.7)
+	id AA00770; Mon, 22 Oct 84 15:43:53 edt
+Date: Mon, 22 Oct 84 15:43:53 edt
+From: romkey@mit-borax (John L. Romkey)
+Message-Id: <8410221943.AA00770@mit-borax.ARPA>
+To: info-hosts@mc
+Subject: mit-vax & mit-charmin
+
+I added an internet address to MIT-VAX (18.26.0.95) and a new host
+called MIT-CHARMIN (18.26.0.1) which is a printer.
+						- John Romkey
+
+Date: 14 October 1984 20:43-EDT
+From: Christopher C. Stacy <CSTACY @ MIT-MC>
+To: INFO-HOSTS @ MIT-MC
+cc: dove @ MIT-BUGS-BUNNY
+
+Latest NIC host table installed on MC.
+I removed the SYLVESTER nicknames from BUGS since they collide with
+an ARPAnet machine's name (and choosing the name BUGS was to avoid
+this collision).
+
+Date: 10 October 1984 14:00-EDT
+From: Daniel Huttenlocher <DPH @ MIT-MC>
+To: INFO-HOSTS @ MIT-MC
+
+Added two 3670's SID-VICIOUS at chaos 13061 and DUANE-ALLMAN at chaos 13063.
+
+Date: Sun 7 Oct 84 16:20-EDT
+From: Martin David Connor <MARTY%MIT-OZ@MIT-MC.ARPA>
+Subject: 28 page host table too big?
+To: bug-its@MIT-MC
+CC: BUG-TCP@MIT-MC, INFO-HOSTS@MIT-MC
+
+
+I fetched the latest NIC host table and installed it on MC,
+and suddenly I couldn't get a DDT from OZ.  I backed out, renaming it
+to SYSBIN;HOSTS3 TOOBG?, and was then able to SUPDUP in and get a DDT without
+it barfing and saying there was a PWORD bug. I bet the bug is it couldn't
+map the host table.
+
+Anyway, someone should look at PWORD.
+
+
+Date: Sun 7 Oct 84 15:19-EDT
+From: Martin David Connor <MARTY%MIT-OZ@MIT-MC.ARPA>
+Subject: Latest NIC host table
+To: info-hosts@MIT-MC
+
+
+I retrieved it, and diked a few obvious hosts.  Someone (CSTACY) should
+make a list of hosts that should have their nicknames diked, or make a
+program that does the right thing.  It would help a lot.
+
+
+Date: 4 October 1984 18:05-EDT
+From: Patrick G. Sobalvarro <PGS @ MIT-MC>
+To: INFO-HOSTS @ MIT-MC
+
+I generated new tables, moving MIT-HEPHAESTUS off subnet 6, to subnet 26.
+
+Date: 25 September 1984 17:43-EDT
+From: Christopher C. Stacy <CSTACY @ MIT-MC>
+Subject:  HOSTS3
+To: INFO-HOSTS @ MIT-MC
+cc: BUG-TCP @ MIT-MC, BUG-ITS @ MIT-MC, KLH @ SRI-NIC,
+    MOON @ SCRC-TENEX
+
+The latest host table (including HSTNIC #384) is compiled and installed.
+The HOSTS3 compiler is "fixed".
+
+HOSTS3 hackers: The compiler does not do the sort of dynamic memory
+allocation I had assumed. I was therefore able to make some more room in
+the ITS version simply by moving where in core the table was being
+constructed.  I didn't calculate how much room is left over for new code
+or tables, but the increase should hold us for a while.  Of course, we
+are racing against the rate of host additions on the various networks in
+our table (the Internet, the Chaosnet, etc.)  Hopefully by the time we
+run out it will be time to implement a hairy namespace system.  
+Won't that be fun!
+
+Date: 24 September 1984 13:07-EDT
+From: Christopher C. Stacy <CSTACY @ MIT-MC>
+To: BUG-ITS @ MIT-MC
+cc: BUG-TCP @ MIT-MC, INFO-HOSTS @ MIT-MC
+
+Well, I think we are finally out of address space.
+New host tables cannot be compiled anymore because
+they are too massive.  People should not try to
+compile any changes until I get back to you,
+hopefully with a solution.
+
+Date: 14 September 1984 21:26-EDT
+From: Christopher C. Stacy <CSTACY @ MIT-MC>
+To: INFO-HOSTS @ MIT-MC
+
+Latest NIC table retrieved and installed.
+
+Date: 14 September 1984 21:03-EDT
+From: Christopher C. Stacy <CSTACY @ MIT-MC>
+To: BUG-ITS @ MIT-MC, INFO-HOSTS @ MIT-MC
+
+The TCP; directory on MC is now called "SYSNET;".
+
+Date: 13 September 1984 02:54-EDT
+From: Christopher C. Stacy <CSTACY @ MIT-MC>
+To: INFO-HOSTS @ MIT-MC
+
+New NIC host table retrieved and installed.
+
+Date: Sat, 8 Sep 84 16:15 EDT
+From: Scott Cyphers <sr.ehpyc%MIT-SPEECH@MIT-MC.ARPA>
+Subject: kodiak, smokey
+To: info-hosts@MIT-MC.ARPA
+
+I added the lisp machine hosts
+MIT-KODIAK (15431)
+MIT-SMOKEY (15432)
+to MC:TCP;HOSTS and HSTMIT
+and ran XFILE
+
+Date: 7 September 1984 21:10-EDT
+From: Christopher C. Stacy <CSTACY @ MIT-MC>
+To: INFO-HOSTS @ MIT-MC
+
+Latest NIC table retrieved; tables compiled and installed on MC.
+
+Date: Wed, 5 Sep 84 22:54 EDT
+From: Chris Lindblad <cjl%MIT-OZ@MIT-MC.ARPA>
+Subject: Changes to mc:tcp;hosts >
+To: Info-Hosts@MIT-MC.ARPA
+
+I removed all synonyms of MIT-DM for the host MIT-MC.
+
+Date: 3 September 1984 17:59-EDT
+From: Christopher C. Stacy <CSTACY @ MIT-MC>
+To: INFO-HOSTS @ MIT-MC
+
+Latest NIC table and other pending changes installed.
+MIT-TWEETY is now in the Internet.
+
+Date: 2 September 1984 15:16-EDT
+From: Martin David Connor <MARTY @ MIT-MC>
+Subject: Updated HSTMIT and HOSTS
+To: INFO-HOSTS @ MIT-MC
+
+
+Rearranged AI Lab concentrators.  Suggest all 20's build new tables
+as soon as possible. Already done for OZ.
+
+
+Received: by mit-borax.ARPA (4.12/4.7)
+	id AA07218; Thu, 30 Aug 84 13:14:56 edt
+Date: Thu, 30 Aug 84 13:14:56 edt
+From: romkey@mit-borax (John L. Romkey)
+Message-Id: <8408301714.AA07218@mit-borax.ARPA>
+To: info-hosts@mc
+Subject: mit-mother
+
+Two changes to the entry for MIT-MOTHER in hstmit and hosts. I've
+changed the address from LCS 32/42 to LCS 12/302 and I've commented it
+out in both files until the NIC gets the new address right.
+							- John
+
+Date: Tue, 28 Aug 84 15:54 EDT
+From: Webster Dove <dove%MIT-BUGS-BUNNY@MIT-MC.ARPA>
+Subject: adding bugs-bunny
+To: info-hosts@MIT-MC.ARPA
+Fcc: BUGS-BUNNY: /syla/dspg/dove/mbox
+
+In order to ease the transition for sylvester to a new name, the
+nicknames "mit-bugs-bunny", "bugs-bunny" and "bugs" have been added to
+the description of mit-sylvester in hosts and hstmit.
+
+Date: Tue, 28 Aug 84 12:24 EDT
+From: Webster Dove <dove%MIT-SYLVESTER@MIT-MC.ARPA>
+Subject: nicknema sylvester for mit-sylvester removed
+To: info-hosts@MIT-MC.ARPA
+Fcc: SYLVESTER: /syla/dspg/dove/mbox
+
+Removed from mc:tcp;hosts and hstmit to prevent conflict with
+cu-sylvester in hstnic.
+
+Date: Wed 15 Aug 84 16:53:18-EDT
+From: John Wroclawski <JTW%MIT-SPEECH@MIT-MC.ARPA>
+To: info-hosts@MIT-MC
+
+TCP;HOSTS 780 updates the entry for RUTGERS, which is completely
+irrelevant unless you need to talk to this machine through a
+CHAOS-ARPA Gateway.
+
+-------
+
+Date: 15 August 1984 14:43-EDT
+From: Christopher C. Stacy <CSTACY @ MIT-MC>
+To: INFO-HOSTS @ MIT-MC
+
+Latest host tables compiled and installed on MC.
+Includes MIT-DM, a VAX (sigh).
+
+Date: Tue, 7 Aug 84 14:59 EDT
+From: Cory Myers <cory%MIT-SYLVESTER@SCRC-STONY-BROOK.ARPA>
+Subject: additional address for mit-sylvester
+To: info-hosts@MIT-MC.ARPA
+
+MIT-SYLVESTER now responds to chaos 016241 as well as its old address of
+chaos 015421.  It also serves as a chaos gateway between subnets 33 and
+34 in parallel with MIT-SPEECH-11.
+
+Files mc:tcp; hstmit and mc:tcp;hosts have been updated to reflect this
+change.
+
+
+Received: by mit-charon (4.12/4.7)
+	id AA25342; Sun, 5 Aug 84 19:47:13 edt
+From: jis@mit-charon (Jeff Schiller)
+Date:  5 Aug 1984 1947-EDT (Sunday)
+To: info-hosts@mit-mc
+Subject: HSTMIT modified.
+
+To indicate that MIT-APHRODITE is now at ChaosNet address 42014.
+
+		-Jeff
+
+Date: 4 August 1984 20:43-EDT
+From: Robert P. Krajewski <RPK @ MIT-MC>
+Subject:  PS...
+To: INFO-HOSTS @ MIT-MC
+cc: DARTH @ MIT-MC
+
+The version numbers of the files concerned are HSTMIT 258 and HOSTS 778.
+We'll edit the namespace object when CADR15 decides to come up...
+
+Date: 4 August 1984 20:41-EDT
+From: Robert P. Krajewski <RPK @ MIT-MC>
+Subject:  Chaos Address for MIT-PI changed
+To: INFO-HOSTS @ MIT-MC
+cc: DARTH @ MIT-MC
+
+Old: 13010 (Subnet 26 (AI Ethernet), Host 010)
+New: 15314 (Subnet 32 (LCS Ethernet), Host 314)
+
+Date: 3 August 1984 11:08-EDT
+From: Christopher C. Stacy <CSTACY @ MIT-MC>
+To: INFO-HOSTS @ MIT-MC
+cc: CRE @ MIT-MC, BEN @ MIT-MC, CJL @ MIT-OZ, DANIEL @ MIT-OZ,
+    MARTY @ MIT-OZ
+
+I installed the latest NIC table, and discovered a new name conflict:
+someone else has a SYLVESTER, so I manually removed their nickname.
+
+People should be careful to remember that hosts whose entries appear
+in multiple tables must match.  I found several offending entries with
+conflicting ARPAnet addresses between the HSTMIT and HSTNIC table,
+conflicting host nicknames, and different machine types.  If the
+HOSTS3 compiler gets confused and thinks that different machines with
+the same name are being talked about in different files, it will throw
+away some or all of the information for those hosts.
+
+Mistakes (which I have corrected) in the HSTMIT table had 
+removed PREP and TINMAN from the Chaosnet!
+
+Also added SANCHO-PANZA (a 3d floor 3600) to the Chaosnet.
+
+Installed the tables on MC and ML.
+
+Chris
+
+Date: Thu, 26 Jul 84 09:16 EDT
+From: "Christopher C. Stacy" <CStacy@MIT-MC.ARPA>
+Subject: host tables
+To: Info-Hosts@MIT-MC.ARPA
+
+The source for the host tables has moved from the SYSENG;
+directory to the TCP; directory, which is a little less crowded.
+Latest NIC table installed.
+
+Chris
+
+Date: Thu 12 Jul 84 16:28:34-EDT
+From: GAB@xx
+Subject: ne43-2a
+Sender: GAB%MIT-OZ@MIT-MC.ARPA
+To: info-hosts@MIT-MC
+Reply-To: gab@xx
+
+	I have changed the entries for ne43-2a in hosts and hstmit to include
+its new subnet 6 address of 3162.
+-------
+
+Date: 10 July 1984 17:23-EDT
+From: Christopher C. Stacy <CSTACY @ MIT-MC>
+Subject: new host tables
+To: INFO-HOSTS @ MIT-MC
+
+I installed the latest host tables on MC, including a new NIC table.
+
+Date: 29 June 1984 01:15-EDT
+From: Christopher C. Stacy <CSTACY @ MIT-MC>
+Subject: latest host table installed
+To: INFO-HOSTS @ MIT-MC
+cc: BUG-MAIL @ MIT-MC, BUG-ITS @ MIT-MC, KLH @ SRI-NIC
+
+I have compiled and installed the latest host tables
+on MC and ML.  Things (such as the HOSTS3 compiler
+and QMAIL) should be working now; please let me
+know if anything blows up.
+
+
+Date: Thu 28 Jun 84 19:59:34-EDT
+From: Clifford Neuman <BCN%MIT-EECS@MIT-MC.ARPA>
+Subject: New addresses for MIT-EECS-11 and MIT-BYPASS
+To: info-hosts@MIT-MC
+
+SYSENG; HSTMIT 243 and
+SYSENG; HOSTS  767
+
+Have been updated to include subnet 25 addresses for MIT-EECS-11 and
+MIT-BYPASS.  In addition to its old addresses, MIT-EECS-11 now resides
+at chaos 12542, and MIT-BYPASS at 12530.
+
+	~ Cliff
+ 
+-------
+
+Date: 27 June 1984 12:13-EDT
+From: Christopher C. Stacy <CSTACY @ MIT-MC>
+Subject: despite my previous warnings
+To: INFO-HOSTS @ MIT-MC
+cc: CSR @ MIT-MC
+
+Whoever installed the latest host tables on MC broke alot
+of system programs.  It was someone who uses the CSR directory.
+Keep your fucking hands off, please.
+
+Received: by mit-borax.ARPA (4.12/4.7)
+	id AA01059; Wed, 27 Jun 84 11:45:37 edt
+Date: Wed, 27 Jun 84 11:45:37 edt
+From: romkey@mit-borax (John L. Romkey)
+Message-Id: <8406271545.AA01059@mit-borax.ARPA>
+To: info-hosts@mc
+Subject: host table change
+
+I added a chaosnet address for mit-coke.
+						- John
+
+Date: 23 June 1984 18:19-EDT
+From: Christopher C. Stacy <CSTACY @ MIT-MC>
+To: INFO-HOSTS @ MIT-MC
+
+No one should compile new host tables on ITS until some
+bugs in various system programs are worked out.
+The most recent valid files are SYSBIN;HOSTS2 726 and HOSTS3 403.
+The ones after that (HOSTS2 LATEST and HOSTS3 LATEST) correspond
+to the most recently updated host table source files and required
+modifications to the HOSTS3 compiler to produce.  Sadly, they have
+pushed the memory limits of assorted system programs and cannot
+be installed yet.   I'll send another message when things are
+working again.
+
+Date: 23 June 1984 17:39-EDT
+From: Christopher C. Stacy <CSTACY @ MIT-MC>
+Subject:  Host name "Harvard" doesn't work right
+To: INFO-HOSTS @ MIT-MC
+cc: MRC @ SU-SCORE, bug-mailer @ MIT-OZ, bug-mm @ MIT-OZ, RMS @ MIT-OZ
+In-reply-to: Msg of Sat 23 Jun 84 14:13:42-PDT from Mark Crispin <MRC at SU-SCORE.ARPA>
+
+I removed the nickname HARVARD from the MINITS machine (Harvard
+Bridge?) at Symbolics, so that Harvard University can be called
+"Harvard" and so many users would be less confused.
+
+Date: Mon 18 Jun 84 20:34:52-EDT
+From: Clifford Neuman <BCN%MIT-EECS@MIT-MC.ARPA>
+Subject: Zarquon, Prak, Hactar, and Slartibartfast
+To: INFO-HOSTS@MIT-MC
+
+The followiwng have been added to HSTMIT 239 and HOSTS 764:
+
+MIT-SLARTIBARTFAST    Chaos 12422
+MIT-PRAK              Chaos 12423
+MIT-ZARQUON           Chaos 12424
+MIT-HACTAR            Chaos 12425
+
+These are the 4 client computers in the building 38 Athena Cluster.
+
+-------
+
+Date: Thu 14 Jun 84 11:13:23-EDT
+From: Clifford Neuman <BCN@MIT-XX.ARPA>
+Subject: MIT-TRILLIAN
+To: INFO-HOSTS@MIT-MC.ARPA
+cc: Staff%MIT-EECS@MIT-XX.ARPA
+
+SYSENG; HSTMIT 238
+
+and
+
+SYSENG; HOSTS 763
+
+Add mit-trillian at chaos address 12421, a VAX-11/750 Running 4.2.
+It is the first Athena machine running in building 38.
+-------
+
+Date: 13 June 1984 14:48-EDT
+From: Christopher C. Stacy <CSTACY @ MIT-MC>
+To: INFO-HOSTS @ MIT-MC
+
+New NIC table installed.
+
+Date: Thu 7 Jun 84 03:19-EDT
+From: Michael J. Konopik <ZZZ%MIT-OZ@MIT-MC.ARPA>
+Subject: you wanted this...
+To: info-hosts@MIT-MC
+
+
+I just changed HOSTS > and HSTMIT > to reflect the fact that HTJR (TINMAN)
+still runs VMS. The claim that it runs UNIX was screwing up CFTP.
+
+				-Mike
+
+Date: 6 June 1984 17:58-EDT
+From: J. Noel Chiappa <JNC @ MIT-MC>
+Subject: Atari
+To: INFO-HOSTS @ MIT-MC
+cc: JNC @ MIT-MC
+
+	Now that Atari Cambridge has gone belly up, should the Atari numbers
+be recycled? Who is competent to know whether or nott these numbers are still
+in use.
+
+Date: 6 June 1984 17:47-EDT
+From: J. Noel Chiappa <JNC @ MIT-MC>
+Subject: Subnets assigned
+To: INFO-HOSTS @ MIT-MC
+cc: JNC @ MIT-MC
+
+	Subnets 64 and 65 (octal) have been assigned to the MIT-Proteon
+link and the main ring out at Natick respectively. I hope the fact that
+they were marked as 'unused' in HSTMIT > means those numbers really were
+unused.
+
+Received: by mit-borax.ARPA (4.12/4.7)
+	id AA04901; Wed, 6 Jun 84 14:09:34 edt
+Date: Wed, 6 Jun 84 14:09:34 edt
+From: romkey@mit-borax (John L. Romkey)
+Message-Id: <8406061809.AA04901@mit-borax.ARPA>
+To: info-hosts@mc
+Subject: Mother and Cub
+
+I removed two nicknames for MIT-MOTHER and added MIT-CUB to hstmit and
+hosts.
+						- John
+
+Date: 2 Jun 1984  04:21 EDT (Sat)
+Message-ID: <MARTY.12020180156.BABYL@MIT-OZ>
+From: Martin David Connor <MARTY%MIT-OZ@MIT-MC.ARPA>
+To:   Info-Hosts@MIT-MC, OZ-HOSTS-HACKERS%MIT-OZ@MIT-MC.ARPA
+Subject: New host tables
+
+
+Well, being rather bored, I decided to teach myself to get new host
+tables from the NIC and compile host tables on MC.
+
+I did the following things.  I think they are right, but would
+appreciate any suggestions for a better way:
+
+   - Ran CSTACY;HOSTS to retrieve the lastest NIC table
+
+   - Did :XFILE SYSENG;HOSTS XFILE to create the tables
+
+   - Got the following cruft printed out:
+
+Nickname WARD for Internet site WASHINGTON is also a CHAOS host, ignored.
+Nickname ROCKY for Internet site CU-ROBOTICS is also a CHAOS host, ignored.
+Nickname MERLIN for Internet site PURDUE-MERLIN is also a CHAOS host, ignored.
+Nickname LARRY for Internet site UW-BLUECHIP is also a CHAOS host, ignored.
+Nickname FORD for Internet site FORD1 is also a CHAOS host, ignored.
+Nickname EDDIE for Internet site UW-EDDIE is also a CHAOS host, ignored.
+Nickname COYOTE for Internet site SU-COYOTE is also a CHAOS host, ignored.
+Nickname ARTHUR for Internet site PURDUE is also a CHAOS host, ignored.
+
+    - Went back in, and hand edited out the DUPS from the NIC table,
+      and wrote back out the table to the same version (349).
+
+    - Compiled the table again, noticing that the NIC had now made
+      MIT-NEWTOWNE-VARIETY the primary name for MIT-FLA.  Of course
+      HSTMIT still had MIT-FLA as the primary name, so HOSTS2 bitched.
+
+    - Edited HSTMIT to make it consistent with HSTNIC.
+
+    - Compiled the tables one last time.
+
+I wasn't sure if ALL the dup nicknames usually got edited out, but it
+seemed like the right thing for local use.
+
+Anyway, if I did something wrong, someone can fix it, and please let
+me know so I don't do it again.
+
+  Marty
+
+
+Date: Thu 31 May 84 18:03:14-EDT
+From: Clifford Neuman <BCN%MIT-EECS@MIT-MC.ARPA>
+Subject: HoG and Franky-Mouse
+To: info-hosts@MIT-MC
+
+The long awaited EE ether loop is now alive.
+
+HSTMIT 228 and HOSTS 758 have been changed.
+
+Franky-Mouse:    Subnet 7  host 10  (3410)
+                 Subnet 25 host 10 (12410)
+
+Heart-of-Gold:   Subnet 25 host 42 (12442)
+
+-------
+
+Date: 27 May 1984 02:00-EDT
+From: Jeffrey I. Schiller <JIS @ MIT-MC>
+To: INFO-HOSTS @ MIT-MC
+
+HSTMIT 225... Added MIT-ATHENA on the ChaosNet...
+
+		-Jeff
+
+Date: 27 May 1984 01:57-EDT
+From: Jeffrey I. Schiller <JIS @ MIT-MC>
+To: INFO-HOSTS @ MIT-MC
+
+
+
+Received: by mit-borax.ARPA (4.12/4.7)
+	id AA01763; Fri, 25 May 84 15:26:24 edt
+Date: Fri, 25 May 84 15:26:24 edt
+From: romkey@mit-borax (John L. Romkey)
+Message-Id: <8405251926.AA01763@mit-borax.ARPA>
+To: info-hosts@mc
+Subject: three changes
+
+Hi. I've added two hosts to the tables: MIT-BLUE-APOLLO and MIT-GOOFY.
+I've also allocated a subnet (151) for some IP speaking Apollo machines
+for Bob Iannucci.
+							- John
+
+Date: 25 May 1984 09:26-EDT
+From: Christopher C. Stacy <CSTACY @ MIT-MC>
+To: INFO-HOSTS @ MIT-MC
+
+Latest NIC table retrieved and compiled on MC.
+
+Received: from MIT-MC by MIT-OZ via Chaosnet; 22 May 84 16:48-EDT
+Date: Tuesday, 22 May 1984, 16:45-EDT
+From: Chris Lindblad <cjl at MIT-OZ>
+Subject: Change to MIT host table
+To: info-hosts at MIT-OZ
+
+mc:syseng; hosts > and mc:syseng; hstmit > have been modified.
+The operating system on MIT-HERMES has changed from VMS to UNIX.
+
+Date: 22 May 1984  03:42 EDT (Tue)
+Message-ID: <MARTY.12017289445.BABYL@MIT-OZ>
+From: Martin David Connor <MARTY%MIT-OZ@MIT-MC.ARPA>
+To:   INFO-HOSTS@MIT-MC
+Cc:   OZ-HOSTS-HACKERS%MIT-OZ@MIT-MC.ARPA
+Subject: Slight frob to HSTMIT and HOSTS
+
+
+In order to make HOSTS3 happy, I had to set the official name of
+MIT-NEWTOWNE-VARIETY to MIT-FLA, since that's what it was in HSTNIC.
+
+If the NIC table ever gets the new apparent official name for FLA,
+then it will be ok to change the MIT tables.
+
+
+Received: from SCRC-PEACE by SCRC-YUKON via CHAOS with CHAOS-MAIL id 41801; Mon 21-May-84 12:25:41-EDT
+Date: Mon, 21 May 84 12:25 EDT
+From: Charles Hornig <Hornig@SCRC-STONY-BROOK.ARPA>
+Subject: HSTNIC 347
+To: info-hosts@MIT-MC.ARPA
+Message-ID: <840521122524.2.HORNIG@PEACE.SCRC.Symbolics>
+
+I brought over the most recent NIC host table, but didn't recompile
+HOSTS3 because I was worried at the apparent resurrection of MIT-AI
+(running ITS on a KS10).  If AI is really coming back, someone can go
+ahead and install it.  If it isn't, someone should tell the NIC.
+
+Date: Sat 19 May 84 19:22:16-EDT
+From: John Wroclawski <JTW%MIT-SPEECH@MIT-MC.ARPA>
+To: info-hosts@MIT-MC
+
+HOSTS 747 and HSTMIT 213 modify XI, the XX net-11. Remove from SN6, add
+to SN32 (15020), change OS to MINITS, remove nickname "NFE", whee.
+-------
+
+Date: 17 May 1984 18:09-EDT
+From: Christopher C. Stacy <CSTACY @ MIT-MC>
+Subject:  MIT-AI
+To: DPH @ MIT-MC
+cc: INFO-HOSTS @ MIT-MC, TAFT @ MIT-MC, TK @ MIT-MC, AI-KL @ MIT-OZ,
+    GLR @ MIT-OZ
+In-reply-to: Msg of 16 May 1984 19:52-EDT from Daniel Huttenlocher <DPH>
+
+I have sent in the update which renames MIT-AI-RESERVED (on IMP 6) to
+MIT-AI, and removes the "AI" nicknames from MIT-OZ (on IMP 77, but
+this entry is commented out.)
+
+Date: 17 May 1984 15:24-EDT
+From: Patrick G. Sobalvarro <PGS @ MIT-MC>
+To: INFO-HOSTS @ MIT-MC
+
+I added a new Chaos host on subnet 32, MIT-NE43-2B-HUB, and regenerated the
+host tables on MC.
+
+Date: 16 May 1984 19:52-EDT
+From: Daniel Huttenlocher <DPH @ MIT-MC>
+To: INFO-HOSTS @ MIT-MC
+
+I removed the aliases MIT-AI and AI from MIT-OZ in HOSTS > and HSTMIT >.
+Somebody (read cstacy) might want to have the NIC remove it from OZ's
+commented out entry in HSTNIC in the eventuality that oz ever makes it
+on the arpanet...
+
+Date: 16 May 1984 17:33-EDT
+From: Christopher C. Stacy <CSTACY @ MIT-MC>
+To: INFO-HOSTS @ MIT-MC
+
+No one should install a host table on MC without removing the
+naming ambiguities for the names "MERLIN", "EDDIE", and "FORD".
+
+Date: 16 May 1984 16:12-EDT
+From: Charles Hornig <CAH @ MIT-MC>
+Subject: new host table
+To: INFO-HOSTS @ MIT-MC
+
+Latest NIC host table (346).
+
+Date: Tuesday, 15 May 1984, 03:27-EDT
+From: Christopher C. Stacy <CStacy at MIT-MC>
+Subject: "PFC"
+To: John G. Aspinall <JGA at MIT-MC>
+Cc: INFO-HOSTS at MIT-MC
+In-reply-to: The message of 9 May 84 16:00-EDT from John G. Aspinall <JGA>
+             The message of 23 January 84 10:13-EST from <JGA>
+
+Added nickname "PFC" to MIT-PFC-VAX in the source.
+
+Date: Thu 10 May 84 23:14:17-EDT
+From: Robert H. Myhill <ROBERT@MIT-XX.ARPA>
+Subject: please take me off of this mailing lists
+To: info-hosts@MIT-MC.ARPA
+
+
+Could someone out there please take me off of the
+info-hosts mailing list/
+Thanks.
+
+robert@xx
+-------
+
+Date: 6 May 1984 23:34-EDT
+From: Christopher C. Stacy <CSTACY @ MIT-MC>
+To: INFO-HOSTS @ MIT-MC
+
+New host table installed, including latest NIC table.
+
+Date: Sat 5 May 84 18:25-EDT
+From: Michael J. Konopik <ZZZ%MIT-OZ@MIT-MC.ARPA>
+Subject: 
+To: info-hosts@MIT-MC
+
+I just added MIT-DIOXIN to the host tables. It is CCC's new terminal
+concentrator. Just thought you'd like to know...
+
+				-Mike
+
+Date: 29 Apr 1984 17:56:58-EDT
+From: walter at mit-htvax
+To: info-hosts@mc
+Subject: MIT-RTS
+
+Commented out MIT-RTS.
+
+Received: from SCRC-PEACE by SCRC-RIVERSIDE via CHAOS with CHAOS-MAIL id 10847; Mon 23-Apr-84 12:52:40-EST
+Date: Mon, 23 Apr 84 12:47 EST
+From: Charles Hornig <Hornig%SCRC-STONY-BROOK@SCRC-RIVERSIDE.ARPA>
+Subject: HSTSYM changes
+To: info-hosts@MIT-MC.ARPA
+Message-ID: <840423124752.5.Hornig@STONY-BROOK.SCRC.Symbolics>
+
+I moved the nickname SCRC from SCRC-TENEX to SCRC-STONY-BROOK.
+
+Date: 12 April 1984 08:11-EST
+From: Charles Hornig <CAH @ MIT-MC>
+To: INFO-HOSTS @ MIT-MC
+
+Changed 128.31.x.x hosts to 18.20.x.x pending the NIC update.
+
+Date: 11 April 1984 18:46-EST
+From: Christopher C. Stacy <CSTACY @ MIT-MC>
+To: INFO-HOSTS @ MIT-MC
+
+New host table installed on MC.
+
+Date: 10 Apr 1984 07:42:57-EST
+From: <smh@mit-ems>
+To: info-hosts@mit-mc
+Subject: Master host tables broken
+
+There are two problems in the current host tables.  The guilty parties
+will know who they are:
+
+[MC:SYSENG;HOSTS 737] is trivially broken by the mysterious addition
+of a newline in the middle of MIT-MARVIN.
+
+[MC:SYSENG;HOSTS 737] lacks the most recent updates appearing in
+[MC;SYSENG;HSTMIT 201].  Should not the MIT data in these files be
+maintained in parallel?
+
+HEY!  Let's be *careful* out there!
+
+Received: from SCRC-PEACE by SCRC-RIVERSIDE via CHAOS with CHAOS-MAIL id 9910; Tue 10-Apr-84 04:59:23-EST
+Date: Tue, 10 Apr 84 05:03 EST
+From: Charles Hornig <Hornig%SCRC-STONY-BROOK@SCRC-RIVERSIDE.ARPA>
+Subject: HOST changes
+To: info-hosts@MIT-MC.ARPA
+Message-ID: <840410050348.5.Hornig@STONY-BROOK.SCRC.Symbolics>
+
+I adjusted SCRC-RIVERSIDE's addresses to reflect the new gateway
+situation and added the Athena machines which are now accessible.
+
+Date: 9 April 1984 21:39-EST
+From: Richard E. Zippel <RZ @ MIT-MC>
+To: INFO-HOSTS @ MIT-MC
+
+Installed MIT-NU-0 thru MIT-NU-29 at their correct Chaos addresses.
+
+Date: 7 April 1984 19:40-EST
+From: Richard E. Zippel <RZ @ MIT-MC>
+To: INFO-HOSTS @ MIT-MC
+
+I've added mit-nu0 through mit-nu29 now that they are on the net.
+
+Received: by mit-borax.ARPA (4.12/4.7)
+	id AA03946; Thu, 5 Apr 84 22:45:23 est
+Date: Thu, 5 Apr 84 22:45:23 est
+From: romkey@mit-borax (John L. Romkey)
+Message-Id: <8404060345.AA03946@mit-borax.ARPA>
+To: info-hosts@mc
+Subject: fla & wild-blue-yonder & such
+Cc: marty%oz@mc
+
+I've uncommented wild-blue-yonder, deleted fla's conflicting net
+address and recompiled the host tables.
+
+I don't mean to harp on the point, but I'm sure that I fixed it when I
+was updating the tables the first time. I am at least sure that I
+editted hstmit > twice but there's only one copy before Marty's update
+bearing my name at the top. So I think that the fixed version got lost
+somewhere (is that sufficiently vague?). I am careful when I change the
+tables!
+						- John
+
+Date: 5 Apr 1984  21:43 EST (Thu)
+Message-ID: <MARTY.12005176464.BABYL@MIT-OZ>
+From: Martin David Connor <MARTY%MIT-OZ@MIT-MC.ARPA>
+To:   INFO-HOSTS@MIT-MC
+Cc:   Romkey@MIT-BORAX.ARPA
+Subject: MIT-WILD-BLUE-YONDER
+
+
+This machine had the same address as MIT-FLA in HSTMIT.
+This made it impossible to compile a new host table.
+I commented it out until someone does it right.
+
+Marty
+
+
+Received: by mit-borax.ARPA (4.12/4.7)
+	id AA01686; Thu, 5 Apr 84 16:21:28 est
+Date: Thu, 5 Apr 84 16:21:28 est
+From: romkey@mit-borax (John L. Romkey)
+Message-Id: <8404052121.AA01686@mit-borax.ARPA>
+To: info-hosts@mc
+Subject: additions to the host tables
+
+I just added MIT-WILD-BLUE-YONDER, MIT-BIG-BLUE, MIT-BLUE-LIGHT and
+MIT-BLUE-DANUBE to the hstmit > and hosts >. I also had to delete the
+subnet 26 address for MIT-FLA because MIT-WILD-BLUE-YONDER is really
+just a name for the other interface on fla. It's all Bob Iannucci's
+fault.
+						- John Romkey
+
+Date: 1 April 1984 22:01-EST
+From: Daniel Huttenlocher <DPH @ MIT-MC>
+To: INFO-HOSTS @ MIT-MC
+
+HOSTS 731 and HSTMIT 191 add MIT-ASPEN and MIT-TELLURIDE,
+3600's and comments out MIT_VAXLET which some twit put at
+a conflicting address with SCRC-PEACE.
+
+Date: 30 March 1984 14:06-EST
+From: Christopher C. Stacy <CSTACY @ MIT-MC>
+To: INFO-HOSTS @ MIT-MC
+cc: MOON @ SCRC-TENEX
+
+Would someone from Symbolics please correct their host
+tables (remove duplicate-address entries)?  The host
+tables cannot be compiled in the current state.
+
+Date: Wed, 28 Mar 1984  19:55 EST
+Message-ID: <UC.GDS.12003059596.BABYL@MIT-EECS>
+From: Greg Skinner <UC.GDS@MIT-EECS>
+To:   Gail Zacharias <GZ@MIT-OZ>
+Cc:   bug-mail@MIT-OZ, ee.mp@MIT-OZ, smh@MIT-EMS, STRAZ@MIT-OZ, info-hosts@MC
+Subject: mailing to athena
+In-reply-to: Msg of 28 Mar 1984  16:47-EST from Gail Zacharias <GZ at MIT-OZ>
+
+There are a few easy ways out of this mess (some easier than
+others).
+
+1.  Somebody add mit-athena, and athena, as nicknames for charon,
+unless there's some special reason why that shouldn't be done.
+
+2.  Steve, if you were using MM, and did 
+
+to: "mit-athena!tony"@mit-eddie,
+
+I believe MM would have converted it properly for MMAILR to use it.
+(Is that so, Gail?  If not, we have a serious problem here.)  If you
+didn't, you don't have to put quotes around the foreign address,
+because the quotes are there so MM won't interpret the ! as a comment.
+(Correct me again Gail if I'm wrong.)
+
+3. In general, you should try to find other means besides using UUCP
+to send mail which you want delivered in a hurry.  (It looked from the
+message as if you expected it to get there immediately.)  UUCP mail is
+more than a magnitude of order slower than CHAOS mail, which means
+that it probably would have taken a day or so for your message to get
+to mit-athena (if it ever got there -- you'd be surprised at how often
+UUCP mail gets lost).  I don't see any reason why they are not
+accepting chaos mail anyhow, seeing as they're on the chaosnet, that
+sort of goes along with the territory.
+
+Date: 22 March 1984 00:47-EST
+From: Christopher C. Stacy <CSTACY @ MIT-MC>
+To: INFO-HOSTS @ MIT-MC
+
+Latest NIC table installed.
+
+Received: by mit-borax.ARPA (4.12/4.7)
+	id AA05041; Fri, 16 Mar 84 16:52:14 est
+Date: Fri, 16 Mar 84 16:52:14 est
+From: romkey@mit-borax (John L. Romkey)
+Message-Id: <8403162152.AA05041@mit-borax.ARPA>
+To: info-hosts@mc
+Subject: hstmit additions
+
+I added two hosts, MIT-GUANO (it's Steve Ward's fault!) and MIT-CJT,
+both ibm pc's, to hstmit > and hosts >.
+						- John Romkey
+
+Date: Tue, 13 Mar 84 06:39 EST
+From: "Christopher C. Stacy" <CStacy@MIT-MC.ARPA>
+Subject: When is a pdp-10 not a pdp-10
+To: "David A. Moon" <Moon%SCRC-TENEX@MIT-MC.ARPA>
+Cc: BUG-FTP@MIT-MC.ARPA, GSB@MIT-MC.ARPA, KLOTZ@MIT-MC.ARPA,
+    Info-Hosts@MIT-MC.ARPA
+In-reply-to: The message of 29 Feb 84 15:41-EST from David A. Moon <Moon at SCRC-TENEX>
+
+    Date: Wed, 29 Feb 84 15:41 EST
+    From: David A. Moon <Moon%SCRC-TENEX at MIT-MC.ARPA>
+	ftp.  Really, it's user-interface brain death.  You see it used
+	to do-the-right-thing between pdp10s and now it doesn't.  We expected
+	without thinking that it would.  (I think that was it anyway;  transfering
+	in ascii rather than 36bit).  It's not like it lies or anythign, but
+	that the default used to be adequate for any file transfer, and who
+	really looks at spastic program printout anyway....
+    Someone changed the machine type in the host table of all the pdp10s from
+    "PDP10" to imaginative things like "DEC-10", "DEC-1080".  Thus FTP can no
+    longer tell when a machine is a pdp10.  Probably this was imposed on us by
+    the NIC.  Someone should give FTP a list of all the known pdp10 machines or
+    all the known pdp10 operating systems, replacing the present code in the
+    NHOSTN routine.
+
+    Presumably this is an attempt to get us all to switch to Unix.
+
+I just changed FTP to think that things which run ITS, WAITS, TOPS10,
+TOPS20, TENEX, and FOONEX are PDP-10s.    
+
+    From: Leigh L. Klotz <KLOTZ @ MIT-MC>
+    To: BUG-FTP @ MIT-MC
+    Why do I get
+    ASCII retrieve of <dir>FILE.EXT.2 started.
+    twice whenever I use FTP to a twenex site?  I haven't had occasion
+    to use it with any other type of site.
+
+I think I have also fixed this bug.
+
+Date: 9 March 1984 19:13-EST
+From: Charles Frankston <CBF @ MIT-MC>
+Subject:  Project Athena Vaxen & Large Chaos subnet numbers
+To: INFO-HOSTS @ MIT-MC
+
+Two Project Athena Vaxen have been added to HSTMIT table as Chaos only
+hosts.
+
+They are MIT-CHARON, Chaos address 042015 and MIT-APOLLO, Chaos address
+042013.  APOLLO is not actually on the chaos net yet, but probably will
+be in time, along with another dozen or two Project Athena machines.
+
+Some of you may have noticed that these machines are on Chaos subnet
+104o.  This subnet is 11d higher than any previously active subnet on the
+MIT-Chaos net.  This is due to various places which have reserved subnets
+not yet operational or connected to the main MIT Chaos net.
+
+This subnet is not reachable by a large number of Chaosnet hosts due to
+their routing tables being too small.  I have fixed the bridges
+MIT-INFINITE and MIT-BYPASS, which merely needed recompiling.  However,
+there are other bridges and hosts that should have their routing tables
+enlarged.  In partcular the front end 11 for every 20 on campus, MIT-VAX
+and I imagine many other Unix hosts.
+
+Note that Chaos subnet 104o=68d, whereas the Athena machines all think
+they are on Internet subnet 18.58.xx.xx.  I understand that there was once
+an attempt to maintain a correspondence between MIT internet subnet and
+Chaos subnet numbers.  Apparently Project Athena was originally assigned a
+set of subnets starting at 58d, but when these were claimed by groups, no
+one bothered informing the Athena staff.  This doesn't represent any
+problem yet, if it ever will, as there is no Internet link from the Athena
+machines to the rest of the Internet.
+
+I would also make a plea that if people increase their routing table sizes
+they go straight to 122d (172o).  This is the number of subnet entries
+that will fit in the maximum size routing packet.  It's real hard to
+figure out that no one can talk to your subnet because your routing
+packets are being ignored.
+
+Date: 6 March 1984 21:44-EST
+From: Daniel Huttenlocher <DPH @ MIT-MC>
+To: INFO-HOSTS @ MIT-MC
+
+Installed MIT-GOLDILOCKS a 3600 at chaos address 15470.
+
+Date: 6 March 1984 03:34-EST
+From: Christopher C. Stacy <CSTACY @ MIT-MC>
+To: INFO-HOSTS @ MIT-MC
+
+Latest NIC table installed on MC.
+
+Received: from SCRC-MERRIMACK by SCRC-RIVERSIDE via CHAOS with CHAOS-MAIL id 8509; Mon 5-Mar-84 08:30:35-EST
+Date: Monday, 5 March 1984, 08:36-EST
+From: Charles Hornig <Hornig%SCRC-QUABBIN@MIT-ML.ARPA>
+Subject: SYMBOLICS-3600
+To: "David C. Plummer" <DCP@MIT-MC.ARPA>
+cc: LispM-Networks%SCRC-TENEX@MIT-ML.ARPA, info-hosts@MIT-MC.ARPA
+In-Reply-To: The message of 25 Feb 84 15:07-EST from David C. Plummer <DCP at MIT-MC>
+Message-ID: <840305083652.1.Hornig@QUABBIN.SCRC.Symbolics>
+
+    Date: 25 February 1984 15:07-EST
+    From: David C. Plummer <DCP @ MIT-MC>
+
+	Date: 25 February 1984 14:59-EST
+	From: David C. Plummer <DCP @ MIT-MC>
+
+	    Date: 24 February 1984 18:08-EST
+	    From: Christopher C. Stacy <CSTACY @ MIT-MC>
+
+	    The NIC seems to be putting CPU types of "SYMBOLICS-3600"
+	    on things, while our local tables say "3600".  This makes
+	    the HOSTS3 compiler print silly warnings, so I edited the
+	    HSTNIC file to use the "3600" convention.  Someone should
+	    decide which they would rather see, and get everyone to use it.
+
+	Charlie, what's the story here?
+
+	(The rest of you, don't expect an answer very soon, he's on
+	vacation for another week or so.)
+
+    Ignore me.  I should have read all my mail first.
+
+	Date: 24 February 1984 20:33-EST
+	From: Ken Harrenstien <KLH @ MIT-MC>
+	To: CSTACY @ MIT-MC
+	cc: INFO-HOSTS @ MIT-MC
+
+	    Date: 24 February 1984 18:08-EST
+	    From: Christopher C. Stacy <CSTACY @ MIT-MC>
+
+
+	    The NIC seems to be putting CPU types of "SYMBOLICS-3600"
+	    on things, while our local tables say "3600".  This makes
+	    the HOSTS3 compiler print silly warnings, so I edited the
+	    HSTNIC file to use the "3600" convention.  Someone should
+	    decide which they would rather see, and get everyone to use it.
+
+	SYMBOLICS-3600 is the way SCRC wanted their hosts listed.  I guess
+	that is the new convention...
+
+When I first had SCRC-Peace added to the NIC host table, I told them
+that it was a Symbolics 3600.  They assigned the machine type
+"SYMBOLICS-3600" to it.  I followed their lead from then on.
+
+Date: 3 March 1984 13:16-EST
+From: Daniel J. Carnese <DJC @ MIT-MC>
+To: INFO-HOSTS @ MIT-MC
+
+MIT-LCS-HQ is now at LCS 12/200.
+
+Date: Thu 1 Mar 84 15:42:02-EST
+From: John Wroclawski <JTW%MIT-SPEECH@MIT-MC.ARPA>
+To: info-hosts@MIT-MC
+cc: smh%MIT-EDDIE@MIT-MC.ARPA
+
+
+HOSTS 724 and HSTMIT 170 add Chaos sites MIT-EMS (6401), MIT-HAYDN (6402),
+and MIT-WAIF (6420). Additionally, MIT-INFINITE (bldg 8 bridge) has grown
+a new address 6410.
+
+Subnet vultures will note that this constitutes the (re)activation of
+subnet 15 as part of the Big Picture.
+
+-------
+
+Received: from SCRC-EUPHRATES by SCRC-QUABBIN with CHAOS; Wed 29-Feb-84 15:42:10-EST
+Date: Wed, 29 Feb 84 15:41 EST
+From: "David A. Moon" <Moon%SCRC-TENEX@MIT-MC.ARPA>
+Subject: When is a pdp-10 not a pdp-10
+To: bug-ftp@MIT-MC.ARPA
+Cc: gsb@MIT-MC.ARPA, info-hosts@MIT-MC.ARPA
+
+    ftp.  Really, it's user-interface brain death.  You see it used
+    to do-the-right-thing between pdp10s and now it doesn't.  We expected
+    without thinking that it would.  (I think that was it anyway;  transfering
+    in ascii rather than 36bit).  It's not like it lies or anythign, but
+    that the default used to be adequate for any file transfer, and who
+    really looks at spastic program printout anyway....
+Someone changed the machine type in the host table of all the pdp10s from
+"PDP10" to imaginative things like "DEC-10", "DEC-1080".  Thus FTP can no
+longer tell when a machine is a pdp10.  Probably this was imposed on us by
+the NIC.  Someone should give FTP a list of all the known pdp10 machines or
+all the known pdp10 operating systems, replacing the present code in the
+NHOSTN routine.
+
+Presumably this is an attempt to get us all to switch to Unix.
+
+Date: Sun 26 Feb 84 22:28:29-EST
+From: John T. Wroclawski <JTW@MIT-XX.ARPA>
+To: info-hosts@MIT-MC.ARPA, bcn%MIT-EECS@MIT-XX.ARPA
+
+
+HOSTS 723 and HSTMIT 169 add MIT-MATH-HUB at chaos 7740 (SN17, 340),
+a MINITS box out at the end of Bldg 2.
+
+It appears there is life out there after all.
+-------
+
+Date: 25 February 1984 15:07-EST
+From: David C. Plummer <DCP @ MIT-MC>
+To: DCP @ MIT-MC
+cc: INFO-HOSTS @ MIT-MC, Hornig @ SCRC-TENEX,
+    LispM-Networks @ SCRC-TENEX
+
+    Date: 25 February 1984 14:59-EST
+    From: David C. Plummer <DCP @ MIT-MC>
+
+        Date: 24 February 1984 18:08-EST
+        From: Christopher C. Stacy <CSTACY @ MIT-MC>
+
+        The NIC seems to be putting CPU types of "SYMBOLICS-3600"
+        on things, while our local tables say "3600".  This makes
+        the HOSTS3 compiler print silly warnings, so I edited the
+        HSTNIC file to use the "3600" convention.  Someone should
+        decide which they would rather see, and get everyone to use it.
+
+    Charlie, what's the story here?
+
+    (The rest of you, don't expect an answer very soon, he's on
+    vacation for another week or so.)
+
+Ignore me.  I should have read all my mail first.
+
+    Date: 24 February 1984 20:33-EST
+    From: Ken Harrenstien <KLH @ MIT-MC>
+    To: CSTACY @ MIT-MC
+    cc: INFO-HOSTS @ MIT-MC
+
+        Date: 24 February 1984 18:08-EST
+        From: Christopher C. Stacy <CSTACY @ MIT-MC>
+
+
+        The NIC seems to be putting CPU types of "SYMBOLICS-3600"
+        on things, while our local tables say "3600".  This makes
+        the HOSTS3 compiler print silly warnings, so I edited the
+        HSTNIC file to use the "3600" convention.  Someone should
+        decide which they would rather see, and get everyone to use it.
+
+    SYMBOLICS-3600 is the way SCRC wanted their hosts listed.  I guess
+    that is the new convention...
+
+Date: 25 February 1984 14:59-EST
+From: David C. Plummer <DCP @ MIT-MC>
+To: Hornig @ SCRC-TENEX
+cc: INFO-HOSTS @ MIT-MC, LispM-Networks @ SCRC-TENEX
+
+    Date: 24 February 1984 18:08-EST
+    From: Christopher C. Stacy <CSTACY @ MIT-MC>
+
+    The NIC seems to be putting CPU types of "SYMBOLICS-3600"
+    on things, while our local tables say "3600".  This makes
+    the HOSTS3 compiler print silly warnings, so I edited the
+    HSTNIC file to use the "3600" convention.  Someone should
+    decide which they would rather see, and get everyone to use it.
+
+Charlie, what's the story here?
+
+(The rest of you, don't expect an answer very soon, he's on
+vacation for another week or so.)
+
+Date: 24 February 1984 20:33-EST
+From: Ken Harrenstien <KLH @ MIT-MC>
+To: CSTACY @ MIT-MC
+cc: INFO-HOSTS @ MIT-MC
+
+    Date: 24 February 1984 18:08-EST
+    From: Christopher C. Stacy <CSTACY @ MIT-MC>
+
+
+    The NIC seems to be putting CPU types of "SYMBOLICS-3600"
+    on things, while our local tables say "3600".  This makes
+    the HOSTS3 compiler print silly warnings, so I edited the
+    HSTNIC file to use the "3600" convention.  Someone should
+    decide which they would rather see, and get everyone to use it.
+
+SYMBOLICS-3600 is the way SCRC wanted their hosts listed.  I guess
+that is the new convention...
+
+Date: 24 February 1984 18:08-EST
+From: Christopher C. Stacy <CSTACY @ MIT-MC>
+To: INFO-HOSTS @ MIT-MC
+
+
+The NIC seems to be putting CPU types of "SYMBOLICS-3600"
+on things, while our local tables say "3600".  This makes
+the HOSTS3 compiler print silly warnings, so I edited the
+HSTNIC file to use the "3600" convention.  Someone should
+decide which they would rather see, and get everyone to use it.
+
+Date: 21 February 1984 04:07-EST
+From: Christopher C. Stacy <CSTACY @ MIT-MC>
+To: INFO-HOSTS @ MIT-MC
+
+Latest NIC table installed on MC and ML.
+
+Received: by mit-borax.ARPA (4.12/4.7)
+	id AA03676; Sun, 12 Feb 84 00:35:01 est
+Date: Sun, 12 Feb 84 00:35:01 est
+From: romkey@mit-borax (John L. Romkey)
+Message-Id: <8402120535.AA03676@mit-borax.ARPA>
+To: info-hosts@mit-mc
+Subject: additions to hstmit
+
+Well, addition. I added mit-pluto, another ibm pc. I also changed the
+host type for mit-borax from vax to vax-11/750 so that lisp machines
+wouldn't complain that it was different from the type in the nic name
+table.
+							- John Romkey
+							  romkey@mit-borax
+
+Date: Fri, 10 Feb 1984  23:21 EST
+Message-ID: <CJL.11990776310.BABYL@MIT-OZ>
+From: CJL%MIT-OZ@MIT-MC.ARPA
+To:   INFO-HOSTS@MIT-MC
+
+I have changes mc:syseng;hstmit > and mc:syseng;hosts > :
+
+Chaosnet host MIT-PREP now is at Chaosnet addresses 13016 and 3413.
+
+
+Date: 8 February 1984 18:31 EST
+From: Patrick A O'Donnell <PAO @ MIT-MC>
+To: INFO-HOSTS @ MIT-MC
+
+Added MIT-COUGAR at CHAOS 3033.  Did not compile.
+
+Date: 8 February 1984 15:24 EST
+From: Richard Mark Soley <SOLEY @ MIT-MC>
+Subject: MAHOGANY
+To: INFO-HOSTS @ MIT-MC
+
+Added MIT-MAHOGANY (HO) to the Lisp Machine Forest.
+Moved MIT-NETLEAF-HACKBERRY to subnet 26..
+
+	-- Richard
+
+Date: 2 February 1984 01:32 EST
+From: Christopher C. Stacy <CSTACY @ MIT-MC>
+To: INFO-HOSTS @ MIT-MC
+
+Latest NIC host table installed on MC and ML.
+
+Date: 23 Jan 1984 15:41:04-EST
+From: roger at mit-dspg
+To: CStacy@mit-mc, INFO-HOSTS@mit-mc
+Subject: Re:  new host table available
+
+I and Sylvester wish to invite all to share in a quick dance of hosannas
+upon becoming an official member of the community.  I thought
+after I sent my note that it was not all that coherent as to what
+it was requesting; I am most impressed at how much you have managed
+to draw out of it.  Several of us would beg to differ, however, on
+the spelling of PUDDYTAT, and would ask to include this one as
+a further nickname.  Many many thanks regardless!
+
+	roger@dspg
+
+Date: 23 Jan 1984 15:41:04-EST
+From: roger at mit-dspg
+To: CStacy@mit-mc, INFO-HOSTS@mit-mc
+Subject: Re:  new host table available
+
+I and Sylvester wish to invite all to share in a quick dance of hosannas
+upon becoming an official member of the community.  I thought
+after I sent my note that it was not all that coherent as to what
+it was requesting; I am most impressed at how much you have managed
+to draw out of it.  Several of us would beg to differ, however, on
+the spelling of PUDDYTAT, and would ask to include this one as
+a further nickname.  Many many thanks regardless!
+
+	roger@dspg
+
+Date: 23 January 1984 15:50 EST
+From: Christopher C. Stacy <CSTACY @ MIT-MC>
+Subject: sufferin' succotash
+To: INFO-HOSTS @ MIT-MC, roger @ MIT-DSPG
+
+I corrected the spelling of PUDDYTAT on the source.
+
+Date: Monday, 23 January 1984, 13:32-EST
+From: Christopher C. Stacy <CStacy at MIT-MC>
+Subject: "PFC"
+To: John G. Aspinall <JGA at MIT-MC>
+Cc: INFO-HOSTS at MIT-MC
+In-reply-to: The message of 23 Jan 84 10:13-EST from John G. Aspinall <JGA at MIT-MC>
+
+    Date: 23 January 1984 10:13 EST
+    From: John G. Aspinall <JGA @ MIT-MC>
+    Could I petition for the nickname "PFC" to be changed to apply to
+    MIT-PFC-VAX (a server) and not MIT-FUSION (a terminal concentrator).
+
+I removed the "PFC" and "PFC-11" nicknames from the PLASMA concentrator,
+in the source.  Will take effect next time there is a significant update.
+
+Date: Monday, 23 January 1984, 13:06-EST
+From: Christopher C. Stacy <CStacy at MIT-MC>
+Subject: new host table available
+To: INFO-HOSTS at MIT-MC
+Cc: roger at mit-dspg, dove at mit-dspg, root at PUTTYTAT
+In-reply-to: The message of 12 Jan 84 09:24-EST from roger at mit-dspg
+
+I added MIT-SYLVESTER, a DSPG VAX running Unix at 15421 on the Chaosnet.  
+Has nicknames SYLVESTER, PUTTYTAT, and SYL.  Updated host tables on MC
+and ML (someone should copy them to OZ and XX, etc.)
+
+Chris
+
+Date: 18 January 1984 10:53 EST
+From: Charles Hornig <CAH @ MIT-MC>
+To: INFO-HOSTS @ MIT-MC
+
+Copied NIC:<NETINFO>HOSTS.TXT.325 to MC and recompiled tables.
+
+Date: 10 Jan 1984 18:04:41-PST
+From: romkey@MIT-BORAX
+Real-name: John L. Romkey
+To: info-hosts@mc
+Subject: name table additions
+
+I added two hosts, MIT-PEPSI and MIT-SELTZER, to hstmit on mc.
+						- John
+
+Date: 9 Jan 1984 21:52:52-PST
+From: romkey@MIT-BORAX
+Real-name: John L. Romkey
+To: info-hosts@mc
+Subject: added two hosts
+
+Hi,
+	I added two hosts (MIT-COKE and MIT-DR-PEPPER, two Now machines) to
+the host tables.
+							- John
+
+Received: from SCRC-CHARLES by SCRC-QUABBIN with CHAOS; Wed 4-Jan-84 20:29:22-EST
+Date: Wed, 4 Jan 84 20:33 EST
+From: "David C. Plummer" <DCP%SCRC-TENEX@MIT-MC.ARPA>
+Subject: Some machines really do care what garbage gets put in databases...
+To: Hostmaster@SRI-NIC.ARPA
+Cc: LispM-Networks%SCRC-TENEX@MIT-MC.ARPA, Info-hosts@MIT-MC.ARPA,
+    lwa@MIT-XX.ARPA
+In-reply-to: The message of 31 Dec 83 17:46-EST from David C. Plummer <DCP at SCRC-TENEX>,
+             The message of 4 Jan 84 17:15-EST from lwa at MIT-CSR
+
+Please remove the TCP/SUPDUP service entry from MIT-BORAX; BORAX does
+not currently (and has never to my knowledge) had a SUPDUP server.
+


### PR DESCRIPTION
The HOSTS3 program had binaries in both SYSHST; TS HOSTS3 and SYSHST; HOSTS3 BIN.  The former makes it much easier to build the host table.

Also adds SYSHST documentation files.