### PR TITLE
Expect improvements

### DIFF
--- a/build/basics.tcl
+++ b/build/basics.tcl
@@ -1,3 +1,5 @@
+log_progress "ENTERING BUILD SCRIPT: BASICS"
+
 expect "\n"; type "\033g"
 pdset
 

--- a/build/build.tcl
+++ b/build/build.tcl
@@ -1,3 +1,12 @@
+proc log_progress {x} {
+    puts ""
+    puts "$x"
+    puts [exec date]
+    puts ""
+}
+
+log_progress "ENTERING MAIN BUILD SCRIPT"
+
 # If the environment variable BASICS is set to "yes", only build
 # the basics; ITS, tools, infastructure.
 if {![info exists env(BASICS)]} {
@@ -140,3 +149,7 @@ type "quit\r"
 
 shutdown
 quit_emulator
+
+puts ""
+puts "MAIN BUILD SCRIPT DONE"
+puts [exec date]

--- a/build/build.tcl
+++ b/build/build.tcl
@@ -115,7 +115,11 @@ proc build_macsyma_portion {} {
 }
 
 set timeout 100
-expect_after timeout abort
+proc setup_timeout {} {
+    # Don't do this until after you've called "spawn", otherwise it'll cause a
+    # read from stdin which will return EOF if stdin isn't a tty.
+    expect_after timeout abort
+}
 
 set ip [ip_address [lindex $argv 0]]
 set gw [ip_address [lindex $argv 1]]

--- a/build/klh10/build.tcl
+++ b/build/klh10/build.tcl
@@ -7,6 +7,7 @@ set emulator_escape "\034"
 
 proc start_salv {} {
     uplevel #0 {spawn ./kn10-ks-its nsalv.ini}
+    setup_timeout
     expect "EOF"
     respond "KLH10#" "go\r"
 }
@@ -20,12 +21,14 @@ proc start_dskdmp {} {
     #respond "KLH10>" "zero\r"
     quit_emulator
     uplevel #0 {spawn ./kn10-ks-its dskdmp.ini}
+    setup_timeout
     expect "EOF"
     respond "KLH10#" "go\r"
 }
 
 proc start_its {} {
     uplevel #0 {spawn ./kn10-ks-its dskdmp.ini}
+    setup_timeout
     expect "EOF"
     respond "KLH10#" "go\r"
 }

--- a/build/lisp.tcl
+++ b/build/lisp.tcl
@@ -1,3 +1,5 @@
+log_progress "ENTERING BUILD SCRIPT: LISP"
+
 # lisp
 respond "*" ":link l;fasdfs 1,lisp;.fasl defs\r"
 respond "*" ":link lisp;grind fasl,lisp;gfile fasl\r"

--- a/build/mark.tcl
+++ b/build/mark.tcl
@@ -1,3 +1,5 @@
+log_progress "ENTERING BUILD SCRIPT: MARK"
+
 start_salv
 
 mark_packs

--- a/build/misc.tcl
+++ b/build/misc.tcl
@@ -1,3 +1,5 @@
+log_progress "ENTERING BUILD SCRIPT: MISC"
+
 respond "*" ":print teach;..new. (udir)\r"
 type ":vk\r"
 

--- a/build/muddle.tcl
+++ b/build/muddle.tcl
@@ -1,3 +1,5 @@
+log_progress "ENTERING BUILD SCRIPT: MUDDLE"
+
 respond "*" ":cwd mudsys\r"
 respond "*" ":midas /t midasm_midas\r"
 respond "\n" "itssw==1\r"

--- a/build/sail.tcl
+++ b/build/sail.tcl
@@ -1,3 +1,5 @@
+log_progress "ENTERING BUILD SCRIPT: SAIL"
+
 # stktrn
 respond "*" ":cwd sail\r"
 respond "*" ":fail stktrn\r"

--- a/build/scheme.tcl
+++ b/build/scheme.tcl
@@ -1,3 +1,5 @@
+log_progress "ENTERING BUILD SCRIPT: SCHEME"
+
 # Old? Scheme interpreter
 respond "*" "complr\013"
 respond "_" "scheme;_nschsy\r"

--- a/build/simh/build.tcl
+++ b/build/simh/build.tcl
@@ -37,6 +37,7 @@ proc create_tape {file} {
 
 proc quit_emulator {} {
     respond "sim>" "q\r"
+    expect eof
 }
 
 proc initialize_comsat {} {

--- a/build/simh/build.tcl
+++ b/build/simh/build.tcl
@@ -4,6 +4,8 @@ set emulator_escape "\034"
 
 proc start_salv {} {
     uplevel #0 {spawn pdp10 build/simh/init}
+    setup_timeout
+
     respond "sim>" "show ver\r"
     respond "sim>" "b tu1\r"
     expect "MTBOOT"
@@ -23,6 +25,7 @@ proc start_dskdmp {} {
 
 proc start_its {} {
     uplevel #0 {spawn pdp10 build/simh/boot}
+    setup_timeout
 }
 
 proc mount_tape {file} {

--- a/build/sims/build.tcl
+++ b/build/sims/build.tcl
@@ -4,6 +4,7 @@ set emulator_escape "\034"
 
 proc start_salv {} {
     uplevel #0 {spawn ./tools/sims/BIN/ka10 build/sims/init}
+    setup_timeout
     expect "MAGDMP\r\n"; send "l\033ddt\r"
     expect "\n"; send "t\033salv\r"
 }
@@ -19,6 +20,7 @@ proc start_dskdmp args {
     }
     set foo "spawn ./tools/sims/BIN/ka10 $ini"
     uplevel #0 $foo
+    setup_timeout
 }
 
 proc mount_tape {file} {

--- a/build/sims/build.tcl
+++ b/build/sims/build.tcl
@@ -43,6 +43,7 @@ proc create_tape {file} {
 
 proc quit_emulator {} {
     respond "sim>" "q\r"
+    expect eof
 }
 
 proc initialize_comsat {} {


### PR DESCRIPTION
- First and foremost, get 'expect' input from /dev/zero to fix missing build log on some CI services.
- Second, make build script progress more clear.