### PR TITLE
CTN - network CRTSTY

### DIFF
--- a/build/basics.tcl
+++ b/build/basics.tcl
@@ -82,6 +82,16 @@ respond " BIN" "\r"
 respond "*" ":kill\r"
 respond "*" ":link sys3;ts crtsty,sysbin;crtsty bin\r"
 
+# CTN, networking "supdup" CRTSTY
+respond "*" ":midas /t sysbin;ctn bin_syseng; crtsty\r"
+respond "with ^C" "NET==1\r\003"
+expect ":KILL"
+respond "*" ":job ctn\r"
+respond "*" ":load sysbin; ctn bin\r"
+respond "*" "purify\033g"
+respond " BIN" "sys3; ts ctn\r"
+respond "*" ":kill\r"
+
 respond "*" ":midas /t sysbin;_sysen2;peek\r"
 peek_switches
 expect ":KILL"

--- a/doc/programs.md
+++ b/doc/programs.md
@@ -56,6 +56,7 @@
 - CRTSTY, provide display support for additional terminal types.
 - CTIMES, Chaosnet time server.
 - CTIMSR, Chaosnet time server.
+- CTN, networking "supdup" CRTSTY.
 - D, SUDS drawing program
 - DATE, print date and time.
 - DATSRV, server for RFC 867 Daytime protocol.


### PR DESCRIPTION
By enabling NET, you get a networking version of CRTSTY, which is called SYS3; TS CTN.