### PR TITLE
Bug fix for TCP from Dave Conroy

### DIFF
--- a/src/system/tcp.276
+++ b/src/system/tcp.276
@@ -3032,7 +3032,7 @@ TSISS2:	TLNE E,(TC%RST)		; Check for RST
 	JUMPE A,TSISS3		; Just for robustness
 	TRCPKT A,"TSISS2 Flushing our SYN from rexmit Q"
 	MOVE T,PK.FLG(A)
-	TLO T,%PKFLS		; Tell IP to flush packet if seen
+	TLO T,(%PKFLS)		; Tell IP to flush packet if seen
 	MOVEM T,PK.FLG(A)
 	CALL PKTRT		; Flush SYN packet if not otherwise busy
 	SETZM XBORTT(I)		; and flush timeout.


### PR DESCRIPTION
I compared Conroy's SYSTEM files against the originals, and found this bug fix.  %PKFLS is a 36-bit value, so its halves need to be swapped.