### PR TITLE
Removes incorrect version number from HERALD expression in LSPSRC;VECTOR 75

### DIFF
--- a/src/lspsrc/vector.75
+++ b/src/lspsrc/vector.75
@@ -5,7 +5,7 @@
 ;;;  ******** (c) Copyright 1982 Massachusetts Institute of Technology ********
 ;;;  **************************************************************************
 
-(herald VECTOR /74)
+(herald VECTOR)
 
 ;; This file cannot be run interpretively, due to the dependence upon
 ;;  the SOURCE-TRANS being expanded while compiling -- if you *must*


### PR DESCRIPTION
The current value doesn't match FN2, as I forgot to update it the last time
I updated this file. Removing the explicit version number will cause HERALD
to display the FN2 as the version number.  Resolves #1318.