### PR TITLE
C compiler is not KCC

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ A list of [known ITS machines](doc/machines.md).
    - BITPRT, print JCL as bits.
    - BYE, say goodbye to user. Used in LOGOUT scripts.
    - CALPRT, decode a .CALL instructions CALL block.
+   - CC, C compiler (binary only).
    - CHADEV, Chaosnet jobdev (binary only).
    - CHARFC/CHARFS, Chaos RFC.
    - CHATST, Chaos test.
@@ -165,7 +166,6 @@ A list of [known ITS machines](doc/machines.md).
    - INSTAL, install executables on other ITS machines.
    - ITSDEV, ITS device server.
    - JOBS, list jobs by category.
-   - KCC, C compiler (binary only).
    - LISP, lisp interpreter and runtime library (autoloads only).
    - LOADP, displays system load.
    - LOCK, shut down system.


### PR DESCRIPTION
I'm now fairly sure the C compiler in the C directory isn't KCC.  C; CDOC 91 and C; C REFMAN mention the name Alan Snyder.

> The C compiler and the support packages were written by Alan Snyder.

I believe this document describes the compiler:  
http://publications.csail.mit.edu/lcs/pubs/pdf/MIT-LCS-TR-149.pdf

The files in KCC are probably only a small subset of the KCC ITS port that was being done around 1988.