### PR TITLE
Build with Circle CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,17 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: debian
+    environment:
+      EMULATOR: "sims"
+    steps:
+      - checkout
+      - run: sh -ex build/dependencies.sh install_linux
+      - run:
+          name: build
+          command: "make EMULATOR=$EMULATOR"
+          no_output_timeout: 60m
+          timeout: 60m
+      - store_artifacts:
+          path: out

--- a/build/dependencies.sh
+++ b/build/dependencies.sh
@@ -1,4 +1,4 @@
-if test -n "$GITLAB_CI"; then
+if test -n "$GITLAB_CI" -o -n "$CIRCLECI"; then
     sudo() {
         "$@"
     }
@@ -9,9 +9,10 @@ install_linux() {
     sudo apt-get install -my expect
     # For GitLab CI
     sudo apt-get install -my git make gcc libncurses-dev autoconf
-    if test "$EMULATOR" = simh; then
-	sudo apt-get install -y simh
-    fi
+    case "$EMULATOR" in
+        simh) sudo apt-get install -y simh;;
+        sims) sudo apt-get install -y libx11-dev libxt-dev;;
+    esac
 }
 
 "$1"

--- a/build/sims/build.tcl
+++ b/build/sims/build.tcl
@@ -10,7 +10,6 @@ proc start_salv {} {
 }
 
 proc start_dskdmp args {
-    puts [llength $args]
     quit_emulator
     set ini ""
     if {[llength $args] == 1} {


### PR DESCRIPTION
Now that expect works without the stdin it expects, we can use Circle CI.

It's a full build with the KA10 simulator, but I may switch it to KLH10.  I'm not sure if it can do more than one build variant, but I'll check.