### PR TITLE
Login messages

### DIFF
--- a/src/sys/net.mail
+++ b/src/sys/net.mail
@@ -1,0 +1,1 @@
+It's a lovely day to be a turist!

--- a/src/sys/system.mail
+++ b/src/sys/system.mail
@@ -1,0 +1,8 @@
+Welcome to ITS!
+
+For brief information, type ?
+For a list of colon commands, type :? and press Enter.
+For the full info system, start Emacs and enter Info:
+Type :emacs Enter Esc X info Enter.
+
+Happy hacking!


### PR DESCRIPTION
TELSER prints out SYS: NET MAIL when a user connects.  This only shows briefly.  As soon as DDT starts, it will clear the screen and print SYS: SYSTEM MAIL.  (There's also SYS: NETLSR MAIL.  I don't know when it's used.)

Helpful messages should be entered in these files.