### PR TITLE
Resolves #704. Renames SYS; PURQIO 1 to SYS; PURQIO 2154

### DIFF
--- a/build/build.tcl
+++ b/build/build.tcl
@@ -738,7 +738,7 @@ respond "*" ":job lisp\r"
 respond "*" ":load .temp.;*lisp bin\r"
 respond "*" "\033g"
 respond "*" "purify\033g"
-respond "*" ":pdump sys;purqio >\r"
+respond "*" ":pdump sys;purqio 2154\r"
 respond "*" ":kill\r"
 
 respond "*" ":link sys;ts lisp,sys:purqio >\r"


### PR DESCRIPTION
Causes newly created lisp to name dumped image as SYS; PURQIO 2154

rather than SYS; PURQIO 1.  The ITS convention is to have the PURQIO version number
match the version of the Lisp dumped.