### PR TITLE
Make NAMDRG more graceful about missing TV-11

### DIFF
--- a/src/sysen2/namdrg.149
+++ b/src/sysen2/namdrg.149
@@ -254,9 +254,9 @@ name:	.close 1,	;close the channel we were loaded on
 	jrst name2
 
 name1:	;char unit out, disp. mode, no continuation lns
-        syscal OPEN,[ [%tjmor+%tjctn+%tjdis+.uao,,tyoc] ? setz b ]
+        syscal OPEN,[ [%tjmor+%tjctn+%tjdis+.uao,,tyoc] ? b ]
 	 .value
-	syscal OPEN,[ [%tjmor+%tjctn+%tjdis+.bao,,tybc] ? setz b ]
+	syscal OPEN,[ [%tjmor+%tjctn+%tjdis+.bao,,tybc] ? b ]
 	 .value
 name2:	.call [	setz ? 'cnsget ? 1000,,tyoc ? 2000,,tcmxv ? 2000,,tcmxh
 		2000,,a ? 2000,,a ? setzm a]

--- a/src/sysen2/namdrg.149
+++ b/src/sysen2/namdrg.149
@@ -226,9 +226,6 @@ init:	setz a,
 
 name:	.close 1,	;close the channel we were loaded on
 	move p,[-lpdl,,pdl-1]
-	.suset [.roption,,a]
-	tlo a,%opint+%opliv+%opopc
-	.suset [.soption,,a]
 	move b,[squoze 0,nf11ty]
 	.eval b,	;TTY # of console free display
 	 .value
@@ -273,6 +270,9 @@ name2:	.call [	setz ? 'cnsget ? 1000,,tyoc ? 2000,,tcmxv ? 2000,,tcmxh
 	pushj p,clrpts	;clear user name ptrs
 	skipl @tt11p	;wait for TV 11 to come up
 	 .hang
+	.suset [.roption,,a]
+	tlo a,%opint+%opliv+%opopc
+	.suset [.soption,,a]
 	pushj p,map11
 	move a,@dmnbd	;find our initial dmnbf ptr
 	movem a,logcnt

--- a/src/sysen2/namdrg.149
+++ b/src/sysen2/namdrg.149
@@ -226,6 +226,9 @@ init:	setz a,
 
 name:	.close 1,	;close the channel we were loaded on
 	move p,[-lpdl,,pdl-1]
+	move b,[squoze 0,tt11p]
+	.eval b,
+	 jsr die
 	move b,[squoze 0,nf11ty]
 	.eval b,	;TTY # of console free display
 	 .value


### PR DESCRIPTION
@eswenson1 has been testing running NAMDRG with less than stellar results.  It seems the IO channel to the frame buffer accepts data from a SIOT, but fails when FINISH is called to flush the buffer.  Quite possibly, NAMDRG is started too soon, before TVFIX aka STUFF has finished loading.

I suggest to fix this by having NAMDRG check ITS' TT11P first.  If it doesn't exist, ITS is built without TV-11 so just .LOGOUT.  Otherwise ensure it's -1, or else wait until it becomes -1.  I think this should be a more robust behaviour.