### PR TITLE
Add back delay in 'type'

### DIFF
--- a/build/build.tcl
+++ b/build/build.tcl
@@ -13,6 +13,7 @@ proc type s {
 	} else {
 	    expect "?"
 	}
+	sleep .03
     }
 }
 


### PR DESCRIPTION
Restore the delay in the build script function that sends keypresses.

Without them, the expect script may not recognize keywords in output.