### PR TITLE
KLH10 console lights

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -171,7 +171,7 @@ $(KLH10):
 	$(MKDIR) tmp; \
 	cd tmp; \
 	export CONFFLAGS_USR=-DKLH10_DEV_DPTM03=0; \
-	../configure --bindir="$(CURDIR)/build/klh10"; \
+	../configure --enable-lights --bindir="$(CURDIR)/build/klh10"; \
 	$(MAKE) -C bld-ks-its; \
 	$(MAKE) -C bld-ks-its install
 

--- a/Makefile
+++ b/Makefile
@@ -166,12 +166,13 @@ $(OUT)/syshst/$(H3TEXT): build/$(H3TEXT)
 
 $(KLH10):
 	cd tools/klh10; \
+	$(RM) -rf tmp; \
 	./autogen.sh; \
 	$(MKDIR) tmp; \
 	cd tmp; \
 	export CONFFLAGS_USR=-DKLH10_DEV_DPTM03=0; \
 	../configure --bindir="$(CURDIR)/build/klh10"; \
-	$(MAKE) base-ks-its; \
+	$(MAKE) -C bld-ks-its; \
 	$(MAKE) -C bld-ks-its install
 
 $(SIMH):

--- a/build/dependencies.sh
+++ b/build/dependencies.sh
@@ -12,6 +12,7 @@ install_linux() {
     case "$EMULATOR" in
         simh) sudo apt-get install -y simh;;
         sims) sudo apt-get install -y libx11-dev libxt-dev;;
+        klh10) sudo apt-get install -y libusb-1.0-0-dev;;
     esac
 }
 

--- a/build/klh10/dskdmp.txt
+++ b/build/klh10/dskdmp.txt
@@ -25,5 +25,8 @@ devdef dz0  ub3   dz11   addr=760010 br=5 vec=340
 ; Define new HOST device hackery
 devdef idler ub3 host addr=777000
 
+; Console lights.
+lights usb
+
 load @.ddt-u
 load dskdmp.216bin


### PR DESCRIPTION
This enables use of the Panda Display console lights with the KLH10 emulator.

- Compiling KLH10 with `--enable-lights` uses libusb to talk to the display.
- In KLH10, the command `lights usb` looks for the device on the USB bus.

If the device isn't there, it's just ignored.  However, this will force everyone to install the libusb library to build KLH10, and that's not good.  Any suggestions how to avoid that?