### PR TITLE
Switch SIMH escape to ^\

### DIFF
--- a/build/simh/boot
+++ b/build/simh/boot
@@ -1,3 +1,4 @@
+set console wru=034
 set cpu its
 set cpu idle
 set tim y2k

--- a/build/simh/build.tcl
+++ b/build/simh/build.tcl
@@ -1,6 +1,6 @@
 set build [pwd]/build
 set out "out/$env(EMULATOR)"
-set emulator_escape "\005"
+set emulator_escape "\034"
 
 proc start_salv {} {
     uplevel #0 {spawn pdp10 build/simh/init}

--- a/build/simh/init
+++ b/build/simh/init
@@ -1,3 +1,4 @@
+set console wru=034
 set cpu its
 set tim y2k
 at tu0 out/simh/minsys.tape

--- a/build/sims/boot
+++ b/build/sims/boot
@@ -1,3 +1,4 @@
+set console wru=034
 set cpu its
 set cpu 512k
 set pd off

--- a/build/sims/boot2
+++ b/build/sims/boot2
@@ -1,3 +1,4 @@
+set console wru=034
 set cpu its
 set cpu 512k
 set cpu mpx

--- a/build/sims/build.tcl
+++ b/build/sims/build.tcl
@@ -1,6 +1,6 @@
 set build [pwd]/build
 set out "out/$env(EMULATOR)"
-set emulator_escape "\005"
+set emulator_escape "\034"
 
 proc start_salv {} {
     uplevel #0 {spawn ./tools/sims/BIN/ka10 build/sims/init}

--- a/build/sims/init
+++ b/build/sims/init
@@ -1,3 +1,4 @@
+set console wru=034
 set cpu its
 set cpu 512k
 at ptr bin/ka10/boot/magdmp.rim

--- a/build/sims/run
+++ b/build/sims/run
@@ -1,3 +1,4 @@
+set console wru=034
 set cpu its
 set cpu 512k
 set cpu idle

--- a/doc/DUMP-itstar.md
+++ b/doc/DUMP-itstar.md
@@ -1,31 +1,39 @@
 # DUMP and itstar
 
-### Saving ITS files and extract them using itstar
+### Saving ITS files and extracting them using itstar
 
-- Mount a tape image in the emulator.  Type Control-\\, and then for KLH10
+- Mount a tape image in the emulator.
 
-       devmount mta0 files.tape create
-       continue
+  - Type Control-\\.
 
-  For SIMH, type
+  - For KLH10, type
 
-       attach tu0 files.tape
-       continue
+         devmount mta0 files.tape create
+         continue
+
+  - For SIMH, type
+
+         attach tu0 files.tape
+         continue
 
 - In ITS, type `:dump`.  At the _ prompt, type `dump`.  The `FILE=`
   prompt will accept directory and file names.  `*` can be used as a
   wild card.  Finish with an empty line.  When DUMP has finished
   writing the files, type `quit` to exit.
 
-- Unmount the tape image.  Type Control-\\, and then for KLH10
+- Unmount the tape image.
 
-       devunmount mta0
-       continue
+  - Type Control-\\.
 
-  For SIMH, type
+  - For KLH10, type
 
-       detach tu0
-       continue
+         devunmount mta0
+         continue
+
+  - For SIMH, type
+
+         detach tu0
+         continue
 
 - In the host, run itstar to extract the files:
 
@@ -35,24 +43,29 @@
 
 - Create one or more directories, and put the files in them.  There
   can not be directories inside directories.  For example, let's say
-  you created the directores foo and bar.
+  you created the directories foo and bar.
 
 - Run itstar to make a tape image:
 
        itstar -cf files.tape foo bar
 
-- Mount the tape image in the emulator.  Type Control-\\, and then for KLH10
+- Mount the tape image in the emulator.
 
-       devmount mta0 files.tape
-       continue
+- Type Control-\\.
 
-  For SIMH, type
+  - For KLH10, type
 
-       attach tu0 files.tape
-       continue
+         devmount mta0 files.tape
+         continue
+
+  - For SIMH, type
+
+         attach tu0 files.tape
+         continue
 
 - In ITS, type `:dump`.  At the _ prompt, type `load`.  The `FILE=`
   prompt will accept file names as above.  Finish with an empty line.
-  When DUMP has finished reading the files, type `quit` to exit.
+  If you need to load more files, type `rewind` to make another pass
+  over the tape.  When you're finished, type `quit` to exit.
 
 - Unmount the tape image as above.

--- a/doc/DUMP-itstar.md
+++ b/doc/DUMP-itstar.md
@@ -2,13 +2,12 @@
 
 ### Saving ITS files and extract them using itstar
 
-- Mount a tape image in the emulator.  For KLH10, type Control-\\, and
-  then
+- Mount a tape image in the emulator.  Type Control-\\, and then for KLH10
 
        devmount mta0 files.tape create
        continue
 
-  For SIMH, type Control-E, and then
+  For SIMH, type
 
        attach tu0 files.tape
        continue
@@ -18,12 +17,12 @@
   wild card.  Finish with an empty line.  When DUMP has finished
   writing the files, type `quit` to exit.
 
-- Unmount the tape image.  For KLH10, type Control-\\, and
+- Unmount the tape image.  Type Control-\\, and then for KLH10
 
        devunmount mta0
        continue
 
-  For SIMH, type Control-E, and then
+  For SIMH, type
 
        detach tu0
        continue
@@ -42,12 +41,12 @@
 
        itstar -cf files.tape foo bar
 
-- Mount the tape image in the emulator.  For KLH10, type Control-\\ and
+- Mount the tape image in the emulator.  Type Control-\\, and then for KLH10
 
        devmount mta0 files.tape
        continue
 
-  For SIMH, type Control-E, and then
+  For SIMH, type
 
        attach tu0 files.tape
        continue


### PR DESCRIPTION
@rmaldersoniii recommends switching the SIMH console escape character to ^\

    d wru 034

Apart from being a great relief when working with EMACS, it will also make the escape character the same as the default in KLH10.