### PR TITLE
Documentation updates

### DIFF
--- a/doc/DDT.md
+++ b/doc/DDT.md
@@ -14,6 +14,7 @@ The `$` character represents typing ESC.
 | ls            | ^F                   | :listf                   |
 | ls dir        | dir^F                | :listf dir               |
 | ls /          | ^R m.f.d. (file)     | :print m.f.d. (file)     |
+| ls *.foo      | ^R dir: second foo   | :print dir: second foo   |
 | more file     | ^R file              | :print file              |
 | mkdir dir     | ^R dir;..new. (udir) | :print dir;..new. (udir) |
 | cd dir        | dir$$s               | :cwd dir                 |

--- a/doc/debugging.md
+++ b/doc/debugging.md
@@ -17,8 +17,9 @@ Notes where exec DDT differs from timesharing DDT.
 | $B | Remove breakpoint at current location | Remove all breakpoints
 | .$B | Set breakpoint at current location
 | . | Current location
+| $. | Current value of PC
 | $Q | Last printed quantity
-| *n*/ | Open location *n* symbolically
+| *n*/ | Open location *n* symbolically (show instructions and symbols)
 | / | Open $Q
 | ^J | Open next location
 | ^ | Open previous location
@@ -29,4 +30,4 @@ Notes where exec DDT differs from timesharing DDT.
 | " | Print $Q as five ASCII characters
 | # | Print $Q as one ASCII character | N/A
 | ^N | Single step | N/A
-| $^N | Stop at next instruction | N/A
+| $^N | Stop at next instruction (skip over calls) | N/A

--- a/doc/machines.md
+++ b/doc/machines.md
@@ -1,24 +1,31 @@
 ## List of ITS machines
 
