### PR TITLE
Build times out waiting for string

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,9 @@ $(OUT)/ka-minsys.tape: $(ITSTAR)
 $(OUT)/sources.tape: $(ITSTAR) build/$(EMULATOR)/stamp $(OUT)/syshst/$(H3TEXT)
 	mkdir -p $(OUT)
 	rm -f src/*/*~
+	touch -d 1981-10-06T19:03:37 'bin/emacs/einit.:ej'
+	touch -d 1981-09-19T21:42:56 'bin/emacs/[pure].162'
+	touch -d 1981-03-31T20:41:45 'bin/emacs/[prfy].173'
 	cd src; $(ITSTAR) -cf ../$@ $(SRC)
 	cd doc; $(ITSTAR) -rf ../$@ $(DOC)
 	cd bin; $(ITSTAR) -rf ../$@ $(BIN)

--- a/build/emacs.tcl
+++ b/build/emacs.tcl
@@ -12,7 +12,9 @@ respond "*" ":link sys3;ts teco,.teco.;tecpur >\r"
 respond "*" ":link sys2;ts emacs,emacs;ts >\r"
 respond "*" ":emacs\r"
 respond "EMACS Editor" "\033xrun\033einit\033? Generate\r"
-expect -timeout 2000 "EINIT"
+expect -timeout 1000 -exact { -> DSK: EMACS; [PURE]}
+expect -timeout 1000 -exact { -> DSK: EMACS; [PRFY]}
+expect -timeout 1000 -exact { -> DSK: EMACS; EINIT}
 respond ":EJ" "\033xgenerate\033emacs;aux\033emacs1;aux\r"
 respond ":EJ" "\030\003"
 respond "*" ":kill\r"


### PR DESCRIPTION
It always seems to die for me in the same place, waiting on the string EINIT even though it's right there.

[build-log.txt](https://github.com/PDP-10/its/files/1668842/build-log.txt)

Steps to reproduce:

git clone https://github.com/PDP-10/its.git
cd its
git submodule init
git submodule update
make EMULATOR=klh10

I also tried building with simh. It still dies as the same place waiting for EINIT.