### PR TITLE
TBMOFF - turn binary mode off

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ SRC = syseng sysen1 sysen2 sysen3 sysnet kshack dragon channa	\
       macsym lmcons dmcg hack hibou agb gt40 rug maeda ms kle aap common \
       fonts zork 11logo kmp info aplogo bkph bbn pdp11 chsncp sca music1 \
       moon teach ken lmio1 llogo chsgtv clib sys3 lmio turnip mits_s rab \
-      stan_k bs
+      stan_k bs cstacy
 DOC = info _info_ sysdoc sysnet syshst kshack _teco_ emacs emacs1 c kcc \
       chprog sail draw wl pc tj6 share _glpr_ _xgpr_ inquir mudman system \
       xfont maxout ucode moon acount alan channa fonts games graphs humor \

--- a/build/misc.tcl
+++ b/build/misc.tcl
@@ -1545,3 +1545,7 @@ expect ":KILL"
 # NEWDEC
 respond "*" ":midas sys3;ts newdec_sysen1;newdec\r"
 expect ":KILL"
+
+# TBMOFF
+respond "*" ":midas sys; ts tbmoff_cstacy; tbmoff\r"
+expect ":KILL"

--- a/doc/programs.md
+++ b/doc/programs.md
@@ -275,6 +275,7 @@
 - RABBIT, Scheme compiler.
 - TAGS, generate tags table for sources.
 - TALK/WHO/WHOJ/WHOM/USERS, list users.
+- TBMOFF, turn TAC or TIP binary mode off.
 - TCTYP, set terminal type and options.
 - TEACHE, Emacs tutorial.
 - TECO, editor.

--- a/src/cstacy/tbmoff.1
+++ b/src/cstacy/tbmoff.1
@@ -1,0 +1,43 @@
+;;;-*-MIDAS-*-
+
+TITLE	TBMOFF - Turn off BINARY mode if on a TAC or TIP.
+	;CStacy 5/4/83
+
+A=1
+B=2
+C=3
+
+USRC=12				   ;User input.
+TTYO=13				   ;TTY typeout.
+
+TIPNUM=121			   ;Location in TELSER.
+
+DEFINE SYSCAL OP,ARGS
+	.CALL [SETZ ? SIXBIT/OP/ ? ARGS ((SETZ))]
+TERMIN
+
+GO:	.SUSET [.RTTY,,A]	   ;Get TTY number.
+	MOVE B,[SIXBIT /00TLNT/]   ;Cons up expected TELSER jname.
+	LDB C,[030300,,A]
+	DPB C,[360300,,B]
+	LDB C,[000300,,A]
+	DPB C,[300300,,B]
+	SYSCAL OPEN,[%CLBIT,,10+.UII ? %CLIMM,,USRC
+			[SIXBIT /USR/] ? B ? [SIXBIT /TELSER/]]
+	 JRST DEATH
+PEEK:	.ACCESS USRC,[TIPNUM]
+	.IOT USRC,A		   ;Get TTYLOC, if any.
+	JUMPE A,DEATH		   ;If on a TIP, type "IAC DONT BINARY".
+DOBIN:	SYSCAL OPEN,[%CLBIT,,<.UIO+%TJSIO> ? %CLIMM,,TTYO ? [SIXBIT /TTY/]]
+	 .LOSE %LSFIL
+	.IOT TTYO,[%TDQOT]
+	.IOT TTYO,[377]	
+	.IOT TTYO,[%TDQOT]
+	.IOT TTYO,[376]
+	.IOT TTYO,[%TDQOT]
+	.IOT TTYO,[0]	
+	.CLOSE TTYO,
+DEATH:	.LOGOUT 1,
+
+END GO
+


### PR DESCRIPTION
SYS; TS TBMOFF
AR1: CSTACY; TBMOFF 1

Turn off BINARY mode if on a TAC or TIP.  Good to have if someone wants to set up an old-school Arpanet.