-| Model | Serial number | Name   | Comment  | Owners |
-| ----- | ------------- | ------ | -------  | ------ |
-| PDP-6 | 2             |        | AI       | MIT (1964-1978) |
-| PDP-6 |               |        | DM       | MIT (1969- |
-| KA10  |               | AI     |          | MIT (1968-1983) |
-| KA10  |               | DM     | Dynamic Modelling | MIT (1970-1983) |
-| KA10  |               | ML     | Math Lab | MIT (1971-1984) |
-| KL10  | 1038          | MC/MX  | Macsyma Consortium | MIT (1975-1988), Peter Löthberg |
-| KS10  | 4627          | AI     |          | MIT (1985-1990), Christoper Zach, LCM |
-| KS10  | 4648          | MD   	 | Mostly Development | MIT (1986-) |
-| KS10  | 4649          | MX/MC  | Mail Computer | MIT (1986-1990), Christoper Zach |
-| KS10  | 4653          | ML   	 |          | MIT (1986-1990), Christoper Zach, Doug Humphrey, Dave McGuire |
-| KS10  | 4142          |        |          | John Wilson |
-| KS10  | 4286/4664     | PM     |          | Marc Crispin, LCM |
-| KS10  | 4428          |        |          | Peter Löthberg |
-| KS10  | 4655          | eLinor |          | LIU, Lysator, Ludd, Anders Magnusson |
-| KS10  |               | SI     |          | Stacken |
-| KS10  |               | FU     |          | Australia |
-| KS10  |               | DX     |          | Doug Humphrey (1989-) |
-| KLH10 |               | SV     |          | Paul Svensson |
-| KLH10 |               | UP     | Update   | Björn Victor |
-| KLH10 |               | ES     |          | Eric Swenson (2015-) |
+| Model | Serial number | Name  | Comment | Owners |
+| ----- | ------------- | ----- | ------- | --- |
+| PDP-6 | 2             |       | AI Lab  | MIT (1964-1982) |
+| PDP-6 |               |       | DynaMod | MIT (1969-) |
+| KA10  |               | AI    |         | MIT (1968-1983), Concourse (1983-) |
+| KA10  | 144           | DM    | Dynamic Modeling | MIT (1970-1983) |
+| KA10  | 198           | ML    | Mathlab | MIT (1971-1984) |
+| KA10  |               |       |         | Stacken
+| KL10  | 1038          | MC/MX | Macsyma Consortium | MIT (1975-1988), Peter Löthberg |
+| KS10  | 4627          | AI    | | MIT (1985-1990), Christoper Zach, LCM |
+| KS10  | 4648          | MD    | Mostly Development | MIT (1986-) |
+| KS10  | 4649          | MX/MC | Mail Computer | MIT (1986-1990), Christoper Zach |
+| KS10  | 4653          | ML    | | MIT (1986-1990), Christoper Zach, Doug Humphrey, Dave McGuire |
+| KS10  | 4428          |       | | Peter Löthberg |
+| KS10  | 4469          |       | | Gordon Greene, Daniel Seagraves |
+| KS10  | 4655          | LI    | eLinor | LIU, Lysator, Ludd, Anders Magnusson |
+| KS10  | 4664          | PM    | | Marc Crispin, LCM |
+| KS10  | 4142          |       | | John Wilson |
+| KS10  |               | SI    | | Stacken |
+| KS10  |               | FU    | Australia | Flinders University |
+| KS10  |               | DX    | | Doug Humphrey (1989-) |
+| PDP-10/X |            | TX    | | Dave Conroy |
+| KLH10 |               | [SV](http://its.svensson.org/)     | | Paul Svensson (2001-) |
+| KLH10 |               | [UP](http://up.update.uu.se/)     | Update | Björn Victor (2004-) |
+|       |               | CC    | | Cosmic Computing |
+| KLH10 |               | ES    | | Eric Swenson's ITS (2015-) |
+| KLH10 |               | NO    | nocrew | Lars Brinkhoff (2017-) |
+| KLH10 |               | SJ    | San Jose | @b4 (2017-) |
+| KLH10 |               | XM    | | @mattwyrm |

--- a/doc/peripherals.md
+++ b/doc/peripherals.md
@@ -30,23 +30,23 @@ This information was collected from SYSTEM; CONFIG >
 - 340 display
 - E&S LDS-1 display
 - Sylvania tablet
-- Deselection device (don't know what that is)
+- Deselection device (coordinate device sharing between PDP-6 and 10)
 - Old DECtape controller (PDP-6)
 - New DECtape controller
 - Robot console
 - ARM (AMF mostly) - don't know what that is (robot arm?)
-- OMX - output multiplexor
-- IMX - input multiplexor
-- VIDI - don't know what that is
+- OMX - output multiplexor (multiple D/A channels)
+- IMX - input multiplexor (multiple A/D channels)
+- VIDI - TV camera?
 - Chess tournament clock
 - D/A converters
 - Old LPT (Data Products)
 - New LPT - line printer (ODEC)
 - Gould LPT
-- COD - don't know what that is
+- COD - Morse code oputput
 - Calcomp plotter
 - Stanford keyboard
-- GT40
+- GT40 - graphical terminal
 
 ### KL10
 

--- a/doc/peripherals.md
+++ b/doc/peripherals.md
@@ -71,8 +71,8 @@ This information was collected from SYSTEM; CONFIG >
 - RP07 - disk drive
 - RM80 - disk drive
 - RM02/RM03 - disk drive
-- TU45 - tape controller
-- TM03 - tape drive
+- TM03 - tape controller
+- TU45 - tape formatter
 - IMP interface (KS), ACC LH/DH on unibus
 - Chaosnet (through unibus)
 - DZ11 - terminal controller

--- a/doc/versions.md
+++ b/doc/versions.md
@@ -1,7 +1,9 @@
 | Year | Versions | Comment
 | --- | --- | ---
 | 1966 |1? | PDP-6
-| 1968? | |  KA10 support
+| 1968 | 350
+| 1969 | 530 | KA10 support?
+| 1970? | | Virtual memory
 | 1971 | 672-703 | Arpanet support
 | 1972 | 720-724
 | 1973 | 785-850


### PR DESCRIPTION
- Fix #703, confused TM03/TU45.
- Cheat sheet: how to "ls *.foo".
- More info on peripherals.

Anyting else to add to this?