### PR TITLE
Fixes to the documentation from the GPL release

### DIFF
--- a/doc/sysdoc/_calls.127
+++ b/doc/sysdoc/_calls.127
@@ -2879,65 +2879,6 @@ Errors:
 	The page number in argument 2 is not between 0 and 377; or the
 	job does not have a page at that position in its address space.
  34	WRONG TYPE DEVICE
-	The <JOB> specifies the pdp-6,followed by JUMPA instructions
-	containing the starting address.  When this is done,
-	the resulting file can be loaded and run as a program
-	under DDT.
-	See the LOAD symbolic system call.
-
-Errors:
-
- 14	BAD CHANNEL NUMBER
- 31	CAN'T MODIFY JOB
-	Can't dump the PDP-6 job.
- 34	WRONG TYPE DEVICE
-	First argument was some oddball channel, or
-	second argument was not a disk output channel number.
- 35	NO SUCH JOB
-
-PGWRIT:	Cause page to be written to disk
-
-	arg 1	(Optional)  A <JOB>
-	arg 2	Virtual page number within that job (a number from 0 to 377).
-	control bits:
-	1.1	1 => don't wait for the page to finish getting written out,
-		     return immediately.  Issue the call again with this bit 0
-		     if you later want to wait for it to get written out.
-	1.2	1 => unlock the page.
-		0 => if the page is locked, swap it out anyway, but when it
-		     next gets swapped in again it will be locked again.
-
-	If there is only one argument, it is arg 2.  The <JOB> is
-	assumed to be the job issuing the call.
-
-	The disk copy of the specified page is brought up to date;
-	if the in-core copy has been modified by the specified <JOB>
-	the page is written out.  The PGDUMP call does not return until
-	the disk has finished recording the page.
-
-	This is useful when pages of a file have been mapped into
-	the user's address space.
-
-	If the page cannot be swapped out because no disk space is available,
-	or some job that is using it cannot be pclsr'ed, it waits a while
-	and tries again.  It does not return.
-
-	This call used to be called PGDUMP, but the name was
-	changed to avoid confusion with PDUMP.
-
-Errors:
-
- 12	MODE NOT AVAILABLE
-	Page is absolute or tied down by exec pages.
- 14	BAD CHANNEL NUMBER
-	The <JOB> argument is invalid.
- 31	CAN'T MODIFY JOB
-	Executing job doesn't have modification rights to the job
-	specified by argument 1.
- 32	CAN'T GET THAT ACCESS TO PAGE
-	The page number in argument 2 is not between 0 and 377; or the
-	job does not have a page at that position in its address space.
- 34	WRONG TYPE DEVICE
 	The <JOB> specifies the pdp-6, which does not have paging.
  35	NO SUCH JOB
 	The <JOB> argument specified a non-existent job.
@@ -5057,7 +4998,74 @@ VIDBUF:	request/release video buffer
 			the first word displayed is that 4*<offset>
 			PDP-11 bytes from the buffer origin.  For
 			best results this should be a multiple
