### PR TITLE
CI build on Mac

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+os:
+  - linux
+  - osx
 language: c
 dist: trusty
 sudo: required
@@ -5,6 +8,12 @@ env:
   - EMULATOR=simh BASICS=yes
   - EMULATOR=klh10 BASICS=yes
   - EMULATOR=sims BASICS=yes
+matrix:
+  exclude:
+    - os: osx
+      env: EMULATOR=klh10 BASICS=yes
+    - os: osx
+      env: EMULATOR=sims BASICS=yes
 install: sh -ex build/dependencies.sh install_${TRAVIS_OS_NAME:-linux}
 script: make check-dirs all
 deploy:

--- a/Makefile
+++ b/Makefile
@@ -107,9 +107,9 @@ $(OUT)/ka-minsys.tape: $(ITSTAR) $(OUT)/system
 $(OUT)/sources.tape: $(ITSTAR) build/$(EMULATOR)/stamp $(OUT)/syshst/$(H3TEXT)
 	$(MKDIR) $(OUT)
 	$(RM) -f src/*/*~
-	$(TOUCH) -d 1981-10-06T19:03:37 'bin/emacs/einit.:ej'
-	$(TOUCH) -d 1981-09-19T21:42:56 'bin/emacs/[pure].162'
-	$(TOUCH) -d 1981-03-31T20:41:45 'bin/emacs/[prfy].173'
+	$(TOUCH) -t 198110061903.37 'bin/emacs/einit.:ej'
+	$(TOUCH) -t 198109192142.56 'bin/emacs/[pure].162'
+	$(TOUCH) -t 198103312041.45 'bin/emacs/[prfy].173'
 	$(ITSTAR) -cf $@ -C src $(SRC)
 	$(ITSTAR) -rf $@ -C doc $(DOC)
 	$(ITSTAR) -rf $@ -C bin $(BIN)

--- a/build/dependencies.sh
+++ b/build/dependencies.sh
@@ -16,4 +16,8 @@ install_linux() {
     esac
 }
 
+install_osx() {
+    true
+}
+
 "$1"


### PR DESCRIPTION
Building on what @TheFausap did in #1325.  Builds using SIMH KS10 on Travis CI.  KLH10 doesn't work well with expect for unknown reasons.  The KA10 simulator complains about not finding X11/X.h.

Tested `touch -t` on Linux and NetBSD, so I suppose it's not a problem to change from `touch -d`.