### PR TITLE
Fix KA10 build script MARK responses.

### DIFF
--- a/build/build.tcl
+++ b/build/build.tcl
@@ -38,14 +38,10 @@ proc respond { w r } {
 }
 
 proc patch_its_and_go {} {
-    expect "\n"
-
     # Disable SYSJOB output (e.g. "IT IS NOW ...") that appears at random
     # places during the build process.
-    type "styo+2/popj p,\r"
-    expect "\n"
-
-    type "\033g"
+    respond "\n" "styo+2/popj p,\r"
+    respond "\n" "\033g"
 }
 
 proc pdset {} {
@@ -71,8 +67,7 @@ proc pdset {} {
 proc shutdown {} {
     global emulator_escape
     respond "*" ":lock\r"
-    expect "_"
-    send "5kill"
+    respond "_" "5kill"
     respond "GO DOWN?\r\n" "y"
     respond "BRIEF MESSAGE" "\003"
     respond "_" "q"

--- a/build/ka10/include.tcl
+++ b/build/ka10/include.tcl
@@ -98,8 +98,8 @@ proc dump_nits {} {
 
     # Since we bootstrap with a 2-pack ITS, we need to copy the MFD to
     # the fresh packs.
-    expect "\n"; type "t\033salv\r"
-    expect "\n"; type "ucop\033g"
+    respond "\n" "t\033salv\r"
+    respond "\n" "ucop\033g"
     respond "UNIT #" "0"
     respond "UNIT #" "2"
     respond "OK?" "Y"
@@ -111,9 +111,9 @@ proc dump_nits {} {
 
     # Now dump the new ITS.
     respond "DSKDMP" "t\033its bin\r"
-    expect "\n"; type "\033u"
+    respond "\n" "\033u"
     respond "DSKDMP" "m\033@ salv\r"
-    expect "\n"; type "d\033nits\r"
+    respond "\n" "d\033nits\r"
 }
 
 proc magdmp_switches {} {

--- a/build/ka10/include.tcl
+++ b/build/ka10/include.tcl
@@ -12,7 +12,6 @@ proc mark_packs {} {
     respond "NO =" "2\r"
     expect -timeout 300 "VERIFICATION"
     respond "ALLOC =" "3000\r"
-    respond "PACK # =" "2\r"
     respond "PACK ID =" "2\r"
 
     respond "\n" "mark\033g"
@@ -21,7 +20,6 @@ proc mark_packs {} {
     respond "NO =" "3\r"
     expect -timeout 300 "VERIFICATION"
     respond "ALLOC =" "3000\r"
-    respond "PACK # =" "3\r"
     respond "PACK ID =" "3\r"
 
     respond "\n" "mark\033g"
@@ -30,7 +28,6 @@ proc mark_packs {} {
     respond "NO =" "0\r"
     expect -timeout 300 "VERIFICATION"
     respond "ALLOC =" "3000\r"
-    respond "PACK # =" "0\r"
     respond "PACK ID =" "0\r"
 
     respond "DDT" "mark\033g"
@@ -39,7 +36,6 @@ proc mark_packs {} {
     respond "NO =" "1\r"
     expect -timeout 300 "VERIFICATION"
     respond "ALLOC =" "3000\r"
-    respond "PACK # =" "1\r"
     respond "PACK ID =" "1\r"
 }
 

--- a/build/ks10/include.tcl
+++ b/build/ks10/include.tcl
@@ -2,11 +2,11 @@ proc start_dskdmp_its {} {
     start_dskdmp
 
     respond "DSKDMP" "l\033ddt\r"
-    expect "\n"; type "t\033its rp06\r"
-    expect "\n"; type "\033u"
+    respond "\n" "t\033its rp06\r"
+    respond "\n" "\033u"
     respond "DSKDMP" "m\033salv rp06\r"
-    expect "\n"; type "d\033its\r"
-    expect "\n"; type "its\r"
+    respond "\n" "d\033its\r"
+    respond "\n" "its\r"
     patch_its_and_go
 }
 

--- a/build/mark.tcl
+++ b/build/mark.tcl
@@ -62,4 +62,4 @@ frontend_bootstrap
 shutdown
 start_dskdmp
 dump_nits
-expect "\n"; type "nits\r"
+expect "\n"; type "g\033"

--- a/build/mark.tcl
+++ b/build/mark.tcl
@@ -62,4 +62,4 @@ frontend_bootstrap
 shutdown
 start_dskdmp
 dump_nits
-expect "\n"; type "g\033"
+respond "\n" "g\033"


### PR DESCRIPTION
SALV prints `PACK # =` for information, not request for input.