### PR TITLE
CHASTA - print Chaos NCP state.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ SRC = syseng sysen1 sysen2 sysen3 sysnet kshack dragon channa	\
       draw wl taa tj6 budd sharem ucode rvb kldcp math as imsrc gls demo \
       macsym lmcons dmcg hack hibou agb gt40 rug maeda ms kle aap common \
       fonts zork 11logo kmp info aplogo bkph bbn pdp11 chsncp sca music1 \
-      moon teach ken lmio1 llogo
+      moon teach ken lmio1 llogo chsgtv
 DOC = info _info_ sysdoc sysnet syshst kshack _teco_ emacs emacs1 c kcc \
       chprog sail draw wl pc tj6 share _glpr_ _xgpr_ inquir mudman system \
       xfont maxout ucode moon acount alan channa fonts games graphs humor \

--- a/build/misc.tcl
+++ b/build/misc.tcl
@@ -811,6 +811,10 @@ expect ":KILL"
 respond "*" ":midas sys2;ts chatst_sysen3;chatst\r"
 expect ":KILL"
 
+# CHASTA
+respond "*" ":midas sys3;ts chasta_chsgtv;chasta\r"
+expect ":KILL"
+
 # STYLOG
 respond "*" ":midas sys2;ts stylog_sysen1;stylog\r"
 expect ":KILL"

--- a/doc/programs.md
+++ b/doc/programs.md
@@ -40,6 +40,7 @@
 - CHADEV, Chaosnet jobdev (binary only).
 - CHARFC/CHARFS, Chaos RFC.
 - CHASE, a 2-player maze game.
+- CHASTA, print Chaos NCP state.
 - CHATST, Chaos test.
 - CHESS, unknown chess program.
 - CHESS2, Alan Baisley's Tech II chess program.

