### PR TITLE
Fix build of ctensr and eigen for Macsyma.

### DIFF
--- a/build/build.tcl
+++ b/build/build.tcl
@@ -89,7 +89,10 @@ proc build_macsyma_portion {} {
     respond_load "(load \"libmax;maxmac\")"
     respond_load "(progn (print (todo)) (print (todoi)) \"=Build=\")"
     expect "=Build="
-    respond "\r" "(mapcan #'(lambda (x) (doit x)) (append todo todoi))"
+    respond "\r" "(mapcan "
+    type "#'(lambda (x) (cond ((not (memq x\r"
+    type "'(TRANSS)\r"
+    type ")) (doit x)))) (append todo todoi))"
     set timeout 1000
     expect {
 	";BKPT" {

--- a/build/lisp.tcl
+++ b/build/lisp.tcl
@@ -547,6 +547,8 @@ respond "*" ":link manual;manual demo,demo;manual demo\r"
 respond "*" "macsym\013"
 respond "(C1)" "compile_lisp_file(translate_file(\"sharem\\;packg >\")\[2\]);"
 respond "(C2)" "compile_lisp_file(translate_file(\"tensor\\;ctensr funcs\")\[2\]);"
+respond "Type ALL;" "all;"
+respond "Type ALL;" "all;"
 respond "(C3)" "quit();"
 
 ### build eigen for macsyma


### PR DESCRIPTION
Resolves #1125.  This reverts the compilation of TRANSS and uses the
FASL file from MC.  I'll have to figure out what is wrong with the
source/compilation in another ticket.