### PR TITLE
Fix Macsyma build timeout on KA

### DIFF
--- a/build/build.tcl
+++ b/build/build.tcl
@@ -89,14 +89,14 @@ proc build_macsyma_portion {} {
     respond_load "(load \"libmax;maxmac\")"
     respond_load "(todo)"
     expect {
-	") \r" {
+	-re {\) *\r} {
 	}
         "NIL" {
 	}
     }
     type "(todoi)"
     expect {
-	") \r" {
+	-re {\) *\r} {
 	}
         "NIL" {
 	}


### PR DESCRIPTION
After working around #1072 (by JFCLing out the XCT), I found that the sims KA build then timed out in `build_macsyma_portion`. This is because DB, with a 132-column-wide console, formats `(todo)` like this:

```
... TRANSS ROMBRG INTPOL NUMER NDIFFQ MLOAD OUTEX MERROR MFORMT ERMSGM LDISP MDOT SUMCON SYNEX RUNTIM UTILS MUTILS OPTION PRIMER !^M
DESCRI FASDMP IRINTE ASKP LIMIT TLIMIT RESIDU DEFINT SPRDET NEWINV LINNEW EEZ NEWFAC ALGFAC CSIMP2 LOGARC RPART APROPO ITENSR CANTE!^M
N GENER SYMTRY FILEOP RESET MSTUFF SPECFN MMACRO BUILDQ EDCTL EDEXP EDBUF EDITS) ^M
```

And KA, with an 80-column-wide console, does it like this:

```
... FASDMP IRINTE ASKP LIMIT TLIMIT RESIDU DEFINT SPRDET NEWINV LINNEW EEZ NEWFA!^M
C ALGFAC CSIMP2 LOGARC RPART APROPO ITENSR CANTEN GENER SYMTRY FILEOP RESET MST!^M
UFF SPECFN MMACRO BUILDQ EDCTL EDEXP EDBUF EDITS)^M
```

... but the expect script was looking for `) \r` at the end. Fixing this lets the build finish successfully.