### PR TITLE
340 Munching Squares

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,8 @@ SRC = syseng sysen1 sysen2 sysen3 sysnet kshack dragon channa	\
       macsym lmcons dmcg hack hibou agb gt40 rug maeda ms kle aap common \
       fonts zork 11logo kmp info aplogo bkph bbn pdp11 chsncp sca music1 \
       moon teach ken lmio1 llogo a2deh chsgtv clib sys3 lmio turnip \
-      mits_s rab stan_k bs cstacy kp dcp2 -pics- victor imlac rjl mb bh
+      mits_s rab stan_k bs cstacy kp dcp2 -pics- victor imlac rjl mb bh \
+      lars
 DOC = info _info_ sysdoc sysnet syshst kshack _teco_ emacs emacs1 c kcc \
       chprog sail draw wl pc tj6 share _glpr_ _xgpr_ inquir mudman system \
       xfont maxout ucode moon acount alan channa fonts games graphs humor \

--- a/build/misc.tcl
+++ b/build/misc.tcl
@@ -554,6 +554,13 @@ respond "*" ":link sys1;ts 340d, stan.k; mod11 bin\r"
 respond "*" ":midas sys2;ts munch_sysen2;munch\r"
 expect ":KILL"
 
+# Munching squares for 340 display.
+respond "*" ":midas lars; ts munch_munch\r"
+expect ":KILL"
+respond "*" ":midas /t dsk0: .; @ munch_lars; munch\r"
+respond "with ^C" ".iotlsr==jfcl\r\003"
+expect ":KILL"
+
 # PI
 respond "*" ":midas sys3;ts pi_rwg; ran\r"
 expect ":KILL"

--- a/doc/programs.md
+++ b/doc/programs.md
@@ -212,6 +212,7 @@
 - MUDDLE, MDL interpreter.
 - MUDINQ, Muddle inquirer.
 - MUNCH, TV-munching square.
+- MUNCH, munching squares for Type 340 display.
 - NAME, shows logged in users and locations, aka FINGER.
 - NAMDRG, free TV display.
 - NETIME, network time dragon.

--- a/src/lars/munch.340
+++ b/src/lars/munch.340
@@ -1,0 +1,71 @@
+title Munching Squares
+
+a=1
+b=2
+c=3
+v=10
+x=11
+y=x+1
+p=17
+
+dis==130
+
+point==020000
+inten==002000
+verti==200000
+
+start:	move p,[-pdllen,,pdl-1]
+
+	setzb x,y
+
+	seto a,
+	.iotlsr a,
+
+	cono dis,100		;Reset display.
+
+	movei a,point+17+<5_4>	;Set intentity and scale, go to point mode.
+	pushj p,send
+
+loop:	move x,[1001002]	;Munching squares algorithm.
+	addb x,v
+	rotc x,-22
+	xor x,v
+
+	move a,x		;Point mode, set X.
+	lsh a,10.-36.
+	iori a,point
+	pushj p,send
+
+	move a,y		;Point mode, set Y and intensify.
+	lsh a,10.-36.
+	iori a,point+verti+inten
+
+	move c,count
+rep:	pushj p,send		;Send this word COUNT times.
+	sojge c,rep
+
+	jrst loop
+
+buf:	0
+state:	first
+send:	jrst @state
+
+first:	movem a,buf		;Buffer this word.
+	movei b,second
+	movem b,state
+	popj p,
+
+second:	conso dis,200		;Wait for display.
+	 jrst .-1
+	move b,a
+	hrl b,buf
+	datao dis,b
+	movei b,first
+	movem b,state
+	popj p,
+
+count: 15.
+
+.vector pdl(pdllen==100)
+
+end start


### PR DESCRIPTION
http://www.dpbsmith.com/munch.html:

> The classic PDP-1 display hack was "munching squares."
> The code for it was something like this:
> 
> ```
> foo,    lat         /load the 18-bit AC from the Test Word
>         add v       /add the contents of memory location v to the AC
>         dac v       /deposit the contents of the AC into v
>         rcl 9s      /Rotate the combined AC-IO 9 bits to the left
>         xor v       /exclusive-or the contents of v into the AC
>         dpy-i 300   /plot point at x = high ten bits of AC, y = high ten bits of IO
>         jmp foo 

[HAKMEM has this version:](http://www.inwap.com/pdp10/hbaker/hakmem/hacks.html#item146)

> Another simple display program. It is thought that this was discovered by Jackson Wright on the RLE PDP-1 circa 1962.
> 
> ```
>         DATAI 2
>         ADDB 1,2
>         ROTC 2,-22
>         XOR 1,2
>         JRST .-4
> ```
> 
> 2=X, 3=Y. Try things like 1001002 in data switches.