### PR TITLE
Multiple targets for the GitLab build.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,16 +1,39 @@
 image: ubuntu
 
-variables:
-  EMULATOR: pdp10-ka
-
 stages:
   - build
 
+# Note, GitLab currently does not build well with KLH10.
+
 job1:
   stage: build
+  variables:
+    EMULATOR: simh
+  script:
+    - sh -ex build/dependencies.sh install_linux
+    - make
+  artifacts:
+    paths:
+      - out/simh/
+
+job2:
+  stage: build
+  variables:
+    EMULATOR: pdp10-ka
   script:
     - sh -ex build/dependencies.sh install_linux
     - make
   artifacts:
     paths:
       - out/pdp10-ka/
+
+job3:
+  stage: build
+  variables:
+    EMULATOR: pdp10-kl
+  script:
+    - sh -ex build/dependencies.sh install_linux
+    - make
+  artifacts:
+    paths:
+      - out/pdp10-kl/


### PR DESCRIPTION
It now builds with SIMH KS10 and KA10; the latter both KA ITS and KL ITS.
