### PR TITLE
.MLLIT bug?

### DIFF
--- a/doc/info/midas.26
+++ b/doc/info/midas.26
@@ -4089,8 +4089,8 @@ $R.	The relocation factor (only in STINK format)
 	The comma serves only to terminate <arg>.
 .M	Main block (as in .M"FOO)
 .MLLIT	set positive to allow multi-line [], (), and <>.
-	Set negative for the old-fashioned mode where they didn't
-	need to be terminated.  Zero selects "error mode" useful
+	Set to zero for the old-fashioned mode where they didn't
+	need to be terminated.  Negative selects "error mode" useful
 	in converting an old-fashioned program to multi-line mode.
 	Now initially positive.
 .MRUNT	MIDAS's runtime so far, in milliseconds.


### PR DESCRIPTION
MIDAS documentation says:

```
.MLLIT  set positive to allow multi-line [], (), and <>.
        Set negative for the old-fashioned mode where they didn't
        need to be terminated.  Zero selects "error mode" useful
        in converting an old-fashioned program to multi-line mode.
        Now initially positive.
```

I tested this, and it looks like the behaviour is reversed between zero and negative.  Setting .MLLIT to 0 makes MIDAS accept unterminated [ constants.  Setting it to -1 raises an error.