### PR TITLE
ARDS picture FOOBAR doesn't render well

### DIFF
--- a/src/dcp/sgincl.15
+++ b/src/dcp/sgincl.15
@@ -26,6 +26,7 @@
 (defvar sg-current-x 0) (defvar sg-current-y 0) (defvar sg-xor-ior 'ior)
 
 (defconst %TDGRF #o231) (defconst %TDNOP #o210) (defconst %TDRST #o230)
+(defconst %TDCRL #o207)
 
 (defconst tv:alu-ior 0) (defconst tv:alu-andcam #o40) (defconst tv:alu-xor -1)
 (defconst %goMVR #o001) (defconst %goMVA #o021)
@@ -159,6 +160,8 @@
       ((ior)	 (sg-out %goIOR) (setq sg-xor-ior 'ior))
       )))
 
+(defun sg-return ()
+  (+tyo %TDCRL sgos))
 
 (defun sg-set-point (x y)
   (sg-move-absolute x y))

--- a/src/dcp/supard.2
+++ b/src/dcp/supard.2
@@ -22,7 +22,7 @@
   (cond ((errset (setq ards-in (open i-file '(in ascii))) t)
 	 (errset (progn
 		  (setq sgos o-file)
-		  (setq ards-x -512. ards-y +511.)
+		  (setq ards-x -485. ards-y +450.)
 		  (cursorpos 'c)
 		  (sg-do '(reset enter clear ior))
 		  (sg-set-point 0 0)

--- a/src/dcp/supard.3
+++ b/src/dcp/supard.3
@@ -48,7 +48,11 @@
        (sg-out 0)
        (sg-set-point 0 0)
        n)
-    (sg-out n)))
+    (caseq n
+      ((0 3) nil)
+      ((12) nil)
+      ((15) (sg-return))
+      (t (sg-out n)))))
 
 (defun enter-set-point-mode ()
   (do ((i 0)

--- a/src/victor/ards.98
+++ b/src/victor/ards.98
@@ -15,6 +15,10 @@
 
 (declare (*lexpr decode-ards-stream ards-to-svg svg-from-ards))
 
+;; Determined experimentally from -PICS-; FOOBAR PIC.
+(defconst start-x -485.)
+(defconst start-y +450.)
+
 ;; Common Lisp compat
 (defun read-byte (s &optional eof)
   (tyi s eof))
@@ -171,7 +175,7 @@
 (defun ards-coordinates (iards)
   (do* ((ards iards (cdr ards))
 	(ard (car ards) (car ards))
-	(cur-x 0) (cur-y 0)
+	(cur-x start-x) (cur-y start-y)
 	(minxy (list 2048. 2048.)
 	       (if (get ard ':invisible) minxy
 		   (list (min cur-x (first minxy))
@@ -206,7 +210,7 @@
 	    (setq nlines (1+ nlines))))
 	)))
 
-(defun svg-from-ards (of iards &optional (cur-x 0) (cur-y 0))
+(defun svg-from-ards (of iards &optional (cur-x start-x) (cur-y start-y))
   (do* ((ards iards (cdr ards))
 	(ard (car ards) (car ards)))
        ((or (null ards)


### PR DESCRIPTION
-PICS-; FOOBAR PIC doesn't render OK with either SUPARD on a TV, or with @bictorv's SVG translation.

![foobar1](https://user-images.githubusercontent.com/775050/51970087-48585480-2476-11e9-92fe-98f745cd003f.jpg)

![foobar2](https://user-images.githubusercontent.com/775050/51970197-8a819600-2476-11e9-91e7-96da0e79e493.png)
