### PR TITLE
SEND programs

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,7 @@ A list of [known ITS machines](doc/machines.md).
    - SALV, old file system tool for KA and KL.
    - SCANDL, TTY OUTPUT SPY.
    - SEND, REPLY, replacements for DDT :SEND.
+   - SENSOR, sends censor.
    - SENVER, Chaosnet SEND server.
    - SN, snoop terminal.
    - SPELL, ESPELL spell checker.

--- a/README.md
+++ b/README.md
@@ -246,6 +246,7 @@ A list of [known ITS machines](doc/machines.md).
    - SALV, old file system tool for KA and KL.
    - SCANDL, TTY OUTPUT SPY.
    - SEND, REPLY, replacements for DDT :SEND.
+   - SENDS, Chaosnet SEND server.
    - SENSOR, sends censor.
    - SENVER, Chaosnet SEND server.
    - SN, snoop terminal.

--- a/README.md
+++ b/README.md
@@ -246,6 +246,7 @@ A list of [known ITS machines](doc/machines.md).
    - SALV, old file system tool for KA and KL.
    - SCANDL, TTY OUTPUT SPY.
    - SEND, REPLY, replacements for DDT :SEND.
+   - SENVER, Chaosnet SEND server.
    - SN, snoop terminal.
    - SPELL, ESPELL spell checker.
    - SRCCOM, Compares/merges source files, compares binary files.

--- a/build/build.tcl
+++ b/build/build.tcl
@@ -903,6 +903,10 @@ expect ":KILL"
 respond "*" ":midas sys2;ts whosen_syseng;wsent\r"
 expect ":KILL"
 
+# sensor
+respond "*" ":midas sys3;ts sensor_gren;sensor\r"
+expect ":KILL"
+
 # more lisp packages
 respond "*" ":link lisp;tty fasl,liblsp;tty fasl\r"
 respond "*" "complr\013"

--- a/build/build.tcl
+++ b/build/build.tcl
@@ -1456,6 +1456,11 @@ respond "*" ":midas sysbin;_sysnet;senver\r"
 expect ":KILL"
 respond "*" ":link device;chaos send,sysbin;senver bin\r"
 
+# Alternate DEVICE; CHAOS SEND
+respond "*" ":midas sysbin;_sysnet;sends\r"
+expect ":KILL"
+#respond "*" ":link device;chaos send,sysbin;senver bin\r"
+
 # OBS
 respond "*" ":midas sys;ts obs_bawden;obs\r"
 expect ":KILL"

--- a/build/build.tcl
+++ b/build/build.tcl
@@ -1447,6 +1447,11 @@ expect ":KILL"
 respond "*" ":midas device;chaos time_syseng;ctimsr\r"
 expect ":KILL"
 
+# DEVICE; CHAOS SEND
+respond "*" ":midas sysbin;_sysnet;senver\r"
+expect ":KILL"
+respond "*" ":link device;chaos send,sysbin;senver bin\r"
+
 # OBS
 respond "*" ":midas sys;ts obs_bawden;obs\r"
 expect ":KILL"

