### PR TITLE
KS10 microcode

### DIFF
--- a/build/ka10/include.tcl
+++ b/build/ka10/include.tcl
@@ -120,3 +120,6 @@ proc bootable_tapes {} {
     respond "_" "Q"
     expect ":KILL"
 }
+
+proc update_microcode {} {
+}

--- a/build/ks10/include.tcl
+++ b/build/ks10/include.tcl
@@ -162,3 +162,15 @@ proc bootable_tapes {} {
     respond "Input file" ".;nsalv bin\r"
     expect ":KILL"
 }
+
+proc update_microcode {} {
+    type ":ksfedr\r"
+    respond "!" "write\r"
+    respond "Are you sure" "yes\r"
+    respond "Which file" "ram\r"
+    expect "Input from"
+    sleep 1
+    respond ":" ".;ram ram\r"
+    respond "!" "quit\r"
+    expect ":KILL"
+}

--- a/build/ks10/include.tcl
+++ b/build/ks10/include.tcl
@@ -30,6 +30,12 @@ proc prepare_frontend {} {
     set dir $expect_out(1,string)
     type "write\r"
     respond "Are you sure" "yes\r"
+    respond "Which file" "ram\r"
+    expect "Input from"
+    sleep 1
+    respond ":" ".;ram ram\r"
+    respond "!" "write\r"
+    respond "Are you sure" "yes\r"
     respond "Which file" "bt\r"
     expect "Input from"
     sleep 1

--- a/build/misc.tcl
+++ b/build/misc.tcl
@@ -850,6 +850,8 @@ respond "*" ":kshack;micro kshack;mcr 262=kshack;its,ks10,simple,flt,extend,inou
 expect ":KILL"
 respond "*" ":copy kshack; mcr ram, .; ram ram\r"
 
+update_microcode
+
 # XXFILE
 respond "*" ":midas sysbin;xxfile bin_sysen1;xxfile\r"
 expect ":KILL"

--- a/src/kshack/its.15
+++ b/src/kshack/its.15
@@ -17,7 +17,7 @@
 .SET/TEST=0		;1 => Testing some new feature.
 
 MICROCODE VERSION/=<99:107>
-	UCV=263.
+	UCV=262.
 
 HARDWARE OPTIONS/=<90:92>
 	HWOPT=0


### PR DESCRIPTION
Write KS10 microcode RAM file to the front end file system.

I somehow missed this step in BUILD DOC, and of course the emulators works just as well without it.  It would have failed miserably on a real KS10.