-			of 9 (for utput device.
+			of 9 (for vertical scrolling).
+	The PDP-11 always sees a video buffer as beginning at its
+	location 60000 (byte address); which video buffer it is looking
+	at is controlled by the console register at location 164044 octal.
+	Thus the PDP-11 sees the scroll register as being at address
+	157776 octal.
+
+	See also the VIDSW symbolic system call.
+Errors:
+
+  4	FILE NOT FOUND
+	Attempt to release a buffer not assigned to the job.
+  7	DEVICE NOT READY
+	The PDP-11 is not ready.
+ 33	MEANINGLESS ARGS
+	Arg 1 is non-negative but not a valid video buffer number.
+
+VIDSW:	set video switch
+
+	arg 1	Video switch input number.
+	arg 2	Video switch output number.
+
+	The video switch is set up so that the specified video
+	output will gobble bits from the specified video input.
+
+	As of July 25, 1975, the only video inputs are TV
+	video buffers.  These correspond to Tnm device numbers
+	as follows:
+
+	Tnm	Video Input Number
+	T47	24		T47 is used for console free buffer.
+	T52	1		When you type ESC<n>S, <n> is
+	T53	2		the video input number.  The PDP-11
+	T54	5		merely switches that input to your
+	T55	6		TV display, which is a video output.
+	T56	7
+	T57	10
+	T60	21
+	T61	22
+	T62	23
+
+	The possible video outputs are mostly TV displays, but also
+	the Tektronix hard-copy device which sits next to the XGP.
+	(The keyboard number may be relevant to use of the TVWHER
+	symbolic system call.)  As of July 25, 1975:
+
+	Video Output	Keyboard	Location of TV
+	 0		 0		809 Fahlman, Holloway, Knight
+	 1		14		820 Minsky
+	 2		21		824 Rich, McDonald, deKleer
+	 3		 6		815 Freiling, Perez, Ullman
+	 4		10		817 Jabari
+	 5		22		825 Freuder, Grossman, Purcell
+	 6		 4		813 Hewitt
+	 7		 5		814 Brown, McDermott, Sussman
+	10		13		819 Goldstein, Woods
+	11		17		822 Marr, Sandewall
+	12		35		915 Cohen, Gosper, etc.
+	13		34		913 Baisley, Greenblatt
+	14		33		334 Lebel
+	15		30		925 Jarvis, Moon
+	16		31		918 Freeman
+	17		32		920 Computer room, near PDP-11
+	20		 3		812 Yvonne, Williams
+	21		36		912 9th Floor Lounge
+	22		37		914 Larson, Lebel, Mousouriss
+	23		1		810 Kuipers
+	27		Tektronix hard-copy output device.
 
 Errors:
 

--- a/doc/sysdoc/arcdev.format
+++ b/doc/sysdoc/arcdev.format
@@ -1,6 +1,6 @@
-Copyright (c) 1999 Massachusetts Institute of Technology
-See the COPYING file at the top-level directory of this project.
-------------------------------
+;Copyright (c) 1999 Massachusetts Institute of Technology
+;See the COPYING file at the top-level directory of this project.
+;------------------------------
 
 ;Archive device format:
 

--- a/doc/sysdoc/chaord.57
+++ b/doc/sysdoc/chaord.57
@@ -1,3 +1,6 @@
+;comment Copyright (c) 1999 Massachusetts Institute of Technology
+;comment See the COPYING file at the top-level directory of this project.
+;comment ------------------------------
 ;skip 1
 ;list
 ;lftmar 350

--- a/doc/sysdoc/chaos.file
+++ b/doc/sysdoc/chaos.file
@@ -1,4 +1,7 @@
 -*- Mode:Text -*-
+Copyright (c) 1999 Massachusetts Institute of Technology
+See the COPYING file at the top-level directory of this project.
+------------------------------
 
 Description of the CHAOS FILE protocol designed by HIC.
 

--- a/doc/sysdoc/clo.100
+++ b/doc/sysdoc/clo.100
@@ -1,4 +1,7 @@
 -*-Text-*-						Alan 12/31/83
+Copyright (c) 1999 Massachusetts Institute of Technology
+See the COPYING file at the top-level directory of this project.
+------------------------------
 
 Here is what I know about the core link device(s).
 

--- a/doc/sysdoc/devdoc.5
+++ b/doc/sysdoc/devdoc.5
@@ -1,3 +1,6 @@
+Copyright (c) 1999 Massachusetts Institute of Technology
+See the COPYING file at the top-level directory of this project.
+------------------------------
 
 SUBTTL I/O DEVICE DISPATCH TABLES
 

--- a/doc/sysdoc/dskdmp.order
+++ b/doc/sysdoc/dskdmp.order
@@ -1,7 +1,6 @@
-Copyright (c) 1999 Massachusetts Institute of Technology
-See the COPYING file at the top-level directory of this project.
-------------------------------
-
+.COMMENT Copyright (c) 1999 Massachusetts Institute of Technology
+.COMMENT See the COPYING file at the top-level directory of this project.
+.COMMENT ------------------------------
 .DEVICE XGP
 .FONT 1 "FONTS;31VG"
 .<<FONT 2 "FONTS1;OLDENG">>

--- a/doc/sysdoc/grphcs.21
+++ b/doc/sysdoc/grphcs.21
@@ -1,3 +1,6 @@
+Copyright (c) 1999 Massachusetts Institute of Technology
+See the COPYING file at the top-level directory of this project.
+------------------------------
                This file was moved to MIT-MC from
               MIT-AI by David C. Plummer on 6 June
                   1981, and may be up to date.

--- a/doc/sysdoc/intrup.108
+++ b/doc/sysdoc/intrup.108
@@ -1,3 +1,7 @@
+Copyright (c) 1999 Massachusetts Institute of Technology
+See the COPYING file at the top-level directory of this project.
+------------------------------
+
 Overview of ITS User Interrupts
 
 When ITS wishes to signal a user program of the existence of an

--- a/doc/sysdoc/itstty.41
+++ b/doc/sysdoc/itstty.41
@@ -1,4 +1,7 @@
 -*-TEXT-*- 
+Copyright (c) 1999 Massachusetts Institute of Technology
+See the COPYING file at the top-level directory of this project.
+------------------------------
 
 File: ITSTTY	Node: Top	Next: A			Up: (DIR)
 

--- a/doc/sysdoc/job.100
+++ b/doc/sysdoc/job.100
@@ -1,3 +1,7 @@
+Copyright (c) 1999 Massachusetts Institute of Technology
+See the COPYING file at the top-level directory of this project.
+------------------------------
+
 PROGRAMMING TECHNOLOGY DIVISION DOCUMENT                     SYS.xx.yy
 
 

--- a/doc/sysdoc/locks.108
+++ b/doc/sysdoc/locks.108
@@ -1,4 +1,7 @@
 								-*- Text -*-
+Copyright (c) 1999 Massachusetts Institute of Technology
+See the COPYING file at the top-level directory of this project.
+------------------------------
 
 
 	This file contains documentation for both the LOCK device,

--- a/doc/sysdoc/magtap.101
+++ b/doc/sysdoc/magtap.101
@@ -1,3 +1,7 @@
+Copyright (c) 1999 Massachusetts Institute of Technology
+See the COPYING file at the top-level directory of this project.
+------------------------------
+
 MAG TAPE SPECS
 Copied from memo from S.Cutler 2/23/72
 THIS MEMO CONTAINS MANY LOWER-CASE CHARS

--- a/doc/sysdoc/ncp.100
+++ b/doc/sysdoc/ncp.100
@@ -1,3 +1,7 @@
+Copyright (c) 1999 Massachusetts Institute of Technology
+See the COPYING file at the top-level directory of this project.
+------------------------------
+
 Warning- don't believe everything in this file!
 
 

--- a/doc/sysdoc/peek.bugs
+++ b/doc/sysdoc/peek.bugs
@@ -1,3 +1,7 @@
+Copyright (c) 1999 Massachusetts Institute of Technology
+See the COPYING file at the top-level directory of this project.
+------------------------------
+
 Date: Fri,  5 May 89 14:14:14 EDT
 From: Devon Sean McCullough <DEVON@AI.AI.MIT.EDU>
 To: BUG-PEEK@AI.AI.MIT.EDU

--- a/doc/sysdoc/tv.100
+++ b/doc/sysdoc/tv.100
@@ -1,3 +1,7 @@
+Copyright (c) 1999 Massachusetts Institute of Technology
+See the COPYING file at the top-level directory of this project.
+------------------------------
+
 	A slightly revised TV-11 program is up and running.
 There are the following features/changes:
 

--- a/doc/sysdoc/usr.102
+++ b/doc/sysdoc/usr.102
@@ -1,3 +1,7 @@
+Copyright (c) 1999 Massachusetts Institute of Technology
+See the COPYING file at the top-level directory of this project.
+------------------------------
+
 JOBS IN ITS
 
 


### PR DESCRIPTION
Three changes:

- Some files in SYSDOC are in formats where the license header should be a comment (as has been done for SYSTEM).

- We've picked up some more of these files since @36bit added the headers originally, so do the same for the new files. (The remaining files are mostly mail archives, which probably shouldn't be included in DB.)

- Our copy of .CALLS 127 was corrupt; fix it.