### PR TITLE
Make hostname and Chaosnet address configurable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,8 @@ SIMH=${PWD}/tools/simh/BIN/pdp10
 ITSTAR=${PWD}/tools/itstar/itstar
 WRITETAPE=${PWD}/tools/tapeutils/tapewrite
 
+H3TEXT=$(shell cd build; ls h3text.*)
+
 all: out/rp0.dsk tools/supdup/supdup
 
 out/rp0.dsk: build/simh/init out/minsys.tape out/salv.tape out/dskdmp.tape build/build.tcl out/sources.tape build/$(EMULATOR)/stamp
@@ -33,7 +35,7 @@ out/minsys.tape: $(ITSTAR)
 	mkdir -p out
 	cd bin; $(ITSTAR) -cf ../$@ $(MINSYS)
 
-out/sources.tape: $(ITSTAR) build/$(EMULATOR)/stamp src/syshst/h3text.2012
+out/sources.tape: $(ITSTAR) build/$(EMULATOR)/stamp src/syshst/$(H3TEXT)
 	mkdir -p out
 	rm -f src/*/*~
 	cd src; $(ITSTAR) -cf ../$@ $(SRC)
@@ -63,7 +65,7 @@ build/simh/stamp: $(SIMH) start
 build/klh10/dskdmp.ini: build/klh10/dskdmp.txt Makefile
 	sed -e 's/%IP%/$(IP)/' -e 's/%GW%/$(GW)/' < $< > $@
 
-src/syshst/h3text.2012: build/h3text.2012
+src/syshst/$(H3TEXT): build/$(H3TEXT)
 	sed -e 's/%IP%/$(IP)/' < $< > $@
 
 $(KLH10):

--- a/build/h3text.2012
+++ b/build/h3text.2012
@@ -178,6 +178,6 @@ HOST : 36.21.0.103 : Hamlet.Stanford.EDU,LOTSC : DEC-2060 : TOPS20 :  :
 
 ;;; KLH: All of the rest of this stuff was flushed... see older versions
 ;;; of H3TEXT for the cruft.
-HOST : %IP% : DB-ITS.EXAMPLE.COM, DB : PDP-10 : ITS : :
+HOST : %CHAOS%%IP% : %HOSTNAME%, DB : PDP-10 : ITS : :
 
 

--- a/build/klh10/.gitignore
+++ b/build/klh10/.gitignore
@@ -1,4 +1,5 @@
 APR.TIMEBASE
+dpchudp
 dpimp
 dprpxx
 dptm03

--- a/build/klh10/config.203
+++ b/build/klh10/config.203
@@ -1071,7 +1071,7 @@ IFN IPUNCP,IFE CHAOSP,.ERR Chaosnet must exist for IP encapsulation scheme
 ;Chaos-specific parameters
 IFN CHAOSP,IFNDEF MYCHAD, .ERR MYCHAD must be defined as CHAOSnet host addr
 IFN CHAOSP,DEFOPT IMPUS4==<<IPADDR 128,31,0,0>+MYCHAD>	; MIT Chaosnet IP addr
-IFN CHAOSP,DEFOPT NM%CHA==<IPMASK IMPUS4>	; Set default netmask for it
+IFN CHAOSP,DEFOPT NM%CHA==<IPADDR 255,255,0,0>	; Set default netmask for it
 DEFOPT NINDX==0		; Number of indices for CHAOS connections
 DEFOPT CH10P==0		;1= CHAOS net via PDP-10 I/O bus
 DEFOPT CH11P==0		;1= CHAOS net via Unibus Chaos board on KS10

--- a/build/klh10/config.203
+++ b/build/klh10/config.203
@@ -989,6 +989,10 @@ DEFOPT IMPUS==100.	; IMP net host number (old-style) (100 octal)
 DEFOPT IMPUS3==<IPADDR %IP%>	; IP address
 DEFOPT NM%IMP==<IPADDR %NETMASK%>	; Subnet mask
 DEFOPT PKTTRC==-1	;Packet tracing code enabled
+DEFOPT CHAOSP==%CHAOSP% ;Has CHAOS net
+DEFOPT MYCHAD==%CHAOSA% ;CHAOS net address
+DEFOPT NINDX==50.       ;Number of indices
+DEFOPT CH11P==%CHAOSP%  ;CHAOS net goes through Unibus
 
 DEFINE ITSIRP BODY
 IRPS ITS,,[DB]

--- a/build/klh10/dskdmp.txt
+++ b/build/klh10/dskdmp.txt
@@ -20,7 +20,7 @@ devdef imp  ub3   lhdh   addr=767600 br=6 vec=250 ipaddr=%IP% gwaddr=%GW%
 ; Dummy definitions.  Only one DZ is still (apparently) needed.
 devdef dz0  ub3   dz11   addr=760010 br=5 vec=340
 ;devdef dz1  ub3   dz11   addr=760020 br=5 vec=350
-;devdef chaos ub3  ch11   addr=764140 br=5 vec=270
+%CHAOSP%devdef chaos ub3  ch11   addr=764140 br=6 vec=270 %CHAOSA%
 
 ; Define new HOST device hackery
 ;devdef idler ub3 host addr=777000


### PR DESCRIPTION
Adds hostname and Chaosnet address as Makefile variables that will configure the built ITS.

Update KLH10 to a version that supports @bictorv's CH11.