### PR TITLE
Fix KS10 SIMH script for GT40.

### DIFF
--- a/build/simh/gt40
+++ b/build/simh/gt40
@@ -12,5 +12,6 @@ set vt crt=vr14
 set vt scale=1
 set vt address=17772000
 set rom enabled
-at rom out/sims/bootvt.img
+set rom0 address=17766000
+at rom out/simh/bootvt.img
 go 166000

--- a/build/simh/start
+++ b/build/simh/start
@@ -2,7 +2,7 @@
 
 gt40() {
     trap kill_gt40 0
-    (sleep 3; tools/simh/BIN/pdp11 build/sims/gt40 >gt40.log 2>&1) &
+    (sleep 3; tools/simh/BIN/pdp11 build/simh/gt40 >gt40.log 2>&1) &
     GT40="$!"
     echo "GT40 started, pid $GT40"
 }


### PR DESCRIPTION
Some mistakes make the GT40 script unusable with SIMH.