### PR TITLE
Possible workaround for #874

### DIFF
--- a/build/misc.tcl
+++ b/build/misc.tcl
@@ -786,7 +786,8 @@ respond "*" ":job xxfile\r"
 respond "*" ":load sysbin;xxfile bin\r"
 respond "*" "ttyop1\033b\033g"
 expect ":PDUMP SYS2;TS XXFILE"
-type ":kill\r"
+expect ">>"
+respond "   " ":kill\r"
 
 # TJ6
 respond "*" ":midas sysbin;_tj6;tj6\r"


### PR DESCRIPTION
At @larsbrinkhoff's suggestion - wait until we're definitely back in DDT before typing the :kill command. I don't know if this'll work around the problem, but it can't hurt!