### PR TITLE
.gitattribtues (doc/c/cc.pat, doc/c/ccdoc.text): Mark as text files.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
-/src/*/* linguist-language=assembly
+/src/*/*	diff linguist-language=assembly
+/doc/*/*	diff linguist-language=Text


### PR DESCRIPTION
See https://github.com/PDP-10/its/pull/1375