### PR TITLE
Updated to no longer explicitly exclude EDLM from the macsyma build

### DIFF
--- a/build/build.tcl
+++ b/build/build.tcl
@@ -77,13 +77,18 @@ proc build_macsyma_portion {} {
     respond "_" "\007"
     respond "*" "(load \"liblsp;iota\")"
     respond "274630" "(load \"maxtul;docgen\")"
-    respond "300052" "(load \"maxtul;mcl\")"
-    respond "302615" "(load \"maxdoc;mcldat\")"
-    respond "302615" "(load \"libmax;module\")"
-    respond "303351" "(load \"libmax;maxmac\")"
-    expect "307161"
+    respond "300064" "(load \"maxtul;mcl\")"
+    respond "302627" "(load \"maxdoc;mcldat\")"
+    respond "302627" "(load \"libmax;module\")"
+    respond "303363" "(load \"libmax;maxmac\")"
+    expect "307173"
     type "(todo)"
-    expect ") \r"
+    expect {
+	") \r" {
+	}
+        "NIL" {
+	}
+    }
     type "(todoi)"
     expect {
 	") \r" {
@@ -91,10 +96,7 @@ proc build_macsyma_portion {} {
         "NIL" {
 	}
     }
-    type "(mapcan "
-    type "#'(lambda (x) (cond ((not (memq x\r"
-    type "'(EDLM)\r"
-    type ")) (doit x)))) (append todo todoi))"
+    type "(mapcan #'(lambda (x) (doit x)) (append todo todoi))"
     set timeout 1000
     expect {
 	";BKPT" {

--- a/build/lisp.tcl
+++ b/build/lisp.tcl
@@ -516,7 +516,6 @@ build_macsyma_portion
 build_macsyma_portion
 build_macsyma_portion
 build_macsyma_portion
-build_macsyma_portion
 
 respond "*" ":maxtul;maxtul\r"
 respond "MAXIMUM TOOLAGE>" "load-info\r"

--- a/src/maxtul/docgen.38
+++ b/src/maxtul/docgen.38
@@ -237,36 +237,44 @@
 	 (DO ((L MACSYMA-SOURCE-FILES (CDR L)))
 	     ((NULL L))
 	     (LET* ((F (CAR L))
-		    (NAME (MACSYMA-SOURCE-FILE-NAME F)))
-		   (FORMAT OUTSTREAM
-			   "~
-			   ~%(PUSH '~S MACSYMA-FILE-NAMES)~
-			   ~%(DEFPROP ~S ~S DIR)~
-			   ~%(DEFPROP ~S ~S GENPREFIX)"
-			   NAME
-			   NAME
-			   (MACSYMA-SOURCE-FILE-DIR F)
-			   NAME
-			   (MACSYMA-SOURCE-FILE-GENPREFIX F)
-			   )
-		  (IF (MACRO-FILE-P (CAR L))
-		      (FORMAT OUTSTREAM
-			      "~%(DEFPROP ~S T MACRO-FILE)"
-			      NAME)
-		      (FORMAT OUTSTREAM
-			      "~
-			      ~%(DEFPROP ~S ~S UNFASL-DIR)~
-			      ~%(DEFPROP ~S ~S FASL-DIR)~
-			      ~%(DEFPROP ~S ~S ERRMSG-DIR)~
-			      ~%(DEFPROP ~S ~S IN-CORE)"
-			      NAME
-			      (MACSYMA-SOURCE-FILE-UNFASL-DIR F)
-			      NAME
-			      (MACSYMA-SOURCE-FILE-FASL-DIR F)
-			      NAME
-			      (MACSYMA-SOURCE-FILE-ERRMSG-DIR F)
-			      NAME
-			      (MACSYMA-SOURCE-FILE-IN-CORE F)))))
+                (NAME (MACSYMA-SOURCE-FILE-NAME F)))
+               (if (and
+		    (not (INTERSECTIONP
+		     '(PDP10 ITS)
+		     (MACSYMA-SOURCE-FILE-SYSTEMS-NOT-FOR F)))
+		    (INTERSECTIONP
+			  '(PDP10 ITS)
+			  (MACSYMA-SOURCE-FILE-SYSTEMS-FOR F)))
+		   (progn 
+                     (FORMAT OUTSTREAM
+                             "~
+			     ~%(PUSH '~S MACSYMA-FILE-NAMES)~
+			     ~%(DEFPROP ~S ~S DIR)~
+			     ~%(DEFPROP ~S ~S GENPREFIX)"
+                             NAME
+                             NAME
+                             (MACSYMA-SOURCE-FILE-DIR F)
+                             NAME
+                             (MACSYMA-SOURCE-FILE-GENPREFIX F)
+                             )
+                     (IF (MACRO-FILE-P (CAR L))
+                         (FORMAT OUTSTREAM
+                                 "~%(DEFPROP ~S T MACRO-FILE)"
+                                 NAME)
+                         (FORMAT OUTSTREAM
+                                 "~
+			         ~%(DEFPROP ~S ~S UNFASL-DIR)~
+			         ~%(DEFPROP ~S ~S FASL-DIR)~
+			         ~%(DEFPROP ~S ~S ERRMSG-DIR)~
+			         ~%(DEFPROP ~S ~S IN-CORE)"
+                                 NAME
+                                 (MACSYMA-SOURCE-FILE-UNFASL-DIR F)
+                                 NAME
+                                 (MACSYMA-SOURCE-FILE-FASL-DIR F)
+                                 NAME
+                                 (MACSYMA-SOURCE-FILE-ERRMSG-DIR F)
+                                 NAME
+                                 (MACSYMA-SOURCE-FILE-IN-CORE F)))))))
 	 (TERPRI OUTSTREAM)
 	 (SETQ WINP T))
 	;; unwind protected.


### PR DESCRIPTION
The build system will now automatically exclude this source (which is intended for
the lisp machine only).  Resolves #1067.