### PR TITLE
Fix link for UPTIME Chaosnet server.

### DIFF
--- a/build/misc.tcl
+++ b/build/misc.tcl
@@ -834,7 +834,7 @@ respond "*" ":link sys1;ts down, sys1;ts up\r"
 # UPTIME
 respond "*" ":midas sysbin;uptime bin_sysen1;uptime\r"
 expect ":KILL"
-respond "*" ":link dragon;hourly uptime,sysbin;uptime bin\r"
+respond "*" ":link device;chaos uptime,sysbin;uptime bin\r"
 
 # SHUTDN
 respond "*" ":midas sys3;ts shutdn_bawden;shutdn\r"


### PR DESCRIPTION
The UPTIME BIN in SYSBIN is the UPTIME server, and should be linked from DEVICE.

There's another UPTIME BIN in BAWDEN which could be linked from DRAGON.