### PR TITLE
DSKDMP 215 versus 216

### DIFF
--- a/src/system/dskdmp.216
+++ b/src/system/dskdmp.216
@@ -1276,14 +1276,11 @@ LOADG:	JSP TT,WRCB		;MAKE SURE ALL LOADED CRUFT IN PSEUDO-CORE IS OUT
 	TRNE CMD,10
 	 JRST READ		;NON-GOING COMMAND
 GO:
-PH,[	MOVSI B,-LSWPADR
-GO1:	IORD DIFF,SWPCS1
-	TRNN DIFF,%HXRDY	; Wait for controller
-	 JRST GO1
-	HRRZ DIFF,SWPVAL(B)
-	IOWR DIFF,SWPADR(B)
-	AOBJN B,GO1
+PH,[
+	JRST PHGO	; Go boot DSKDMP in.  See comments there
+			; explaining why RH11 code was moved to bootstrap.
 ];PH
+
 RH,[	MOVE B,ERRWD
 	CONI DSK,HEAD
 	TLNE HEAD,(%HID22)
@@ -1295,6 +1292,7 @@ GO1:	CONSZ DSK,%HIBSY
 	MOVE DIFF,SWPOU1(B)
 	JSP HEAD,RHSET
 	AOBJN B,GO1
+	JRST WAIT
 ];RH
 RP,[	MOVE B,ERRWD
 	MOVEM B,@ICWA
@@ -1304,9 +1302,11 @@ RP,[	MOVE B,ERRWD
 	CONSO DPC,DONE
 	 JRST .-1
 	DATAO DPC,SWPOU2
-];RP
-SC,	DATAO DC0,[DJMP SWPOUT]
 	JRST WAIT
+];RP
+SC,[	DATAO DC0,[DJMP SWPOUT]
+	JRST WAIT
+];SC
 
 LISTS:	JSP P,CRLF
 LISTS2:	JSP P,TYI0
@@ -1610,6 +1610,7 @@ BADBLK:	0		;BLOCK WITH HDWE ERROR
 INFORM BADBLK,\.-1-BEG+<MEMSIZ-2000>
 
 ];END IFE BOOTSW
+
 IFN BOOTSW,[
 BEG=MEMSIZ-2000
 LOC MEMSIZ-100
@@ -1747,9 +1748,25 @@ IFN .-SWPVAL-LSWPADR, .ERR SWPVAL wrong length.
 
 CBLK:	-NSWBL,,NBLKS
 
-WAIT:	IORD B,SWPCS1
+; Bootstrap entry point to swap DSKDMP into memory.
+; This code used to live at GO: but has been moved into the bootstrap
+; to avoid a horrible race condition where it blissfully commanded the
+; disk to write over the GO-code before it jumped out of harm's way.
+; A real RH11 is slow enough that this used to work, but under the
+; KLH10 emulator it can and does get clobbered!    --KLH
+
+PHGO:	MOVSI B,-LSWPADR
+PHGO1:	IORD DIFF,SWPCS1
+	TRNN DIFF,%HXRDY	; Wait for controller
+	 JRST PHGO1
+	HRRZ DIFF,SWPVAL(B)
+	IOWR DIFF,SWPADR(B)
+	AOBJN B,PHGO1
+
+PHWAIT:	IORD B,SWPCS1
 	TRNN B,%HXRDY
-	 JRST WAIT
+	 JRST PHWAIT
+	; Fall through when bootstrap has finished loading full DSKDMP.
 ];PH
 
 RH,[
@@ -1859,8 +1876,13 @@ CBLK:	-NSWBL,,NBLKS		;DISK ADDR OF CORE BUFFER, - # BLOCKS IN LH
 WAIT:	CONSZ DC0,DSSACT
 	 JRST .-1
 ];SC
+
+	; End of last-100-words bootstrap.
+	; Fall through to here from device-specific code when I/O complete
 SADR:	JRST BOOT		;AND GO TO PROGRAM TO BE STARTED
 SYSN:	SIXBIT /./		;CURRENT DIRECTORY
+
+	; Make sure bootstrap didn't go off edge of world (777777)
 IFG .+1-MEMSIZ,.ERR BOOT BLOAT
 
 IFE BOOTSW,{			;CURLY BRACKETS TO AVOID ERROR MESSAGE


### PR DESCRIPTION
I just noticed that the DSKDMP I have on ES was built from SYSTEM; DSKDMP 216 and the one in DB was built from SYSTEM; DSKDMP 215. I did a SRCCOM on the two versions and there are several differences -- including some comments by KLH regarding running under KLH10.  Are we using version 215 for a specific reason?