### PR TITLE
Add, and look for, an explicit marker after (todo)/(todoi).

### DIFF
--- a/build/build.tcl
+++ b/build/build.tcl
@@ -87,21 +87,9 @@ proc build_macsyma_portion {} {
     respond_load "(load \"maxdoc;mcldat\")"
     respond_load "(load \"libmax;module\")"
     respond_load "(load \"libmax;maxmac\")"
-    respond_load "(todo)"
-    expect {
-	-re {\) *\r} {
-	}
-        "NIL" {
-	}
-    }
-    type "(todoi)"
-    expect {
-	-re {\) *\r} {
-	}
-        "NIL" {
-	}
-    }
-    type "(mapcan #'(lambda (x) (doit x)) (append todo todoi))"
+    respond_load "(progn (print (todo)) (print (todoi)) \"=Build=\")"
+    expect "=Build="
+    respond "\r" "(mapcan #'(lambda (x) (doit x)) (append todo todoi))"
     set timeout 1000
     expect {
 	";BKPT" {


### PR DESCRIPTION
Today I've had a couple of slow VMs doing repeated full builds with sims and simh. This revealed that my fix to #1126 didn't always work; sometimes expect would match a ";Loading (foo)" line instead of the list output, and get out of sync with the Lisp process.

Rather than making the regexp even more complicated, I've made it print a message at the end that's easy to match unambiguously. This is effectively the same thing we've done with XFILE builds elsewhere in the process. (And maybe we should have a standard marker for this - if you've got a better idea than "=Build=", that doesn't contain regexp metacharacters or start with a dash, let me know...)