### PR TITLE
Fixed UPTIME daemon to specify start address 

### DIFF
--- a/src/bawden/uptime.1
+++ b/src/bawden/uptime.1
@@ -62,4 +62,4 @@ dbfn2:	sixbit /data/
 
 cnstnt:	constants
 
-end
+end go


### PR DESCRIPTION
This fixes issue with UPTIME daemon immediately dying with an ILOPR
fault due to starting at address 0. Resolves #1444