### PR TITLE
Build standalone version of MIDAS.

### DIFF
--- a/build/build.tcl
+++ b/build/build.tcl
@@ -343,6 +343,11 @@ respond "*" ":midas sys1;ts salv_system;salv\r"
 respond "time-sharing?" "y\r"
 expect ":KILL"
 
+# standalone midas
+respond "*" ":midas /t .;@ midas_midas;midas\r"
+respond "with ^C" "TS==0\r\003"
+expect ":KILL"
+
 # magdmp
 respond "*" ":midas .;_syseng;magdmp\r"
 respond "PTRHRI=" "y\r"


### PR DESCRIPTION
The latest version of MIDAS still retains the ability of standalone operation. 

Not tested at all.  I don't see much in the way of I/O instructions, so I'm guessing input and output goes from/to memory.  There's probably an AI memo for this.

Together with #662 and exec DDT, this forms a complete toolchain for standalone programming:

- Editing with TECO
- Assemling with MIDAS
- Linking with STINK
- Debugging with DDT

These can be run from DSKDMP, but they probably want access to a DECtape unit.  So MACDMP would be nice too, see #449.