### PR TITLE
Updated NSMDAT procedure in SYSNET; NETRTS > to fix hang during SMTP delivery

### DIFF
--- a/src/sysnet/netrts.356
+++ b/src/sysnet/netrts.356
@@ -1773,10 +1773,12 @@ NSMDT5:	D7BPT B			; Back up the BP to period
 	POPAE P,[C,B]
 NSMDT8:	POP P,C
 	OUT(NETO,FRC)		; Ensure buffer forced out
+ifn 0,[	;; [BV] Hangs forever
 	SYSCAL FINISH,[MOVEI NETO]	; Wait for transmission ACK
 	 JRST [	STAT (,("FINISH call failed - "),ERR)
 		MOVEI A,MR$TEH	; Temp err for host.
 		RET]
+]
 	JRST POPJ1
 
 ; NSMDON - Terminate SMTP message transaction, see if it won or not.


### PR DESCRIPTION
Updated NSMDAT procedure in SYSNET; NETRTS > to comment out the call to FINISH when sending SMTP headers or data. This call appears to hang, preventing delivery of the message. This fix has been in place on UP for a couple years. I've tested it and it does fix the issue.
Resolves #1516.