--- a/src/gren/sensor.87
+++ b/src/gren/sensor.87
@@ -1,0 +1,573 @@
+;-*-Midas-*-
+
+
+	Title :SENSOR - Sends cENSOR
+
+
+A=1	;General porpoise
+B=2
+C=3
+D=4
+J=5
+F=6
+G=7
+
+I=10	;Index
+
+R1=11	;Returns
+R2=12
+R3=13
+
+T1=14	;Transient
+T2=15
+T3=16
+
+P=17	;The obligatory PDL
+
+  Call=<PUSHJ P,>
+Return=<POPJ P,>
+
+TTYo==1
+CLIo==2
+USRi==3
+
+PDLen==15
+JCLen==20
+
+MaxIs==10	;Max # unames to /Ignore
+MaxPs==10	; "  # jnames to /Program
+MaxFs==10	; "  # jnames to /Forward to 
+
+ ;;;
+;;;;;
+ ;;;
+
+Define SYSCAL op,args
+	.Call [Setz ? Sixbit /op/ ? args ((Setz))]
+Termin
+
+Define TYPE &string
+	Movei T1,<.Length string>
+	Move T2,[440700,,[Ascii string]]
+	Syscal SIOT,[%Climm,,TTYo ? T2 ? T1]
+	  .Lose %LsSys
+Termin
+
+ ;;;
+;;;;;
+ ;;;
+
+Keys:	"B  ? "F  ? "I  ? "P  ? "S  ? "V ?  "N
+Hands:	DoB ? DoF ? DoI ? DoP ? DoS ? DoV ? DoN
+NKeys==.-Hands
+
+BFlag:	0
+FFlag:	0
+IFlag:	0
+PFlag:	0
+SFlag:	0
+VFlag:	0
+
+oChan:	TTYo
+
+Uname:	0	;Your uname
+
+Valret:	Ascii ":SELF
+.JNAME/1'HACRTN
+:KILL
+HACTRNJ
+L DSK:KP;SERVER BIN
+:GZP
+ :FORGET
+J :VK "
+
+Numbel:	1		;Number of bells before message
+Verbos:	4		;Verbosity level
+SaveSs:	-1		;0 if not Saving Sends
+
+Device:	Sixbit /DSK/	;Filename of your sends file
+Sname:	Sixbit /.TEMP./
+FN1:	0
+FN2:	Sixbit /SENDS/
+
+Ignore:	0		;# unames we're ignoring
+INames:	Block MaxIs	;da poop
+IValue:	Block MaxIs	;Ignorance level
+
+Sacred:	0		;# special programs
+PNames:	Block MaxPs	;more poop
+PVerb:	Block MaxPs	;Verbosity
+PBell:	Block MaxPs	;Bells.
+
+Forwar:	0		;# jnames to foreward to
+FNames:	Block MaxFs
+FRilly:	Block MaxFs
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;
+;;;	Header-parse cruft that needs to be zeroed every pass goes
+;;;	tween the Zer's.  Contents of ZerTop is written over it all.
+;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+ZerTop:	0	;Had better be zero!
+
+JOBp:	0	;-1 if print funame/jname and mesage only.
+MAILp:	0	;-1 for mail notification
+YesCLI:	0
+
+Fname:	Block 4	;From Name
+F6name:	0	;6bit name of sender. nonzero iff this is from an ITS site
+
+Fsite:	Block 3	;From Site
+F6Site:	0
+
+FUname:	0	;From Uname/Jname (might be COMSYS or some such)
+FJname:	0
+
+Length:	0	;Length of message
+pText:	0
+
+ZerBot:	0	;Hi, mom.
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;
+;;;	End zeroed stuff
+;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+
+No:	0	;True if this keyword has the /No prefix
+gotFN1:	0
+
+PDList:	-PDLen,,.
+	Block PDLen
+
+JCLbuf:	Block JCLen
+	-1
+
+OB:	"[
+CB:	"]
+EOF:	-1,,3
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;
+;;;	The program (finally) begins
+;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+Begin:	Move P,PDList
+	Syscal OPEN,[%Clbit,,.uao\%TJDIS
+		     %Climm,,TTYo
+		     [Sixbit /TTY/]]
+	  .Lose %LsFil
+	.Suset [.rUNAME,,Uname]
+
+JCLp:	.Break 12,[..rJCL,,JCLbuf]
+	Skipn JCLbuf
+	  Jrst Go		;No JCL to parse
+	Move J,[350700,,Jclbuf]
+
+NabCmd:	Setzm No
+	Call Getcmd
+	  Jrst Go		;Nothing more to get
+	Movsi T1,NKeys
+Fcomd:	Camn R1,Keys(T1)
+	  Jrst @Hands(T1)
+	Aobjn T1,Fcomd
+
+	Type "Unknown command: '"
+	.Iot TTYo,R1
+	.Iot TTYo,["']
+	Jrst JCLerr
+
+;;;
+;;;	/BELLS nnn
+;;;
+
+DoB:	Call Getnum
+	  Jrst NoNum
+	Cail R1,10.
+	  Jrst BadNum
+	Movem R1,Numbel
+	Setom BFlag
+	Jrst NabCmd
+
+;;;
+;;;	/VERBOSITY nnn
+;;;
+
+DoV:	Call Getnum
+	  Jrst NoNum
+	Caile R1,3
+	  Jrst BadNum
+	Movem R1,Verbos
+	Setom VFlag
+	Jrst NabCmd
+
+;;;
+;;;	[/NO] /PROGRAM uname bells verbosity ...
+;;;
+
+DoP:	Setz B,
+	Call GetSix
+	  Jrst NoArg
+DoP2:	Cail B,MaxPs
+	  Jrst ToMany
+	Move C,R1
+	Call GetNum
+	  Jrst [Movei R1,1	;B=1
+		Movei R2,2	;V=2
+		Jrst SaveP]
+	IDivi R1,10.
+	Caig R1,9.
+	  Caile R2,3
+	    Jrst BadNum
+SaveP:	Movem C,PNames(B)
+	Movem R2,PVerb(B)
+	Movem R1,PBell(B)
+	Call GetSix
+	  Jrst [Aoj B,
+		Movem B,Sacred
+		Setom PFlag
+		Jrst NabCmd]
+	Aoja B,DoP2
+
+;;;
+;;;	[/NO] /SENDSAVE dev:sname;fn1 fn2
+;;;
+
+DoS:	Skipe No
+	  Jrst [Setzm SaveSs
+		Jrst NabCmd]
+	Setom SaveSs
+	Setzm gotFN1
+	Setom SFlag
+gFile:	Call GetSix
+	  Jrst NabCmd
+	Cain R2,":
+	  Jrst [Movem R1,Device
+		Jrst gFile]
+	Cain R2,";
+	  Jrst [Movem R1,Sname
+		Jrst gFile]
+	Movei T1,FN1
+	Skipe gotFN1
+	  Aoj T1,
+	Movem R1,(T1)
+	Setom GotFN1
+	Jrst gFile
+
+;;;
+;;;	[/NO] /IGNORE uname intensity ...
+;;;
+
+DoI:	Setz B,
+	Call GetSix
+	  Jrst NoArg
+DoI2:	Cail B,MaxIs
+	  Jrst ToMany
+	Skipe No
+	  Jrst [Setom IValue(B)
+		Jrst DoI3]
+	Move C,R1
+	Call GetNum
+	  Jrst NoNum
+	Movem R1,IValue(B)
+DoI3:	Movem C,INames(B)
+	Call GetSix
+	  Jrst [Aoj B,
+		Movem B,Ignore
+		Setom IFlag
+		Jrst NabCmd]
+	Aoja B,DoI2
+
+;;;
+;;;	[/NO] /FORWARD jname ...
+;;;
+
+DoF:	Setz B,
+	Call GetSix
+	  Jrst NoArg
+DoF2:	Cail B,MaxFs
+	  Jrst ToMany
+	Movem R1,FNames(B)
+	Move T1,No
+	Movem T1,FRilly(B)
+	Call GetSix
+	  Jrst [Aoj B,
+		Movem B,Forwar
+		Setom FFlag
+		Jrst NabCmd]
+	Aoja B,DoF2
+
+DoN:	Setcmm No
+	Jrst NabCmd
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;
+;;;	JCL is all parsed - Now we summon a new server, or just
+;;;	ship off these params to an existing one.
+;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+Go:	Syscal OPEN,[%Clbit,,.bii
+		     %Climm,,USRi
+		     [Sixbit /USR/]
+		     Uname
+		     ['HACRTN]]
+	  .Value Valret
+	.Close USRi,
+	Syscal OPEN,[%Clbit,,.uao
+		     %Climm,,CLIo
+		     [Sixbit /CLI/]
+		     Uname
+		     ['HACTRN]]
+	  Jrst CantS
+	.Iot CLIo,[177]
+	.Iot CLIo,[177]			;Set up lead-in sequence
+
+;;;
+;;;	<0><#of bells>
+;;;
+
+SendB:	Skipn BFlag
+	  Jrst SendF
+	.Iot CLIo,[0]
+	.Iot CLIo,Numbel
+
+;;;
+;;;	<1><number><jname 1><0><jname 2><0> ...
+;;;
+
+SendF:	Skipn FFlag
+	  Jrst SendI
+	.Iot CLIo,[1]
+	.Iot CLIo,Forwar
+	Movn A,Forwar
+	Movss A
+SendFl:	Move T1,FNames(A)
+	Call 6Type
+	.Iot CLIo,[0]
+	Aobjn A,SendF
+
+;;;
+;;;	<2><number><ignorance 1><uname 1><0><ignorance 2><uname 2><0> ...
+;;;
+
+SendI:	Skipn IFlag
+	  Jrst SendP
+	.Iot CLIo,[2]
+	.Iot CLIo,Ignore
+	Movn A,Ignore
+	Movss A
+SendI1:	.Iot CLIo,IValue(A)
+	Move T1,INames(A)
+	Call 6Type
+	.Iot CLIo,[0]
+	Aobjn A,SendI1
+
+;;;
+;;;	<3><number><verbosity 1><bells 1><jname 1><0> ...
+;;;
+
+SendP:	Skipn PFLag
+	  Jrst SendS
+	.Iot CLIo,[3]
+	.Iot CLIo,Sacred
+	Movn A,Sacred
+	Movss A
+SendP1:	.Iot CLIo,PVerb(A)
+	.Iot CLIo,PBell(A)
+	Move T1,PNames(A)
+	Call 6Type
+	Aobjn A,SendP1
+
+;;;
+;;;	<4><flag>[<device><0><sname><0><fn1><0><fn2><0>]
+;;;
+
+SendS:	Skipn SFlag
+	  Jrst SendV
+	.Iot CLIo,[4]
+	.Iot CLIo,SaveSs
+	Skipn SaveSs
+	  Jrst SendV
+	Move T1,Device
+	Call 6Type
+	.Iot CLIo,[0]
+	Move T1,Sname
+	Call 6Type
+	.Iot CLIo,[0]
+	Move T1,FN1
+	Call 6Type
+	.Iot CLIo,[0]
+	Move T1,FN2
+	Call 6Type
+	.Iot CLIo,[0]
+
+;;;
+;;;	<5><verbosity>
+;;;
+
+SendV:	Skipn SendV
+	  Jrst Finish
+	.Iot CLIo,[5]
+	.Iot CLIo,Verbos
+
+Finish:	.Close CLIo,
+	Type "[Arghs sent]"
+	Jrst Die
+
+
+ ;;;
+;;;;;
+ ;;;
+
+
+
+NoNum:	Type "Missing numeric argument?"
+	Jrst JCLerr
+
+BadNum:	Type "Numeric argument out of valid range?"
+	Jrst JCLerr
+
+NoArg:	Type "Missing argument?"
+	Jrst JCLerr
+
+BadArg:	Type "Invalid argument?"
+	Jrst JCLerr
+
+ToMany:	Type "Too many arguments?"
+
+JCLerr:	.Iot TTYo,[^P]
+	.Iot TTYo,["A]
+	Move A,[440700,,JCLbuf]
+JEloop:	Ildb T1,A
+	Jumpe T1,Die
+	Cail T1,40
+	  .Iot TTYo,T1
+	Came A,J
+	  Jrst JEloop
+	.Iot TTYo,["<]
+	.Iot TTYo,["-]
+	Jrst JEloop
+
+CantS:	Type "Can't send arguments to HACTRN"
+
+DIE:	.Logout 1,
+
+6Type:	Setz T2,
+	Rotc T1,6
+	Addi T2,40
+	.Iot CLIo,T2
+	Jumpn T1,6Type
+	Return
+
+GCmOne:	Ibp J
+GetCmd:	Ldb T1,J
+	Caie T1,40	;Skip leading whitespace
+	  Cain T1,^I
+	    Jrst GCmOne
+	Caie T1,^M	;Die on ^C, ^M, ^_, ^@
+	  Cain T1,^C
+	    Return
+	Skipe T1
+	  Cain T1,^_
+	    Return
+	Caie T1,"/	;Ah, we found the "/"!
+	  Jrst GCmOne
+	Ildb R1,J	;Get the command-char
+	Cail R1,"a
+	  Trz R1,40	;Uppercase it
+
+Gc2:	Ildb T1,J
+	Caie T1,40
+	  Cain T1,"=
+	    Jrst PopJ1
+	Caie T1,^I
+	  Cain T1,",
+	    Jrst PopJ1
+	Jumpn T1,GC2
+	Jrst PopJ1
+
+GetSix:	Setz R1,
+	Movei T3,6
+	Move T2,[440600,,R1]
+	Ildb R2,J
+	Caie R2,40
+	  Cain R2,^I
+	    Jrst .-3
+	Skipa
+g6Char:	Ildb R2,J
+	Caie R2,^M
+	  Cain R2,^C
+	    Jrst 6Check
+	Skipe R2
+	  Cain R2,"/
+	    Jrst 6Check
+	Caie R2,";
+	  Cain R2,":
+	    Jrst 6Check
+	Cain R2,40
+	  Jrst 6Check
+	Jumpe T3,g6Char
+	Cail R2,"a
+	  Trz R2,40
+	Subi R2,40
+	Idpb R2,T2
+	Soja T3,g6Char
+
+6Check:	Caie T3,6
+	  Jrst PopJ1
+	Return
+
+GetNum:	Setz T3,
+	Ildb T1,J
+	Caie T1,40
+	  Cain T1,^I
+	    Jrst GetNum
+	Skipa
+gNChar:	Ildb T1,J
+	Caie T1,^M
+	  Cain T1,^C
+	    Jrst NCheck
+	Caie T1,"/
+	  Skipn T1
+	    Jrst NCheck
+	Caie T1,40
+	  Cain T1,^I
+	    Jrst NCheck
+	Cail T1,"0
+	  Caile T1,"9
+	    Jrst [Skipn T3
+		    Return
+		  Pop P,T1
+		  Jrst .-3]
+	Subi T1,"0
+	Push P,T1
+	Aoja T3,gNChar
+
+NCheck:	Skipn T3
+	  Return
+	Setz R1,
+	Movei R2,1
+ToTen:	Pop P,T1
+	IMul T1,R2
+	IMuli R2,10.
+	Add R1,T1
+	Sojn T3,ToTen
+	Jrst PopJ1
+
+PopJ1:	Aos (P)
+	Return
+
+ ;;;
+;;;;;
+ ;;;
+
+Variables
+Constants
+
+
+	END Begin

--- a/src/sysnet/sends.24
+++ b/src/sysnet/sends.24
@@ -1,0 +1,351 @@
+;-*-midas-*-
+title sends
+;chaosnet qsend server
+
+a=1
+b=2
+c=3
+d=4
+e=5
+n=7
+t=10
+tt=11
+u=12
+h=13
+p=17
+
+.insrt system;chsdef
+
+usrch==0
+clioch==1
+hstich==2
+chaich==10
+chaoch==11
+
+;hosts2 stuff
+nw%chs==7			;standard network number for chaosnet
+netptr==12			;word 12 of header pointer to network table
+netnum==0			;word 0 of those entries has network number in it
+ntlnam==1			;word 1 has name,,address pointer
+addadr==0			;word 0 of those entries has host's address
+adlsit==1			;word 1 has site,,next addr
+stlnam==0			;word 0 of that has the name
+
+;storage
+debug:	0			;non-zero => .value on barfage
+usrbp:	0			;byte pointer to start of user field
+usrcnt:	0			;count of bytes at that point
+hstbp:	0
+hstcnt:	0
+chapkt:	block %cpmxw		;chaosnet packet goes here
+npdl==17
+pdl:	block npdl
+
+;interrupt handler
+tsint:	loc 42
+	-tsintl,,tsint
+loc tsint
+	p
+	%piioc ? 0 ? -1 ? -1 ? iocerr	;handle ioc errors
+tsintl==.-tsint
+
+iocerr:	jsr die			;cheapo
+
+;error handler
+die:	0
+	skipe debug
+	 .value
+passon:	.logout			;natural causes
+	.value
+
+sndpkt:	setz ? 'PKTIOT ? movei chaoch ? setzi chapkt
+rcvpkt:	setz ? 'PKTIOT ? movei chaich ? setzi chapkt
+
+;main program
+go:	.close 1,		;this can still be open from loading us
+	move p,[-npdl,,pdl-1]
+	.suset [.roption,,t]
+	tlo t,optint		;new style interrupts
+	.suset [.soption,,t]
+	.suset [.smask,,[%piioc]]	;catch ioc errors
+	.call [setz ? 'CHAOSO ? movei chaich ? movei chaoch ? setzi 5]
+	 jsr die
+	move t,[.byte 8 ? %colsn ? 0 ? 0 ? 4]
+	movem t,chapkt
+	move t,[.byte 8 ? "S ? "E ? "N ? "D]
+	movem t,chapkt+%cpkdt
+	.call sndpkt
+	 jsr die
+	movei t,30.*60.
+	skipe debug
+	 hrloi t,177777		;wait forever if debugging
+	.call [setz ? 'NETBLK ? movei chaich ? movei %cslsn ? t ? setzm t]
+	 jsr die
+	caie t,%csrfc		;did we get an rfc for this?
+	 jsr die
+	.call rcvpkt		;yes, read it in
+	 jsr die
+
+	skipe debug		;debugging?
+	 jrst getusr
+	ldb t,[chapkt+$cpksa]	;get source host address
+	move tt,[sixbit /000C00/]	;convert host number to sixbit
+	dpb t,[220300,,tt]
+	lsh t,-3
+	dpb t,[300300,,tt]
+	lsh t,-3
+	dpb t,[360300,,tt]
+	.suset [.ruind,,t]	;incoroporate user index also
+	dpb t,[000300,,tt]
+	lsh t,-3
+	dpb t,[060300,,tt]
+	move t,tt		;save copy for xuname
+	.call [setz
+	       sixbit /LOGIN/
+	       tt ? [sixbit /CHAOS/] ? setz t]
+	 aoja tt,.-1		;error, perhaps need to try other uname
+	.suset [.sjname,,[sixbit /SEND/]]
+	.call [setz ? 'DETACH ? movei %jself ? andi 3 ]
+	 jsr die
+
+;now see to whom this is a message
+getusr:	ldb n,[chapkt+$cpknb]	;get byte count
+	move b,[440800,,chapkt+%cpkdt]	;and pointer to data portion of packet
+getus1:	sojl n,nouser		;didnt specify a user name, barf at them
+	ildb t,b
+	caie t," 		;space?
+	 jrst getus1		;no, keep looking
+	setzb u,h
+	movem b,usrbp
+	movem n,usrcnt
+	move e,[440600,,u]	;get byte pointer to user name we will make
+getus2:	sojl n,gotusr		;count down bytes in rfc
+	ildb t,b
+	cain t," 		;only look at the first token
+	 jrst gotusr
+	cain t,"@		;specifying a hostname?
+	 jrst gethst		;yes
+	caige t,140
+	 subi t,40
+	tlne e,770000
+	 idpb t,e
+	jrst getus2
+
+gethst:	movem b,hstbp		;save start of hostname in rfc
+	movem n,hstcnt
+	move e,[440600,,h]	;byte pointer to hostname
+	jrst getus2
+
+gotusr:	jumpe h,gothst		;didnt specify a host
+	.call [	setz ? 'SSTATU ? movem t ? movem t ? movem t ? movem t ? movem t ? setzm t]
+	 jsr die
+	camn h,t		;specified local host for some reason?
+	 jrst myhost		;yes, optimize
+	came h,[sixbit /AI/]	;places i think i can talk to
+	 camn h,[sixbit /MC/]
+	 jrst gothst
+	came h,[sixbit /ML/]
+	 camn h,[sixbit /DM/]
+	 jrst gothst
+	jrst badhst
+
+myhost:	setz h,
+gothst:	skipn t,h		;was there a foreign host?
+	 skipa t,[sixbit /USR/]	;no, look for local one then
+	 ior t,[sixbit /  USR/]	;yes, use the MLUSR device
+	.call [	setz
+		sixbit /OPEN/
+		movsi 10+.uii ? movei usrch
+		t ? u
+		setz [sixbit /HACTRN/]]
+	 jrst nolog		;apparently not logged in
+	.close usrch,
+
+;guy is apparently there, accept the rfc
+	movei t,%coopn
+	dpb t,[chapkt+$cpkop]
+	.call sndpkt
+	 jsr die
+
+	move t,[440800,,netbuf]
+	movei tt,msgsiz
+	.call [	setz
+		sixbit /SIOT/
+		movei chaich
+		t ? setz tt]
+	 jsr die
+	jumpe tt,toobig		;if we filled up the whole buffer, complain
+	movei n,msgsiz
+	sub n,tt		;get number of bytes we got
+	move e,[440700,,msgbuf]	;now convert message's character set
+	movei t,177		;start with rubout so can have our own header
+	idpb t,e
+	movei c,1		;count bytes we make
+	movei t,[asciz /TTY message from chaosnet site /]
+	pushj p,sout
+	ldb a,[chapkt+$cpksa]
+	hrli a,nw%chs_9		;chaosnet
+	pushj p,hstout
+	movei t,[asciz /:
+/]
+	pushj p,sout
+	move b,[440800,,netbuf]
+cnvmsg:	sojl n,sndmsg
+	ildb t,b
+	cain t,215		;eol becomes crlf
+	 jrst [idpb t,e
+	       movei t,12
+	       aoja c,.+1]
+	cail t,210		;210-214 become 10-14
+	 jrst cnvms1
+	trne t,200		;200-207 are flushed
+	 jrst cnvmsg
+cnvms1:	idpb t,e
+	aoja c,cnvmsg
+
+sndmsg:	skipn t,h
+	 skipa t,[sixbit /CLI/]
+	 ior t,[sixbit /  CLI/]	;using MLCLI device
+	.call [	setz
+		sixbit /OPEN/
+		movsi .uao
+		movei clioch
+		t ? u
+		[sixbit /HACTRN/]]
+	 jrst goaway		;guy logged out fast, send a cls of that
+	move t,[440700,,msgbuf]
+	.call [	setz
+		sixbit /SIOT/
+		movei clioch
+		t ? setz c]
+	 jsr die
+	.close clioch,
+
+	movei t,[asciz /Message send successfully./]
+sndcls:	setz c,
+	move e,[440800,,chapkt+%cpkdt]
+sndcl0:	pushj p,sout
+sndcl2:	dpb c,[chapkt+$cpknb]
+	movei t,%cocls
+	dpb t,[chapkt+$cpkop]
+	.call sndpkt
+	 jsr die
+	.close chaoch,
+	.close chaich,
+	jrst passon		;die of natural causes
+
+telusr:	move tt,[chapkt,,netbuf]
+	blt tt,netbuf+%cpmxw-1	;save losing rfc
+	setz c,
+	move e,[440800,,chapkt+%cpkdt]
+	hrli t,440700
+telus1:	ildb tt,t
+	jumpe tt,telus2
+	idpb tt,e
+	aoja c,telus1
+
+telus2:	addi b,netbuf-chapkt
+telus3:	sojl n,cpopj
+	ildb tt,b
+	idpb tt,e
+	aoja c,telus3
+
+;random error conditions
+nouser:	movei t,[asciz /You must specify the user in the rfc./]
+	jrst sndcls		;didnt say to whome to send
+
+nolog:	movei t,[asciz /User "/]	;guy not around
+	move b,usrbp
+	move n,usrcnt
+	pushj p,telusr
+	movei t,[asciz /" not logged in./]
+	jrst sndcl0
+
+toobig:	movei t,[asciz /Message too long./]
+	jrst sndcls
+
+badhst:	movei t,[asciz /Cannot send messages to "/]
+	move b,hstbp
+	move n,hstcnt
+	pushj p,telusr
+	movei t,[asciz /"./]
+	jrst sndcl0
+
+goaway:	movei t,[asciz /User no longer logged in, message not sent./]
+	jrst sndcls
+
+hstout:	.call [	setz
+		sixbit /OPEN/
+		movsi .uii
+		movei hstich
+		[sixbit /DSK/]
+		[sixbit /HOSTS2/]
+		[sixbit />/]
+		setz [sixbit /SYSBIN/]]
+	 jrst nout
+	.call [	setz
+		sixbit /FILLEN/
+		movei hstich
+		setzm t]
+	 jsr die
+	addi t,1777
+	lsh t,-12		;get page count
+	movsi t,-1(t)
+	xor t,[-1,,hstpag_-12]	;make aobjn pointer to hstpag
+	.call [	setz
+		sixbit /CORBLK/
+		movei %cbndr
+		movei %jself
+		t
+		setzi hstich]
+	 jsr die
+	.close hstich,
+
+fndnet:	ldb d,[331000,,a]	;get network number
+	move b,hstpag+netptr	;pointer to network table
+	move t,hstpag+0(b)	;number of network entries
+	move tt,hstpag+1(b)	;size of those entries
+	addi b,hstpag+2
+fndnt1:	camn d,netnum(b)	;is this our network?
+	 jrst fndhst		;yes, go find host then
+	add b,tt		;point to next network
+	sojg t,fndnt1		;if there are still any to be found
+	jrst nout		;didnt find network, give up
+
+fndhst:	hrrz b,ntlnam(b)	;yes, get address table pointer
+	move t,hstpag+0(b)	;get number of entries
+	move tt,hstpag+1(b)	;and size of each entry
+	addi b,hstpag+2
+fndhs1:	camn a,addadr(b)	;this the right address?
+	 jrst fndnam		;yes, go stick in the asciz name
+	add b,tt		;move to next entry
+	sojg t,fndhs1		;so long as there are more to come
+	jrst nout
+
+fndnam:	hlrz t,adlsit(b)	;get site pointer
+	hlrz t,hstpag+stlnam(t)	;and official name from there, fall into sout to type it
+	addi t,hstpag
+
+sout:	hrli t,440700		;insert asciz string from t to e increment count in c
+sout1:	ildb tt,t
+	jumpe tt,cpopj
+	idpb tt,e
+	aoja c,sout1
+
+nout:	movei t,(a)		;clear network number
+nout0:	jumpe t,cpopj		;cheapo number typer
+	idivi t,10
+	push p,tt
+	pushj p,nout0
+	pop p,tt
+	addi tt,"0
+	idpb tt,e
+	addi c,1
+cpopj:	popj p,
+
+msgsiz==20000
+netbuf:	block msgsiz+3/4
+msgbuf:	block msgsiz+4/5
+hstpag==.\1777+1
+
+end go

--- a/src/sysnet/senver.45
+++ b/src/sysnet/senver.45
@@ -1,0 +1,445 @@
+; -*- Midas -*-
+
+title SENVER - Chaosnet SENd serVER
+
+a=1
+b=2
+c=3
+d=4
+e=5
+t=6
+tt=7
+pbp=10
+h=11		;BP to the ascii message buffer w/header
+hl=12		;Number of bytes in above buffer
+n=13		;BP to the chaos-format message text
+nl=14		;Number of bytes of above
+k=15		;Kount of #bytes in CLS packet
+l=16
+p=17
+
+call=pushj p,
+return=popj p,
+
+hosti==1	;To suck in HOSTS3 with
+usri==2		;To test for loginedness of local people
+outo==3		;Outputting the message, either CLI or MAIL:
+chaosi==4	;The twisted pair.
+chaoso==5
+erri==6		;For sucking in an error message
+
+pdlen==20
+nw%chs==:7	;Chaosnet host#
+nw%arp==:12	;Arpanet host#
+hostsp==100	;Page to map in HOSTS3 at
+length==2000*10	;Number of bytes to allow for a message
+
+.insrt dsk:system;chsdef
+
+define syscall op,args
+	.call [setz ? .1stwd sixbit /op/ ? args(400000)]
+termin
+
+define type &string
+	movei t,<.length string>
+	move tt,[440700,,[ascii string]]
+	syscall siot,[movei outo ? move tt ? move t]
+	 jfcl
+termin
+
+subttl Silly Random Crufty Storage
+
+pdlist:	-pdlen,,.
+	block pdlen
+
+debug:	0		;Non-0 for debugging
+tolate:	0		;Non-0 if it is too late to refuse connection.
+error:	0		;Gack!  .CALL error code!
+here:	0		;Our hostname
+
+hostn:	0		;Host number you are sending to
+host6:	0		;Sixbit abbreviated name of...
+l$host:	0		;Length of below name.
+phost:	440700,,host
+host:	block 20	;Host name you're sending to.
+
+from:	block 20
+
+pfsite:	440700,,fsite
+fsite:	block 20	;From site.
+msglen:	0		;Length of incoming message.
+
+l$name:	0		;Length of below name...
+name6:	0		;Sixbit of name, for ITS messages.
+pname:	440700,,name
+name:	block 20	;Who you're sending to.
+
+usr:	sixbit /USR/	;Sometimes clobbered to "AIUSR" or similar
+cli:	sixbit /CLI/	;Likewise
+
+packet:	block %cpmxw	;One chaotic bundle.
+
+tsint:	loc 42		;Interrupt handler
+	-tsintl,,tsint
+loc tsint
+	p			;need a stack
+	%piioc ? 0 ? -1 ? -1 ? iocerr
+tsintl==:.-tsint
+
+iocerr:	call choke		;sigh
+
+$$hst3==1
+$$arpa==1
+$$chaos==1
+$$hstmap==1
+$$hostnm==1
+$$symlook==1
+$$mit==1
+$$hstsix==1
+.insrt dsk:syseng;netwrk
+
+
+subttl Do It
+
+begin:	.close 1,		;Might still be open from loading us.
+	move p,pdlist
+	move tt,[-2,,[
+		.soption,,[(%opint\%opopc)]	;We use new-style interrupts.
+		.smask,,[%piioc]	;Interrupt in IOC errors
+		]]
+	.suset tt
+	syscall chaoso,[movei chaosi ? movei chaoso ? movei 5]
+	 call die
+	movei t,%colsn
+	dpb t,[$cpkop packet]		;LiSteN for...
+	movei t,4
+	dpb t,[$cpknb packet]		;A name with this many bytes,
+	move t,[.byte 8 ? "S ? "E ? "N ? "D]
+	movem t,packet+%cpkdt		;Namely that.
+	syscall pktiot,[movei chaoso ? movei packet]
+	 call die
+	movei a,5*30.			;Five seconds,
+	skipe debug
+	 movei a,60.*60.*30.		;or 1 hour if debugging.
+	syscall netblk,[movei chaosi ? movei %cslsn
+			move a		;Wait this long
+			movem t]	;Will be new socket state.
+	 call die
+	caie t,%csrfc			;Was there an RFC?
+	 call die			;  Then what are we doing here??
+	syscall pktiot,[movei chaosi ? movei packet]	;Yes, so suck it in.
+	 call die
+	syscall sstatu,[repeat 6,[ ? movem here]]
+	 jfcl
+	movei a,hostsp
+	movei b,hosti
+	call netwrk"hstmap		;Inhale HOSTS3 binary.
+	 call die
+	ldb b,[$cpksa packet]
+	hrli b,nw%chs_9
+	call netwrk"hstsrc		;Find sender's site.
+	 caia
+	  jrst fsitok
+fsituk:	move d,pfsite			;Sender's site is unknown.
+	ldb b,[$cpksa packet]		;Make a fake name.
+	call octdpb			;Looks like octal Chaos addr.
+	move a,[440700,,[asciz "/CHAOS"]]	;Followed by net name.
+fsitu1:	ildb t,a
+	idpb t,d			; * Note that since NETWRK"HSTLOOK
+	skipe t				; * can parse addresses like this.
+	 jrst fsitu1			; * (Therefore the SENDER program can
+	jrst benice			; *  actually REPLY to these frobs!)
+
+fsitok:	hrli a,440700
+	move b,pfsite
+weeeee:	ildb t,a
+	jumpe t,benice
+	idpb t,b
+	jrst weeeee
+
+subttl We are Alive - Be Sociable
+
+benice:	skipe debug
+	 jrst parse			;No need to be sociable if bizy
+	ldb t,[$cpksa packet]		;Source address.
+	move a,[sixbit /000C00/]	;The jname template.
+	dpb t,[220300,,a]		;Save low byte: 00xS00
+	lsh t,-3
+	dpb t,[300300,,a]		;Next highest:  0x0S00
+	lsh t,-3
+	dpb t,[360300,,a]		;And the last:  x00S00
+	.suset [.ruind,,t]		;Our user index/job#
+	dpb t,[000300,,a]		;Low byte:      000S0x
+	lsh t,-3
+	dpb t,[060300,,a]		;Finally done:  000Sx0
+	move b,a			;B/ xuname, A/ uname
+	syscall login,[move a ? [sixbit /CHAOS/] ? move b]
+	 aoja a,.-1			;  Loss! Try another uname.
+	syscall detach,[movsi 3 ? movei %jself]	;Set ourself free.
+	 call die
+	.suset [.sjname,,[sixbit /SENVER/]]	;Don't be shy...
+
+subttl See What the Fuck You Want
+
+parse:	setz hl,
+	move h,[440700,,buffer]
+	ldb l,[$cpknb packet]		;Length.
+	move pbp,[440800,,packet+%cpkdt]
+	move n,pbp
+	setz k,
+schaff:	sojl l,hoo
+	ildb t,pbp
+	caie t,40
+	 jrst schaff
+	move a,[440700,,name]
+	setz b,
+usnarf:	sojl l,gotu
+	ildb t,pbp
+	cain t,40
+	 jrst gotu
+	cain t,"@
+	 jrst gots
+	idpb t,a
+	aoja b,usnarf
+
+gotu:	jumpe b,hoo			;Be nice about too many blanks.
+	movem b,l$name			;Save name length.
+gotu1:	move a,[440700,,name]
+	move c,[440600,,name6]
+	move tt,l$name
+	caile tt,6
+	 movei tt,6
+guloop:	ildb t,a
+	caige t,"a
+	 subi t,40
+	idpb t,c
+	sojn tt,guloop
+ucheck:	syscall open,[movsi .uii ? movei usri ? move usr
+			move name6 ? [sixbit /HACTRN/]]
+	 jrst nogots
+	.close usri,
+	syscall open,[movsi .uio ? movei outo ? move cli
+			move name6 ? [sixbit /HACTRN/]]
+	 jrst gagged
+	.close outo,
+	movei a,[asciz /ÔTY message from chaosnet site /]
+	call stuff
+	movei a,fsite
+	call stuff
+	movei a,[asciz /:
+/]
+	call stuff
+	call accept
+	movei t,6		; Knock 6 times ("twice on the pipe...")
+knock:	syscall open,[movsi .uao ? movei outo ? move cli
+			move name6 ? [sixbit /HACTRN/]]
+	 caia			; he was there just moment ago...
+	  jrst sendit
+	sojle t,gone		; I guess he went away
+	movei tt,30.		; Knock every 1 second
+	.sleep tt,
+	jrst knock		; Go knock on his door again
+
+subttl Dolt!  You specified a site!  VERIFICATION!
+
+gots:	jumpe b,hoo
+	movem b,l$name
+	move a,phost
+	setz b,
+gsloop:	sojl l,scheck
+	ildb t,pbp
+	cain t,40
+	 jrst scheck
+	cail t,"a
+	 trz t,40
+	idpb t,a
+	aoja b,gsloop
+
+scheck:	jumpe b,gotu1			;Not really a site here.
+	movem b,l$host
+	movei a,host
+	call netwrk"hstlook
+	 jrst badsite
+	movem a,hostn
+	hlrz t,1(b)
+	add t,netwrk"hstadr
+	hlrz tt,1(t)
+	add tt,netwrk"hstadr
+	move c,(tt)
+	camn c,[ascii /ITS/]
+	 jrst [	call netwrk"hstsix
+		 jfcl
+		lsh a,4*6
+		camn a,here
+		 jrst gotu1
+		movem a,host6
+		move t,usr
+		lsh t,-6*2
+		ior t,a
+		movem t,usr
+		move tt,cli
+		lsh tt,-6*2
+		ior tt,a
+		movem tt,cli
+		jrst gotu1 ]
+	call accept
+	move a,[440700,,from]
+	setz b,
+gfrom:	sojl l,qsend
+	ildb t,pbp
+	idpb t,a
+	aoja b,gfrom
+
+qsend:	jumpe b,nofrom
+	syscall open,[movsi .uao ? movei outo ? [sixbit /DSK/] ? moves error
+			[sixbit /MAIL/] ? [sixbit />/] ? [sixbit /.MAIL./]]
+	 call losage
+	type "FROM-PROGRAM:SENVER
+FROM:"
+	move a,[440700,,from]
+	syscall siot,[movei outo ? move a ? move b ? moves error]
+	 call losage
+	type "
+RCPT:("
+	move t,pname
+	move tt,l$name
+	syscall siot,[movei outo ? move t ? move tt ? moves error]
+	 call losage
+	.iot outo,["@]
+	move t,phost
+	move tt,l$host
+	syscall siot,[movei outo ? move t ? move tt ? moves error]
+	 call losage
+	type " (R-MODE-SEND 0))
+TEXT;-1
+"
+
+subttl Send the Silly Thing and then Quit
+
+sendit:	move t,[440700,,buffer]
+	move tt,hl
+	syscall siot,[movei outo ? move t ? move tt ? moves error]
+	 call losage
+done:	.close outo,
+close:	.close chaoso,
+	.close chaosi,
+	call die
+
+loss:	call gargle
+loss1:	dpb k,[$cpknb packet]		;Length
+	movei t,%cocls
+	dpb t,[$cpkop packet]		;Opcode
+	syscall pktiot,[movei chaoso ? movei packet]
+	 call choke
+	call choke
+
+choke:	skipn tolate
+die:	 skipe debug
+	  .value
+	.logout 1,
+
+subttl Random and Sundry Subroutines
+
+;;; OCTDPB - Deposit octal number in B down ASCII Bp in D.
+;;; Smashes B,C; Updates D.
+
+octdpb:	idivi b,8.
+	movm b,b
+	movm c,c
+octdp1:	addi c,"0
+	caile c,"9
+	 addi c,<"a-10.-"0>
+	jumpe b,octdp2
+	hrlm c,(p)
+	idivi b,8.
+	call octdp1
+	hlrz c,(p)
+octdp2:	idpb c,d
+	return
+
+accept:	movei t,%coopn
+	dpb t,[$cpkop packet]
+	syscall pktiot,[movei chaoso ? movei packet]
+	 call die
+	setom tolate
+	move t,[440800,,netbuf]
+	movei tt,length
+	syscall siot,[movei chaosi ? move t ? move tt ? moves error]
+	 call losage
+	jumpe tt,toobig
+	movei nl,length
+	sub nl,tt
+transl:	move a,[440800,,netbuf]
+send2:	sojl nl,cpopj
+	ildb t,a
+	cain t,200\^m
+	 jrst [	idpb t,h
+		movei t,^j
+		aoja hl,send3 ]
+	trnn t,200
+	 skipa
+	  caile t,207
+send3:	   idpb t,h
+	aoja hl,send2
+
+stuff:	hrli a,440700
+sloop:	ildb t,a
+	jumpe t,cpopj
+	idpb t,h
+	aoja hl,sloop
+
+gargle:	hrli a,440700
+garg1:	ildb t,a
+	jumpe t,cpopj
+	idpb t,n
+	aoja k,garg1
+
+hoo:	movei a,[asciz /You must specify a name in the RFC./]
+	jrst loss
+
+toobig:	movei a,[asciz /Message is too big - Can't cope./]
+	jrst loss
+
+nogots:	movei a,[asciz /User "/]
+	call gargle
+	movei a,name
+	call gargle
+	movei a,[asciz /" is not logged in./]
+	jrst loss
+
+gagged:	movei a,[asciz "User is not accepting messages."]
+	jrst loss
+
+gone:	movei a,[asciz /User is no longer logged in or accepting messages./]
+	jrst loss
+
+badsit:	movei a,[asciz /Invalid site specified: "/]
+	call gargle
+	movei a,host
+	call gargle
+	movei a,[asciz /"./]
+	jrst loss
+
+nofrom:	movei a,[asciz /Senders name not specified in C->A forwarding RFC./]
+	jrst loss
+
+losage:	movei a,[asciz /?ITS LOSSAGE - /]
+	call gargle
+	syscall open,[movsi .uai ? movei erri ? [sixbit /ERR/]
+			movei 4 ? move error]
+	 jrst [	movei a,[asciz /?!Can't get error message/]
+		jrst loss ]
+eloop:	.iot erri,t
+	caige t,40
+	 jrst loss1
+	idpb t,n
+	aoja k,eloop
+	
+popj1:	aos (p)
+cpopj:	return
+
+netbuf:	block <length+3>/4
+
+buffer:	block <length+4>/5
+
+	end begin


### PR DESCRIPTION
SYSNET; SENVER 45 - Chaosnet SEND server → SYSBIN (linked from DEVICE; CHAOS SEND)  
SYSNET; SENDS 24 - Chaosnet SEND server → SYSBIN (*not* linked from DEVICE; CHAOS SEND)  
GREN; SENSOR 87 - Sends censor → SYS3

SENVER and SENSOR appear to both do the same thing.  I chose to install SENVER as the Chaosnet SEND server, because it's newer and bigger.