### PR TITLE
Fix typo in script to set up a TAP interface

### DIFF
--- a/build/sims/tap.sh
+++ b/build/sims/tap.sh
@@ -21,7 +21,7 @@ start() {
 
     brctl show > config.log
     ifconfig -a >> config.log
-    route -n > config.log
+    route -n >> config.log
 
     #
     tunctl -t $TAP -u $USER


### PR DESCRIPTION
The logfile got truncated by the last command