### PR TITLE
Updated misc.tcl to build jotto successfully despite IT IS NOW messages.

### DIFF
--- a/build/misc.tcl
+++ b/build/misc.tcl
@@ -466,7 +466,7 @@ type "c/\0331'dict\033\r"
 # Run the dictionary loader, skipping its filename setup code.
 type "beg7\033g"
 # Dump out TS JOTTO including the dictionary.
-respond ". words" ":pdump sys1;ts jotto\r"
+respond "words" ":pdump sys1;ts jotto\r"
 respond "*" ":kill\r"
 
 # ngame


### PR DESCRIPTION
On my machine the expect script fails to see the ". words" because the "." is
separated by a newline and the message "IT IS NOW..." (time) followed by a newline with "words".  Chnaged from ". words" to "words".
Resolves #1134.