### PR TITLE
SYS; ATSIGN CHAOS

### DIFF
--- a/build/build.tcl
+++ b/build/build.tcl
@@ -536,7 +536,7 @@ expect ":KILL"
 # Chaosnet support
 respond "*" ":midas sysbin;_syseng;@chaos\r"
 expect ":KILL"
-respond "*" ":link device;atsign chaos,sysbin;@chaos bin\r"
+respond "*" ":link sys;atsign chaos,sysbin;@chaos bin\r"
 
 respond "*" ":link syseng;netwrk 999999,sysnet;netwrk >\r"
 


### PR DESCRIPTION
@CHAOS is currently assembled to SYSBIN and linked from DEVICE; ATSIGN CHAOS.  The link should be from SYS; ATSIGN CHAOS instead.