### PR TITLE
Work around a Mac OS X/BSD bug requiring expect to send two \0 characters in a row.

### DIFF
--- a/build/misc.tcl
+++ b/build/misc.tcl
@@ -1439,7 +1439,10 @@ respond "*" ":stinkr\r"
 respond "=" "x c/clib\r"
 respond "=" "l sysen2/oinit.stk\r"
 respond "=" "o sys3/ts.oinit\r"
-respond "=" "\0"
+# Use the ^_ octal-input feature of ITS to send \0. The space ends the
+# octal digits without ITS passing it through to the program. Using octal
+# input works around Mac OS X and BSD which require literal \0s to be doubled.
+respond "=" "\0370 "
 expect ":KILL"
 
 # Versatec spooler


### PR DESCRIPTION
Please see #1611 for more details about the bug.