### PR TITLE
Change GitLab CI to use the KA10 simulator.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,7 +1,7 @@
 image: ubuntu
 
 variables:
-  EMULATOR: klh10
+  EMULATOR: sims
 
 stages:
   - build
@@ -13,4 +13,4 @@ job1:
     - make
   artifacts:
     paths:
-      - out/klh10/
+      - out/sims/


### PR DESCRIPTION
Because it doesn't work with KLH10.  For unknown reasons, it seems to work fine everywhere else.