### PR TITLE
Build script occasionally hangs due to DAYLIGHT SAVINGS

### DIFF
--- a/build/build.tcl
+++ b/build/build.tcl
@@ -63,7 +63,7 @@ proc pdset {} {
     type [timestamp -seconds $t -format "%y%m%dD"]
     type [timestamp -seconds $t -format "%H%M%ST"]
     type "!."
-    expect "DAYLIGHT SAVINGS" {
+    expect -exact "DAYLIGHT SAVINGS TIME?  " {
         type "N"
         expect "\n"
     } "\n" {


### PR DESCRIPTION
I have seen this from SIMH and KLH10:

```
PDSET.114
Please don't use this program unless you know how.
You are certain to break something if you happen to hit the wrong key.
Type Control-Z to exit, or ? for a reminder of the commands.
20C
1810
30D
073956T
!.DAYLIGHT SAVINGS TIME?  
The last command timed out.
```

The script seems to be doing the right thing:

```
    type "!."
    expect "DAYLIGHT SAVINGS" {
        type "N"
        expect "\n"
    } "\n" {
    }
    type "Q"
