### PR TITLE
Silence the system job by patching ITS on boot

### DIFF
--- a/build/basics.tcl
+++ b/build/basics.tcl
@@ -1,6 +1,6 @@
 log_progress "ENTERING BUILD SCRIPT: BASICS"
 
-expect "\n"; type "\033g"
+patch_its_and_go
 pdset
 
 respond "*" ":login db\r"

--- a/build/build.tcl
+++ b/build/build.tcl
@@ -37,8 +37,19 @@ proc respond { w r } {
     type $r
 }
 
+proc patch_its_and_go {} {
+    expect "\n"
+
+    # Disable SYSJOB output (e.g. "IT IS NOW ...") that appears at random
+    # places during the build process.
+    type "styo+2/popj p,\r"
+    expect "\n"
+
+    type "\033g"
+}
+
 proc pdset {} {
-    expect "SYSTEM JOB USING THIS CONSOLE"
+    expect "IN OPERATION"
     sleep 1
     type "\032"
 
@@ -50,12 +61,10 @@ proc pdset {} {
     type "!."
     expect "DAYLIGHT SAVINGS" {
         type "N"
-	respond "IT IS NOW" "Q"
-    } "IT IS NOW" {
-        type "Q"
-    } "ITS revived" {
-        type "Q"
+        expect "\n"
+    } "\n" {
     }
+    type "Q"
     expect ":KILL"
 }
 

--- a/build/ka10/include.tcl
+++ b/build/ka10/include.tcl
@@ -2,7 +2,7 @@ proc start_dskdmp_its {} {
     start_dskdmp build/sims/boot
 
     respond "DSKDMP" "its\r"
-    expect "\n"; type "\033g"
+    patch_its_and_go
 }
 
 proc mark_packs {} {

--- a/build/ks10/include.tcl
+++ b/build/ks10/include.tcl
@@ -7,7 +7,7 @@ proc start_dskdmp_its {} {
     respond "DSKDMP" "m\033salv rp06\r"
     expect "\n"; type "d\033its\r"
     expect "\n"; type "its\r"
-    expect "\n"; type "\033g"
+    patch_its_and_go
 }
 
 proc mark_packs {} {
@@ -56,7 +56,7 @@ proc prepare_frontend {} {
 
     start_its
     respond "DSKDMP" "its\r"
-    type "\033g"
+    patch_its_and_go
     pdset
 
     respond "*" ":login db\r"


### PR DESCRIPTION
Avoid problems like #1134, where the system job has printed a message at an unhelpful time, by disabling its print routine with a boot-time patch. This also makes build logs shorter and more consistent, so they're easier to diff.

This needs some discussion before merging; in particular:

* Patching a random instruction into STYO+2 seems a bit ugly; we could add a label to patch, or even have a flag bit somewhere. But it has the advantage of working with unmodified original ITS when we're using it for bootstrapping...

* The sources.tape LOAD phase now doesn't produce any output until it completes. This may cause problems with tests - e.g. I think Travis gives up if it hasn't seen any new output for ten minutes, and at present LOAD is taking about 7 minutes on some builds (#1100).