### PR TITLE
Updated PAPSAV to use SYSMSG macros for maintaining patch table 

### DIFF
--- a/src/sysen3/papsav.3
+++ b/src/sysen3/papsav.3
@@ -5,8 +5,55 @@
 	; source did. The original PAPSAV shared some code with SYSEN1;SYSMSG > (which
 	; also inserted SYSENG; CALRET >). Where applicable, the source from SYSMSG was
 	; used in this reconstruction.
+	;
+	; EJS (2018-12-21): This version uses macros from SYSMSG to build table
+	; of patches (ABSTB1).
 
 .INSRT SYSENG;CALRET >
+
+;;; DEFINE MACROS SO THAT SYSTEM VARIABLES ACCESSED
+;;; THROUGH ABS PAGES CAN BE REFERENCED IN A NATURAL WAY
+
+DEFINE CONC A,B
+A!B!TERMIN
+
+DEFINE ABSREF SYMS
+DEFINE ABSTAB
+IRPW SYM,,[SYMS]
+IFSE [SYM]----, IMMEDS:	;FROM HERE DOWN ARE NOT ADDRESSES
+.ELSE [  SQUOZE 0,SYM
+  CONC ABSRF",\.IRPCNT,ABS
+  CONC [EXPUNGE ABSRF"]\.IRPCNT,ABS
+]
+TERMIN
+TERMIN
+IRPW SYM,,[SYMS]
+IFSN [SYM]----, ABSRF. SYM,\.IRPCNT
+TERMIN
+TERMIN
+
+DEFINE ABSRF. SYM,CT
+ABSRF"!CT!ABS==0
+IF1,[DEFINE SYM ?MOD
+(MOD)[.,,ABSRF"!CT!ABS]TERMIN
+]
+IF2,[DEFINE SYM ?MOD
+(MOD)<ZZZ==ABSRF"!CT!ABS ? ABSRF"!CT!ABS==[.,,ZZZ] ? ZZZ>TERMIN
+]
+TERMIN
+
+.BEGIN ABSRF		;PLACE TO KEEP NNNABS SYMBOLS
+.END
+
+ABSREF [SYSMBF		;SYSTEM MESSAGE BUFFER
+	TOIP		;TTY OUTPUT PTR
+	TOBEP		;.., END OF BUFFER
+	TOOP		;output buffer output pointer
+----
+	TOBL		;TTY OUTPUT BUFFER LENGTH
+	SYSCON		;SYSTEM TTY NUMBER
+	SYSMLNG		;LOG 2 OF NUMBER OF 4-WORD BLOCKS
+]
 
 a=4
 b=5
@@ -68,8 +115,8 @@ PROGRAM SYSMSG
 	CALL RITUAL		;ASSURANCE OF PURITY
 
 	MOVEI COUNT, 1		;SET UP COUNT OF MESSAGE SLOTS
-	LSH COUNT, 0		;instruction patched through abstb1 (SYSMLN)
-	movei pt,0              ; instruction patched through abstb1 (SYSMBF)
+	LSH COUNT, SYSMLNG	;instruction patched through abstb1 (SYSMLN)
+	movei pt,SYSMBF         ; instruction patched through abstb1 (SYSMBF)
 	jrst papsav
 
 g00002:
@@ -107,8 +154,8 @@ g00003:
 	movei t1,[sep]
 	pushj p,type
 
-papsav:	MOVEI C, 0		;-> SYSTEM JOB TTY (patched by abstb1 (SYSCON))
-	MOVE PT, 0(C)		;SCAN THROUGH (patch by abstb1 (TOOP))
+papsav:	MOVEI C, SYSCON		;-> SYSTEM JOB TTY (patched by abstb1 (SYSCON))
+	MOVE PT, TOOP(C)	;SCAN THROUGH (patch by abstb1 (TOOP))
 
 SYFNDL:	PUSHJ P,SYGET
 	tyo a
@@ -116,10 +163,10 @@ SYFNDL:	PUSHJ P,SYGET
 	  tyo [^J]		; emit a linefeed
 	jrst syfndl
 
-SYGET0:	CAMN PT,0(C)		; patched by abstb1 (TOIP)
+SYGET0:	CAMN PT,TOIP(C)		; patched by abstb1 (TOIP)
 	  .hang
-	CAMN PT,0(C)		; get chr from tty buf (patched by abstb1 (TOBEP)
-	  SUBI PT,0		; with wrap-around (patched by abstb1 (TOBL))
+	CAMN PT,TOBEP(C)	; get chr from tty buf (patched by abstb1 (TOBEP)
+	  SUBI PT,TOBL		; with wrap-around (patched by abstb1 (TOBL))
 	ILDB A,PT		; GET char
 	POPJ P,
 
@@ -283,22 +330,8 @@ NOGOOD:	CALL TYPE, bletch	; wrong system version, purify
 CONSTANTS
 VARIABLES
 
-abstb1:	<squoze 0,SYSMBF>	; system message buffer
-	sysmsg+7				
-	<squoze 0,TOIP>		; tty output ptr
-	sysmsg"syget0			
-	<squoze 0,TOBEP>	; end of buffer
-	sysmsg"syget0+2
-	<squoze 0,TOOP>		; output buffer output pointer
-	sysmsg"papsav+1
-
-immeds:	<squoze 0,TOBL>		; tty output buffer length
-	sysmsg"syget0+3
-	<squoze 0,SYSCON>	; system tty number
-	sysmsg"papsav
-	<squoze 0,SYSMLN>	; log 2 of number of 4-word blocks
-	sysmsg+6
-abstb2:
+ABSTB1:	ABSTAB
+ABSTB2:
 
 PURIFY:  PROCEDURE 
 
@@ -315,11 +348,12 @@ EVLOOP:	MOVE V,ABSTB1(I)		; get symbol
 	  SUBI V,REMAPT			; into high core
 EVLP00:	ADDI I, 1
 	MOVE TT,ABSTB1(I)		; follow patch list
-PLOOP:	skipn l,tt
-	  jrst evlpnx
-	HRRZ TT,(L)			; loc to patch
-	HRRM V,(L)			; patch it
-	JRST PLOOP			; and try again
+PLOOP:	JUMPE TT,EVLPNX			; jump if end of list
+	MOVE L,TT
+	HLRZ TT,(L)			;LOC TO PATCH
+	HRRM V,(TT)			;PATCH IT
+	HRRZ TT,(L)			;LINK TO NEXT
+	JRST PLOOP			;AND TRY AGAIN
 
 EVLPNX:	AOBJN I,EVLOOP			; next symbol
 


### PR DESCRIPTION
Updated PAPSAV to use SYSMSG macros for maintaining patch table and for doing more elegant patching of ITS addresses in the code.

Resolves #1454.