### PR TITLE
Update DDT to use TV meta bucky bit

### DIFF
--- a/src/sysen1/ddt.1547
+++ b/src/sysen1/ddt.1547
@@ -6966,9 +6966,20 @@ TYI:	CALL TYOFRC	;.LISTEN IS SUPPOSED TO FORCE OUTPUT.
 TYI3:	CALL HAKKAM	;DO HAKKAH RQ'S, SAY DO ANY MORE WHEN QUEUED.
 	SETZM CTLZFL
 	SKIPGE D,TTYUNR
-	  .IOT TYIC,D
+	  .IOT TYIFC,D	;READ FULL CHAR SET INPUT CHANNEL
+	SKIPE METAP
+	 JRST [TRZ D,%TXTOP+%TXSUP	;CLEAR TOP AND SUPER
+	       TRZE D,%TXCTL	;IF CONTROL BIT SET,
+	        TRZ D,140	;CONVERT TO ASCII.
+	       TRZN D,%TXMTA
+		JRST .+1
+	       MOVEM D,TTYUNR	;META BIT SET, SAVE CHAR FOR LATER.
+	       MOVEI D,33	;RETURN ALTMODE.
+	       JRST TYI4]
 	SETOM TTYUNR
-	setzm hakok	;defer HAKKAH rq's again.
+TYI4:	setzm hakok	;defer HAKKAH rq's again.
+	skipe echop
+	 pushj p,echo	;Echo character.
 	skipn tthelp		   ;If [HELP] isn't desired
 	  caie d,%txtop+"H	   ;  help key becomes question mark
 	    caia
@@ -6998,6 +7009,15 @@ TYI3:	CALL HAKKAM	;DO HAKKAH RQ'S, SAY DO ANY MORE WHEN QUEUED.
 	  cain d,^W
 	    popj p,
 	jrst popj1
+
+echo:	caie d,^I	;TAB and LF don't echo.
+	  cain d,^J
+	    popj p,
+	cain d,^L	;FF clears screen.
+	  jrst formfa
+	caie d,177	;Rubout doesn't echo.
+	  .iot tyoc,d
+	popj p,
 
 ;IF THE CHAR IN D IS ^V, ^W, ^B, ^E OR ^S, PROCESS IT AND DON'T SKIP.
 ;OTHERWISE SKIP.
@@ -10571,6 +10591,10 @@ IOCOPN:	TSOPEN TYOC,[[21,,'TTY]]
 	tlnn i4,%toers	;if the TTY is erasible
 	  tlnn i4,%toovr  ;  or can't be overwritten,
 	    setom erase	;   ^PX and friends will win!
+	TLNE I4,%TOFCI	;CAN TTY DO FULL 12-BIT CHARACTER SET?
+	 AOSA METAP	; META KEY WINS
+	  CAIA
+	   AOS ECHOP	; DO ECHOING.
 	TLNE I4,%TOMVU
 	 AOS GETTY
 	TLZ C,%TSSAI+%TSROL+%TSMOR
@@ -10588,6 +10612,11 @@ IOCOPN:	TSOPEN TYOC,[[21,,'TTY]]
 	 TLNE I4,%TOERS
 	  SETZM NOERASE	;NOERASE IS SET IF TTY IS A STORAGE TUBE.
 	MOVEM C,TTYSTS
+	SKIPE ECHOP	;Turn off echoing by ITS.
+	 JRST [ MOVE C,[171717,,171717]
+		ANDM C,TTYST1
+		ANDM C,TTYST2
+		JRST .+1 ]
 	TSCALL TTYSB1
 	MOVE C,GETTY
 	MOVEM C,PCPNTF
@@ -10596,8 +10625,8 @@ IOCOPN:	TSOPEN TYOC,[[21,,'TTY]]
 
 TTYSB1:	SETZ ? 'TTYSET
 	%CLIMM,,TYOC
-	[232222,,222222]
-	[230222,,220222]
+	TTYST1
+	TTYST2
 	SETZ TTYSTS
 
 TTYGYP:	SETZ
@@ -17385,6 +17414,8 @@ TTYMXH:	0	;TTY's horizontal size
 OSPEED:	0	;TTY's OSPEED variable
 ISPEED:	0	;TTY's ISPEED variable
 SMARTS:	0	;TTY's SMARTS variable
+TTYST1:	232222,,222222
+TTYST2:	230222,,220222
 TTYSTS:	0	;NORMAL TTYSTS; **MORE** ENABLED.
 TTYSCM:	0	;TTYCOM SAVED HERE TO RESTORE STATE OF OCO AT %SAVEX
 SCROLL:	0	;-1 IFF TTY IS IN SCROLL MODE.
@@ -17598,6 +17629,8 @@ JPDLP:	004400,,JPDLB+1	;POINTER INTO JPDL
 JPDLB:	BLOCK JPDLL
 JPDLE::
 JPDLC:	0		;# OF VALID ENTRIES IN JPDL (BETWEEN 0 AND JPDLL)
+METAP:	0		;WINNING META KEY
+ECHOP:	0		;DO ECHOING
 
 	VARIAB
 DDTEND:	INFORM [Start of SYMTAB space]\.-1


### PR DESCRIPTION
When logged in from a TV, typing to e.g. DDT will ignore the Meta bucky bit.  Typing <kbd>Meta</kbd>+<kbd>U</kbd> prints just U, which is a disappointment.

Also, ^Z is no longer a system-level attention characters, but a plain control character.  That's jarring, but maybe we can get used to that.