### PR TITLE
Updating mismatched apostrophes and single quotes

### DIFF
--- a/src/sysen3/zork.21
+++ b/src/sysen3/zork.21
@@ -31,7 +31,7 @@ zork:	syscal OPEN,[ %clbit,,.uao\%tjdis ? %climm,,ttyo  ;open TTY for output
 There appears before you a huge figure clothed in a dark
 robe. As you shrink back in awe, he speaks:
 
-   ``This is not the machine of the Zork Implementors!''
+   ''This is not the machine of the Zork Implementors!''
 
 Then, as suddenly as it appeared, his image dissolves,
 leaving you in darkness. 


### PR DESCRIPTION
In the `zork` file, the apostrophes and single quotes are currently used to start and open a sentence. This PR standardizes on one character.