### PR TITLE
Resolves #724. Build MLMAC from source.

### DIFF
--- a/build/lisp.tcl
+++ b/build/lisp.tcl
@@ -535,18 +535,48 @@ respond "(C1)" "quit();"
 respond "*" ":link sys3;ts macsym,maxdmp;loser >\r"
 
 ### build ctensr for macsyma
+# ejs: commented out until we can fix NXM error in KA10 emulator
+#respond "*" "macsym\013"
+#respond "(C1)" "compile_lisp_file(translate_file(\"sharem\\;packg >\")\[2\]);"
+#respond "(C2)" "compile_lisp_file(translate_file(\"tensor\\;ctensr funcs\")\[2\]);"
+#respond "Type ALL;" "all;"
+#respond "Type ALL;" "all;"
+#respond "(C3)" "quit();"
+
+### build eigen for macsyma
+# ejs: commented out until we can fix NXM error in KA10 emulator
+#respond "*" "macsym\013"
+#respond "(C1)" "compile_lisp_file(translate_file(\"share\\;eigen >\")\[2\]);"
+#respond "Type ALL;" "all;"
+#respond "(C2)" "quit();"
+
+### build ctensr for macsyma
 respond "*" "macsym\013"
-respond "(C1)" "compile_lisp_file(translate_file(\"sharem\\;packg >\")\[2\]);"
-respond "(C2)" "compile_lisp_file(translate_file(\"tensor\\;ctensr funcs\")\[2\]);"
+respond "(C1)" "translate_file(\"sharem\\;packg >\");"
+respond "(C2)" "quit();"
+respond ":KILL" "complr\013"
+respond "_" "sharem;packg fasl_packg trlisp\r"
+respond "_" "\032"
+type ":kill\r"
+respond "*" "macsym\013"
+respond "(C1)" "translate_file(\"tensor\\;ctensr funcs\");"
 respond "Type ALL;" "all;"
 respond "Type ALL;" "all;"
-respond "(C3)" "quit();"
+respond "(C2)" "quit();"
+respond ":KILL" "complr\013"
+respond "_" "share;ctensr fasl_tensor;ctensr trlisp\r"
+respond "_" "\032"
+type ":kill\r"
 
 ### build eigen for macsyma
 respond "*" "macsym\013"
-respond "(C1)" "compile_lisp_file(translate_file(\"share\\;eigen >\")\[2\]);"
+respond "(C1)" "translate_file(\"share\\;eigen >\");"
 respond "Type ALL;" "all;"
 respond "(C2)" "quit();"
+respond ":KILL" "complr\013"
+respond "_" "share;eigen fasl_share;eigen trlisp\r"
+respond "_" "\032"
+type ":kill\r"
 
 ### more lisplib stuff
 respond "*" "complr\013"

--- a/build/lisp.tcl
+++ b/build/lisp.tcl
@@ -840,6 +840,12 @@ respond "*" ":midas liblsp;_gsb;ttyvar\r"
 respond "Use what filename instead?" "lisp;\r"
 expect ":KILL"
 
+# MLMAC
+respond "*" "complr\013"
+respond "_" "lisp;_lspsrc;mlmac\r"
+respond "_" "\032"
+type ":kill\r"
+
 # Lisp display library
 respond "*" ":midas lisp; slave fasl_l; slave\r"
 expect ":KILL"


### PR DESCRIPTION
Also reverts translate-and-compile of macsyma programs in one step since
this causes an NXM error in KA10 emulator.  Will put back when we find
issue with KA10.