### PR TITLE
Fix wrong URL for KA10 simulator.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -21,4 +21,4 @@
 	url = https://github.com/larsbrinkhoff/mldev
 [submodule "tools/sims"]
 	path = tools/sims
-	url = https://github.com/rcornwell/sims
+	url = https://github.com/larsbrinkhoff/ka10-simh


### PR DESCRIPTION
This was supposed to have been done in f1f2df4, #1140.