### PR TITLE
Updated MLDEV to return NO SUCH DEVICE error when host not found

### DIFF
--- a/src/sysen2/mldev.106
+++ b/src/sysen2/mldev.106
@@ -2,6 +2,9 @@
 
 TITLE	BOJ JOB MLDEV, Uses MLSLV on other system
 
+;;; Updated 2019-01-23 by EJS to cause NO SUCH DEVICE error if host
+;;;   not found in host table.
+
 VERSIO==.FNAM2
 
 ICPSOC==123			;This is the Postel-approved number
@@ -148,7 +151,7 @@ GOTHS2:	LSH A,6
 	IDPB A,B
 	MOVEI A,BUF
 	PUSHJ P,NETWRK"HSTLOOK
-	 .VALUE				;Host not in host table?
+	 JRST NSD			; if we can't lookup host address -> no such device
 	MOVEM A,HOSTN'			;Host number
 	MOVEM TT,NETWRK'		;Network number
 	PUSHJ P,NETWRK"HSTUNMAP		;Don't need host table any more


### PR DESCRIPTION
When host lookup failes, MLDEV now returns NO SUCH DEVICE. 

Resolves #1467.