### PR TITLE
Supported peripherals

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -6,6 +6,7 @@
   [Getting Started Computing at the AI Lab](ai_wp_235.pdf)
 - DDT: [manual](info/ddt.33), [commands](_info_/ddtord.1462),
   [colon commands](_info_/ddt.:cmnds)
+- [Supported peripherals](peripherals.md)
 
 ### Tools
 

--- a/doc/peripherals.md
+++ b/doc/peripherals.md
@@ -1,0 +1,78 @@
+## Complete list of supported peripherals
+
+This informat was collected from SYSTEM; CONFIG >
+
+### KA10
+
+- Console TTY
+- 512K or 768K memory
+- DC10 - Systems Concepts disk controller
+- RP10 - DEC disk controller
+- RP02/RP03 - disk drive
+- PI channel 1 multiplexing
+- TM10A/B - magnetic tape controller
+- DF10 - data channel
+- Paper tape reader and punch
+- DeCoriolis clock
+- Holloway clock
+- Datapoint kludge - terminal multiplexor
+- TK10 - terminal multiplexor
+- Morton box - terminal multiplexor
+- Nova TTYs
+- IMP interface (KA, DM)
+- KA10 console lights
+- Morse code output device
+- Rubin 10-11 interface
+- XGP printer
+- Chaosnet (through 10-11 or I/O bus)
+- Knight TVs
+- PDP-6 auxilliary processor
+- 340 display
+- E&S LDS-1 display
+- Sylvania tablet
+- Deselection device (don't know what that is)
+- Old DECtape controller (PDP-6)
+- New DECtape controller
+- Robot console
+- ARM (AMF mostly) - don't know what that is (robot arm?)
+- OMX - output multiplexor
+- IMX - input multiplexor
+- VIDI - don't know what that is
+- Chess tournament clock
+- D/A converters
+- Old LPT (Data Products)
+- New LPT - line printer (ODEC)
+- Gould LPT
+- COD - don't know what that is
+- Calcomp plotter
+- Stanford keyboard
+- GT40
+
+### KL10
+
+- Console TTY
+- 2048K memory
+- RH10 - disk controller
+- RP04 - disk drive
+- T300 - Trident disk drive (through PDP-11)
+- DF10 - data channel
+- DL10- 10-11 interface channel
+- KL-udge - DeCoriolis clock, console lights
+- Chaosnet (through DL10)
+- DTE20
+- DC76 - terminal controller
+
+### KS10
+
+- Console TTY
+- 512K memory
+- RH11 - massbus controller
+- RP06 - disk drive
+- RP07 - disk drive
+- RM80 - disk drive
+- RM02/RM03 - disk drive
+- TU45 - tape controller
+- TM03 - tape drive
+- IMP interface (KS), ACC LH/DH on unibus
+- Chaosnet (through unibus)
+- DZ11 - terminal controller


### PR DESCRIPTION
Complete list of supported peripherals, as gleaned from SYSTEM; CONFIG >

KA10:

- Console TTY
- 512K or 768K memory
- DC10 - Systems Concepts disk controller
- RP10 - DEC disk controller
- RP02/RP03 - disk drive
- PI channel 1 multiplexing
- TM10A/B - magnetic tape controller
- DF10 - data channel
- Paper tape reader and punch
- DeCoriolis clock
- Holloway clock
- Datapoint kludge - terminal multiplexor
- TK10 - terminal multiplexor
- Morton box - terminal multiplexor
- Nova TTYs
- IMP interface (KA, DM)
- KA10 console lights
- Morse code output device
- Rubin 10-11 interface
- XGP printer
- Chaosnet (through 10-11 or I/O bus)
- Knight TVs
- PDP-6 auxilliary processor
- 340 display
- E&S LDS-1 display
- Sylvania tablet
- Deselection device (don't know what that is)
- Old DECtape controller (PDP-6)
- New DECtape controller
- Robot console
- ARM (AMF mostly) - don't know what that is (robot arm?)
- OMX - output multiplexor
- IMX - input multiplexor
- VIDI - don't know what that is
- Chess tournament clock
- D/A converters
- Old LPT (Data Products)
- New LPT - line printer (ODEC)
- Gould LPT
- COD - don't know what that is
- Calcomp plotter
- Stanford keyboard
- GT40

KL10:

- Console TTY
- 2048K memory
- RH10 - disk controller
- RP04 - disk drive
- T300 - Trident disk drive (through PDP-11)
- DF10 - data channel
- DL10- 10-11 interface channel
- KL-udge - DeCoriolis clock, console lights
- Chaosnet (through DL10)
- DTE20
- DC76 - terminal controller

KS10:

- Console TTY
- 512K memory
- RH11 - massbus controller
- RP06 - disk drive
- RP07 - disk drive
- RM80 - disk drive
- RM02/RM03 - disk drive
- TU45 - tape controller
- TM03 - tape drive
- IMP interface (KS), ACC LH/DH on unibus
- Chaosnet (through unibus)
- DZ11 - terminal controller