### PR TITLE
Run ICHECK after full dump

### DIFF
--- a/build/build.tcl
+++ b/build/build.tcl
@@ -1389,6 +1389,9 @@ type ":dump\r"
 respond "_" "dump links full\r"
 respond "TAPE NO=" "0\r"
 expect "REEL"
+respond "_" "rewind\r"
+respond "_" "icheck\r"
+respond "=" "\r"
 respond "_" "quit\r"
 
 shutdown


### PR DESCRIPTION
This sets the "dumped" bit on all files.  Or whatever the bit is called that is output as "!" in directory listings.

ICHECK checks the tape number.  When it sees 0, it asks for confirmation.   Maybe the tape number should start at 1.  Or maybe 0 is good for this purpose.