### PR TITLE
Update PWORD to not add MIT- prefix to machine names in emails

### DIFF
--- a/src/sysen1/pword.2662
+++ b/src/sysen1/pword.2662
@@ -9815,6 +9815,10 @@ bltspc:	syscal sstatu,[val x ? val x ? val x ? val x ? val x
 	  jrst [move x,[mdspec,,tsspec]	 ;yes, so use MD's specs
 	        blt x,spcend-1	   ;  all of them, to the end
 		ret ]
+	camn x,[sixbit /ES/]	   ;is it ES?
+	  jrst [move x,[mdspec,,tsspec]	 ;yes, so use MD's specs
+	        blt x,spcend-1	   ;  all of them, to the end
+		ret ]
 	camn x,[sixbit /DM/]	   ;DM-P?
 	  jrst [move x,[dmspec,,tsspec]	 ;yes, use DM's specs
 	       blt x,spcend-1	   ;  all of them to the bitter end

--- a/src/sysen1/pword.2662
+++ b/src/sysen1/pword.2662
@@ -8431,7 +8431,7 @@ sndltp:	-10,,snddsc		   ; Just header
 
 snddsc: 440700,,[asciz /[Message from /]
 	tp$6bt runame
-	440700,,[asciz / at MIT-/]
+	440700,,[asciz / at /]
 	tp$6bt machin
 	440700,,[asciz /  /]
 	tp$6bt a
@@ -9601,7 +9601,7 @@ ife $$pand,[
 	hrrzs t			   ; flush the op-code part
 	cain t,telmal		   ; Is this notification mail?
 	  jrst [ 
-	       type dsko,/ MIT-/
+	       type dsko,/ /
 	       6type dsko,machin   ; tell where to send it
 	       type dsko,/ (R-HEADER-FORCE NULL)/  ; force into RFC733 format
 	       jrst .+1]
@@ -9662,10 +9662,10 @@ From: /				   ; now for the FROM: field
 	setom mdlflg
 	typout dsko,[tp$6bt uname]  ; tell the UNAME involved
 	setzm mdlflg
-	type dsko,/ at MIT-/
+	type dsko,/ at /
 	6type dsko,machin	   ; tell where
 	type dsko,/>
-To: USER-ACCOUNTS at MIT-/
+To: USER-ACCOUNTS at /
 	6type dsko,machin 	   ; tell where
 	type dsko,/
 /


### PR DESCRIPTION
Also, add ES to list of known machines.