### PR TITLE
Fix TELNET to interoperate with buggy servers.

### DIFF
--- a/src/sysnet/telnet.753
+++ b/src/sysnet/telnet.753
@@ -910,7 +910,10 @@ iacsr0:	call ntic			; get command character
 			 .lose %lssys	; oops!
 			telcmf [IAC SE]
 			jrst ntimpg]	; all done
-		telcmd [IAC DONT]	; refuse to accept this option
+		movei nt,IAC		; refuse to accept this option
+		call ntout
+		movei nt,DONT
+		call ntout
 		call ntosnd		; send what I refuse
 		call ntofrc		; and send it out
 		jrst ntimpg]		; and continue
@@ -963,7 +966,10 @@ iacsr0:	call ntic			; get command character
 
 			telcmf [IAC WILL TRNBIN]
 			jrst ntimpg]	; no, random, win anyway
-		telcmd [IAC WONT]	; well, I won't do it!
+		movei nt,IAC		; well, I won't do it!
+		call ntout
+		movei nt,WONT
+		call ntout
 		call ntosnd		; so there.
 		call ntofrc		; and force it out
 		jrst ntimpg]		; and continue


### PR DESCRIPTION
@rcornwell wrote:

> here is the patch to get telnet to talk to a modern telnetd. This weekend I will finish adding DHCP to IMP and doing some more cleanup on code.
> 
> The basic change was to expand the telcmd to several calls to remove the flush at the end of the macro. Modern telnetd seems to want WONT/DONT commands not to span packets.