--- a/src/chsgtv/chasta.8
+++ b/src/chsgtv/chasta.8
@@ -1,0 +1,360 @@
+	title Print Chaos NCP State
+
+temp=0
+a=1
+b=2
+c=3
+d=4
+e=5
+ptrl=14
+ptr=15
+idx=16
+p=17
+
+pdl:	block 100
+pat:
+patch:	block 40
+
+tyoch==1
+tyich==2
+
+define symtab syms
+irp sym,,[syms]
+	sym',,[squoze 0,/sym/]
+termin
+	0
+termin
+
+define print message
+	move ptr,[440700,,[ascii /message/]]
+	movei ptrl,.length /message/
+	.call [	setz ? sixbit /SIOT/ ? 1000,,tyoch ? ptr ? setz ptrl]
+	 .lose 1000
+termin
+
+define exam addr
+	hrlzi temp,addr
+	.getloc temp,
+termin
+
+define extab tab,ind
+	move temp,tab
+	addi temp,ind
+	hrlz temp,temp
+	.getloc temp,
+termin
+
+start:	move p,[-100,,pdl]
+	.call [	setz ? sixbit /OPEN/ ? [.uao,,tyoch] ? setz [sixbit /TTY/]]
+	 .lose 1000
+	.call [ setz ? sixbit /OPEN/ ? [.uai,,tyich] ? setz [sixbit /TTY/]]
+	 .lose 1000
+	pushj p,evsyms
+	pushj p,getidx
+	skipl idx,index		;get index to print
+	 jrst oneidx		;only one
+	move a,nindx		;get aobjn pointer
+	hrloi idx,-1(a)
+	eqvi idx,0
+idxlp:	extab chsusr,(idx)
+	skipl temp		;Skip if no user on this index
+	 pushj p,prtidx		;print index
+	aobjn idx,idxlp
+	pushj p,prtrec		;print recent-headers ring buffer
+	.break 16,120000
+oneidx:	pushj p,prtidx
+	.break 16,120000
+
+
+prtidx:	print [
+Channel: ]
+	hrrz a,idx
+	pushj p,numout
+	print [  User: ]
+	extab chsusr,(idx)
+	skipge a,temp
+	 jrst [print [<none>] ? jrst prtdon]
+	hrrz c,a		;get user index
+	extab jname,(c)
+	push p,temp
+	extab uname,(c)
+	print [|]
+	move a,temp
+	pushj p,sixout
+	print [|,|]
+	pop p,a
+	pushj p,sixout
+	print [|]
+prt1:	print [  State: ]
+	extab chssta,(idx)
+	hrrz a,temp
+	hrrz b,statab(a)
+	hrli b,440700
+	hlrz c,statab(a)
+	.call [	setz ? sixbit /SIOT/ ? 1000,,tyoch ? b ? setz c]
+	 .lose
+	print [
+  Local: ]
+	extab chslcl,(idx)
+	push p,temp
+	move a,temp
+	lsh a,-24
+	pushj p,numout
+	print [,]
+	pop p,a
+	lsh a,-4
+	andi a,177777
+	pushj p,numout
+	print [  Foreign: ]
+	extab chsfrn,(idx)
+	push p,temp
+	move a,temp
+	lsh a,-24
+	pushj p,numout
+	print [,]
+	pop p,a
+	lsh a,-4
+	andi a,177777
+	pushj p,numout
+	print [
+    Transmit side:: Window: ]
+	extab chswin,(idx)
+	hrrz a,temp
+	pushj p,numout
+	print [  Trans: ]
+	extab chspkn,(idx)
+	hrrz a,temp
+	pushj p,numout
+	print [  Ack: ]
+	extab chsack,(idx)
+	hrrz a,temp
+	pushj p,numout
+	print [
+      Buffered: ]
+	extab chsobf,(idx)
+	pushj p,pkrang
+	print [
+    Receive side:: Window: ]
+	extab chswin,(idx)
+	hlrz a,temp
+	pushj p,numout
+	print [  Ack: ]
+	extab chsack,(idx)
+	hlrz a,temp
+	pushj p,numout
+	print [  Sack: ]
+	extab chspkn,(idx)
+	hlrz a,temp
+	pushj p,numout
+	print [
+      Order Buffer: ]
+	extab chsibf,(idx)
+	pushj p,pkrang
+	print [  Unorder buffer: ]
+	extab chspbf,(idx)
+	pushj p,prlist
+prtdon:	popj p,
+
+;Print ring-buffer of recent headers
+if1 .insrt system;chsdef
+
+.vector hdr(%cpkdt)
+
+prtrec:	print [
+Recent headers in from network:
+]
+	hrlz temp,rechdp
+	hrri temp,e
+	.getloc temp,		;e:=Address of next into buffer, = oldest
+	move d,nrechd		;Get size of buffer
+	imuli d,%cpkdt
+	add d,rechdr		;Address of end of buffer
+	move c,nrechd		;Number of entries to print
+	movem c,prtrcn'
+prtrc1:	movsi c,-%cpkdt		;Number of words to get
+prtrc2:	hrlz temp,e
+	;hrri temp,temp
+	.getloc temp,
+	movem temp,hdr(c)
+	addi e,1
+	aobjn c,prtrc2
+	ldb b,[$cpkop hdr]
+	cail b,%comax
+	 move a,[sixbit/max???/]
+	cail b,%codat
+	 move a,[sixbit/dat/]
+	caige b,%comax
+	 move a,opsix(b)
+prtrc3:	pushj p,sixout
+	.iot tyoch,[" ]
+	.iot tyoch,["[]
+	ldb a,[$cpknb hdr]
+	pushj p,numout
+	.iot tyoch,["]]
+	.iot tyoch,[" ]
+	ldb a,[$cpksa hdr]
+	pushj p,numout
+	.iot tyoch,["-]
+	ldb a,[$cpksi hdr]
+	pushj p,numout
+	.iot tyoch,["-]
+	.iot tyoch,[">]
+	ldb a,[$cpkda hdr]
+	pushj p,numout
+	.iot tyoch,["-]
+	ldb a,[$cpkdi hdr]
+	pushj p,numout
+	move a,[sixbit/ pkt#=/]
+	pushj p,sixout
+	ldb a,[$cpkpn hdr]
+	pushj p,numout
+	move a,[sixbit/ ack#=/]
+	pushj p,sixout
+	ldb a,[$cpkan hdr]
+	pushj p,numout
+	.iot tyoch,[^M]
+	.iot tyoch,[^J]
+	camn e,d
+	 move e,rechdr
+	sosle prtrcn
+	 jrst prtrc1
+	popj p,
+
+;prints number in a, smashes b, c, temp, assumes a=temp+1
+
+numout:	movei c,12.		;number of digits in 
+	setz temp		;zero temp
+	skipge a		;skip if non negative
+	 jrst [ print [-] ? movm a,a ?  jrst .+1]
+zerlp:	lshc temp,3		;shift to supress leading 0's
+	jumpn temp,nplp		;skip if it is non-zero
+	 sojg c,zerlp		;otherwise keep shifting
+	aos c			;increase count by one
+nplp:	addi temp,"0		;convert to ascii
+	.iot tyoch,temp		;output it
+	setz temp		;clear it out
+	lshc temp,3		;get top bits into temp
+	sojg c,nplp		;print it all
+	popj p,
+
+;prints object in a as sixbit
+sixout:	setz temp
+	skipn a			;stop when 0
+	 popj p,
+	lshc temp,6		;get six bit's
+	addi temp,40		;convert to ascii
+	.iot tyoch,temp		;output it
+	jrst sixout
+
+;prints packet range pointed to by temp (first,,last)
+pkrang:	skipn temp
+	 jrst pknull
+	push p,temp		;save for later
+	hrrz a,temp		;get first
+	pushj p,prpk		;prints packet number pointed to by a
+	print [ - ]
+	pop p,a			;get address of last
+	hlrz a,a		;get pointer to the last packet
+	pushj p,prpk		;call prpk
+	popj p,			;and return
+pknull:	print [<none>]
+	popj p,
+
+prpk:	extab a,3		;get the packet number
+	move a,temp
+	lsh a,-24
+	pushj p,numout
+	popj p,
+
+;print the packet number of the packets on this list
+; temp is the out of order pointer
+prlist:	hlrz c,temp		;get pointer to first packet in c
+	skipn c
+	 jrst pknull		;no packets
+prlpk:	move a,c		;copy pointer to packet
+	pushj p,prpk		;print this packet number
+	extab c,-2		;Get this packets previous pointer
+	hrrz c,c		;get the pointer to the next packet
+	skipn c			;if it is zero, that is end of list
+	 popj p,
+	cain c,-1		;it is on list
+	 popj p,		;return if we hit one not on list
+	print [,]
+	jrst prlpk		;and loop back.
+
+
+getidx:	push p,
+	.break 12,[5,,jclbuf]	;read jcl
+	skipn jclbuf		;did we read anything?
+	 jrst allidx
+	move a,[440700,,jclbuf]
+	setz b,			;number read here
+splp:	movem a,(p)		;save it away
+	ildb c,a		;look for non blank char
+	cain c,40		;if space
+	 jrst splp		;loop back
+	cain c,15		;cr is * convention
+	 jrst allidx
+	move a,(p)		;get back pointer
+numlp:	ildb c,a		;get next char
+	cain c,15
+	 jrst numdon		;done
+	cain c,"*		;if star, print all info
+	 jrst allidx
+	subi c,"0		;convert to octal
+	jumpl c,numerr		;error if less
+	caile c,9		;should be anumber
+	 jrst numerr
+	lsh b,3			;accumulate number
+	add b,c
+	jrst numlp
+
+numdon:	pop p,a
+	movem b,index		;store it away
+	jumpl b,numerr
+	camge b,nindx		;if index is too big, error out
+	 popj p,
+
+numerr:	print [Bad index
+]
+	.break 16,120000
+
+
+allidx:	pop p,a
+	setom index		;print all indicies
+	popj p,
+
+jclbuf:	block 10
+index:	0
+
+evsyms:	movei a,symtbl
+evslp:	hrrz b,(a)
+	skipn b
+	 popj p,
+	move b,(b)
+	.eval b,
+	 .lose 1000
+	hlrz c,(a)
+	movem b,(c)
+	aoja a,evslp
+
+symtbl:	symtab [nindx,chsusr,uname,jname,chssta,chswin,chspkn,chsack,chslcl,chsfrn,chsobf,chsibf,chspbf,rechdp,rechdr,nrechd]
+
+define state name
+	.length /name/,,[ascii /name/]
+termin
+
+statab:	state [CLOSED]
+	state [LISTEN]
+	state [RFCRCV]
+	state [RFCSNT]
+	state [OPEN  ]
+	state [LOSING]
+	state [INCXMT]
+	state [LOWLVL]
+
+opsix:	irps op,,zero rfc opn cls fwd ans sns sts rut los lsn mnt unc .a. .b. .c.
+	sixbit/op/
+	termin
+
+end start


### PR DESCRIPTION
As seen in [Amber](https://lm-3.github.io/amber.html#Utility-Programs).

Typical output without JCL:

```
Recent headers in from network:
SNS [0] 3143-134023->3150-130053 PKT#=0 ACK#=1
SNS [0] 3143-134023->3150-130053 PKT#=0 ACK#=1
RUT [20] 3040-0->3150-0 PKT#=0 ACK#=0
SNS [0] 3143-134023->3150-130053 PKT#=0 ACK#=1
RUT [20] 3040-0->3150-0 PKT#=0 ACK#=0
SNS [0] 3143-134023->3150-130053 PKT#=0 ACK#=1
SNS [0] 3143-134023->3150-130053 PKT#=0 ACK#=1
RUT [20] 3040-0->3150-0 PKT#=0 ACK#=0
SNS [0] 3143-134023->3150-130053 PKT#=0 ACK#=1
SNS [0] 3143-134023->3150-130053 PKT#=0 ACK#=1
RUT [20] 3040-0->3150-0 PKT#=0 ACK#=0
SNS [0] 3143-134023->3150-130053 PKT#=0 ACK#=1
RUT [20] 3040-0->3150-0 PKT#=0 ACK#=0
SNS [0] 3143-134023->3150-130053 PKT#=0 ACK#=1
SNS [0] 3143-134023->3150-130053 PKT#=0 ACK#=1
RUT [20] 3040-0->3150-0 PKT#=0 ACK#=0
