### PR TITLE
Support idling in emulators

### DIFF
--- a/build/klh10/config.203
+++ b/build/klh10/config.203
@@ -921,6 +921,7 @@ TERMIN
 
 IFE MCOND DB,[		;DistriBution world
 DEFOPT KS10P==1		;DB is a KS10 
+DEFOPT KLH10P==1	;(actually a KLH10)
 
 IF1,[
 PRINTX /Configuration? (RP06, RP07, RM03 or RM80) /

--- a/build/klh10/dskdmp.txt
+++ b/build/klh10/dskdmp.txt
@@ -23,7 +23,7 @@ devdef dz0  ub3   dz11   addr=760010 br=5 vec=340
 %CHAOSP%devdef chaos ub3  ch11   addr=764140 br=6 vec=270 %CHAOSA%
 
 ; Define new HOST device hackery
-;devdef idler ub3 host addr=777000
+devdef idler ub3 host addr=777000
 
 load @.ddt-u
 load dskdmp.216bin

--- a/build/simh/boot
+++ b/build/simh/boot
@@ -1,4 +1,5 @@
 set cpu its
+set cpu idle
 set tim y2k
 set rp0 rp06
 at rp0 out/rp0.dsk


### PR DESCRIPTION
Both SIMH and KLH10 supports saving host CPU cycles when the target operating system is idling.

- For SIMH, just throw a configuration toggle, and it detects the idle loop automatically.
- For KLH10, configure a special device and patch the operating system to use it.