### PR TITLE
Remove obsolete mode bit when opening TTY.

### DIFF
--- a/src/games/wumpus.103
+++ b/src/games/wumpus.103
@@ -89,7 +89,7 @@ INSTEAD OF A ROOM NUMBER.
        GOOD LUCK HUNTING!!
 î/
 BEG:					;The beginning
-GO:	.OPEN TTYI,[20+.UAI,,'TTY]	;[FIXME why 20?]
+GO:	.OPEN TTYI,[.UAI,,'TTY]
 	 .VALUE 0
 	.OPEN TTYO,[.UAO,,'TTY]
 	 .VALUE 0


### PR DESCRIPTION
@larsbrinkhoff spotted that TS3TTY has a comment listing TTY input open
mode bits which includes:

;3.5 => CONVERT LOWER TO UPPER CASE

This mode bit isn't documented in the similar lists in BITS or CALLS
(they skip from 3.4 to 3.6), and doesn't appear to be implemented
anywhere. However, ITS 785 (circa 1973) has a test for this bit in
TTYO4:

	TRNE D,10	;SKIP ON OLD MODE OFF
	IOR J,[000400,,0]	;OLD MODE INPUT -> CONVERT LOWER CASE TO UPPER

So it looks like when WUMPUS was first written, this bit was how it
handled lower-case input; at some point, ITS stopped supporting this
bit, and WUMPUS was binary-patched to handle lower-case input explicitly
instead.