### PR TITLE
Macsyma build script problem

### DIFF
--- a/build/build.tcl
+++ b/build/build.tcl
@@ -81,14 +81,21 @@ proc build_macsyma_portion {} {
     respond "302615" "(load \"maxdoc;mcldat\")"
     respond "302615" "(load \"libmax;module\")"
     respond "303351" "(load \"libmax;maxmac\")"
-    respond "307161" "(todo)"
+    expect "307161"
+    send "(todo)"
+    expect "(todo)"
     sleep 10
-    type "(todoi)"
+    send "(todoi)"
     sleep 10
-    type "(mapcan #'(lambda (x) (cond ((not (memq x\r"
+    expect "(todoi)"
+    sleep 10
+    send "(mapcan "
+    expect "(mapcan "
+    type "#'(lambda (x) (cond ((not (memq x\r"
     type "'(SETS TRANSS MTREE TRHOOK EDLM)\r"
     type ")) (doit x)))) (append todo todoi))"
-    expect -timeout 1000 {
+    set timeout 1000
+    expect {
 	";BKPT" {
 	    type "(quit)"
 	}
@@ -96,6 +103,7 @@ proc build_macsyma_portion {} {
 	    type "(quit)"
 	}
     }
+    set timeout 100
 }
 
 set timeout 100


### PR DESCRIPTION
I may have found a problem with the script used to build Macsyma.

When `(todo)` is sent, there will be a lot of output about not finding unfasl files.  When `(todoi)` is sent, the type procedure will ensure that characters are echoed.  But the individual characters will match the pending output from the compiler.  So the script thinks characters are echoed, even though they not yet have.

I'm not sure if this is actually a problem or not.  Maybe the characters are buffered and received later.