### PR TITLE
LEMOTE MIPS : build.tcl change

### DIFF
--- a/build/muddle.tcl
+++ b/build/muddle.tcl
@@ -16,7 +16,7 @@ respond "*" ":midas ts stinkm_stink\r"
 expect ":KILL"
 
 respond "*" ":xfile assem xfile\r"
-expect "Assembly done!"
+expect -timeout 300 "Assembly done!"
 
 respond "*" ":print mudsav; ..new. (udir)\r"
 type ":vk\r"


### PR DESCRIPTION
Hello,

in order to build under Debian8 (using LEMOTE MIPS loongson2f), the timeout needs to be 1000 at line 110 in build.tcl

Do you think this it's possible to change that value?

thanks
Fausto