### PR TITLE
Link from TS BOOT11 to 11STNK.

### DIFF
--- a/build/misc.tcl
+++ b/build/misc.tcl
@@ -1418,6 +1418,7 @@ expect ":KILL"
 # PDP-11 linker.
 respond "*" ":midas sys1;ts 11stnk_kldcp;11stnk\r"
 expect ":KILL"
+respond "*" ":link .; ts boot11, sys1; ts 11stnk\r"
 
 # CARPET, remote PDP-11 debugger through Rubin 10-11 interface.
 respond "*" ":midas sys3;ts carpet_syseng;carpet\r"


### PR DESCRIPTION
11STNK doubles as a timesharing BOOT11 command.  I haven't tested it, obviously, but I would expect it to send something to the DL10 PDP-11.

I can't see any link in the records, so I'm guessing the . directory is a good location.