### PR TITLE
Use H3MAKE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ DOC = info _info_ sysdoc sysnet syshst kshack _teco_ emacs emacs1 c kcc \
       combat pdl minits mits_s chaos hal
 BIN = sys2 emacs _teco_ lisp liblsp alan inquir sail comlap c decsys \
       graphs draw datdrw fonts fonts1 fonts2 games macsym maint imlac \
-      _www_ hqm gt40 llogo bawden
+      _www_ hqm gt40 llogo bawden sysbin
 MINSRC = midas system $(DDT) $(SALV) $(KSFEDR) $(DUMP)
 
 # These are not included on the tape.

--- a/build/basics.tcl
+++ b/build/basics.tcl
@@ -178,9 +178,13 @@ respond "*" ":midas syshst;_syshst;h3make\r"
 expect ":KILL"
 respond "*" ":link syshst;ts h3make,syshst;h3make bin\r"
 
-# build binary host table
-respond "*" ":syshst;hosts3 /insert syshst; h3text > /outfil sysbin; hosts3 bin\r"
-expect ":KILL"
+# Run H3MAKE to make the SYSBIN; HOSTS3 > database.  H3MAKE looks for
+# an older version, so there is an empty placeholder to make this
+# work.  H3MAKE runs in the background and leaves either SYSHST; H3TYO
+# or H3ERR with the output from the HOSTS3 program.  The placeholder
+# file is removed later.
+respond "*" ":syshst;h3make\r"
+expect {$$^K}
 
 # basic TCP support
 respond "*" ":midas sys;atsign tcp_syseng;@tcp\r"
@@ -282,6 +286,9 @@ respond "*" ":pdump sysbin;panda bin\r"
 respond "*" ":kill\r"
 respond "*" ":link sys;atsign pword,sysbin;pword bin\r"
 respond "*" ":link sys;ts panda,sysbin;panda bin\r"
+
+# Remove placeholder SYSBIN; HOSTS3 database.
+respond "*" ":delete sysbin; hosts3 <\r"
 
 respond "*" ":copy sysbin;name bin,sys;ts name\r"
 respond "*" "name\033j"


### PR DESCRIPTION
Use H3MAKE to build the host table from the source file.

This also fixes the bug that the host table should be named SYSBIN; HOSTS3 > rather than SYSBIN; HOSTS3 BIN.