### PR TITLE
Update location of TCTYP; no link.

### DIFF
--- a/build/basics.tcl
+++ b/build/basics.tcl
@@ -34,9 +34,8 @@ respond "*" ":print device;..new. (udir)\r"
 type ":vk\r"
 
 # TCTYP
-respond "*" ":midas sysbin;_syseng;tctyp\r"
+respond "*" ":midas sys1; ts tctyp_syseng;tctyp\r"
 expect ":KILL"
-respond "*" ":link sys;ts tctyp,sysbin;tctyp bin\r"
 
 source $build/emacs.tcl
 

--- a/build/basics.tcl
+++ b/build/basics.tcl
@@ -36,6 +36,7 @@ type ":vk\r"
 # TCTYP
 respond "*" ":midas sys1; ts tctyp_syseng;tctyp\r"
 expect ":KILL"
+respond "*" ":link sys1;ts tctype, sys1; ts tctyp\r"
 
 source $build/emacs.tcl
 


### PR DESCRIPTION
SYS1; TS TCTYPE should link to TS TCTYP.

Resolves #1261.