### PR TITLE
Update configuration for KA10 simulator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -237,7 +237,7 @@ $(SIMH):
 	$(MAKE) -C tools/simh pdp10
 
 $(KA10):
-	$(MAKE) -C tools/sims pdp10-ka TYPE340=y
+	$(MAKE) -C tools/sims pdp10-ka
 
 $(KL10):
 	$(MAKE) -C tools/sims pdp10-ka

--- a/build/pdp10-ka/boot
+++ b/build/pdp10-ka/boot
@@ -6,6 +6,11 @@ set rpb dis
 set tua dis
 set fha dis
 set dpb dis
+set lpt dis
+set cr dis
+set dc dis
+set dtc dis
+set dk dis
 at ptr bin/ka10/boot/dskdmp.rim
 at mta0 out/pdp10-ka/minsrc.tape
 at dpa0 out/pdp10-ka/rp03.2

--- a/build/pdp10-ka/boot2
+++ b/build/pdp10-ka/boot2
@@ -13,6 +13,8 @@ set cr dis
 set dc dis
 set dtc dis
 set dk dis
+set pd ena
+set pd on
 at ptr bin/ka10/boot/dskdmp.rim
 at mta0 out/pdp10-ka/sources.tape
 set mta mpx=7

--- a/build/pdp10-ka/boot2
+++ b/build/pdp10-ka/boot2
@@ -8,6 +8,11 @@ set rpb dis
 set tua dis
 set fha dis
 set dpb dis
+set lpt dis
+set cr dis
+set dc dis
+set dtc dis
+set dk dis
 at ptr bin/ka10/boot/dskdmp.rim
 at mta0 out/pdp10-ka/sources.tape
 set mta mpx=7

--- a/build/pdp10-ka/init
+++ b/build/pdp10-ka/init
@@ -6,6 +6,11 @@ set rpb dis
 set tua dis
 set fha dis
 set dpb dis
+set lpt dis
+set cr dis
+set dc dis
+set dtc dis
+set dk dis
 at mta0 out/pdp10-ka/magdmp.tap
 at mta5 out/pdp10-ka/ka-minsys.tape
 at dpa0 out/pdp10-ka/rp03.2

--- a/build/pdp10-ka/run
+++ b/build/pdp10-ka/run
@@ -3,11 +3,16 @@ set cpu its
 set cpu 1024k
 set cpu idle
 set cpu mpx
-dis rpa
-dis rpb
-dis tua
-dis fha
-dis dpb
+set rpa dis
+set rpb dis
+set tua dis
+set fha dis
+set dpb dis
+set lpt dis
+set cr dis
+set dc dis
+set dtc dis
+set dk dis
 set pd enabled
 set pd on
 set dpy enabled

--- a/build/pdp10-kl/boot
+++ b/build/pdp10-kl/boot
@@ -1,6 +1,17 @@
 set console wru=034
 set cpu its
 set cpu 512k
+set dpa dis
+set dpb dis
+set rpb dis
+set tua dis
+set fha dis
+set dpb dis
+set lpt dis
+set cr dis
+set dc dis
+set dtc dis
+set dk dis
 set pd off
 at mta0 out/pdp10-kl/minsrc.tape
 at rpa0 out/pdp10-kl/rp04.0

--- a/build/pdp10-kl/boot2
+++ b/build/pdp10-kl/boot2
@@ -1,6 +1,17 @@
 set console wru=034
 set cpu its
 set cpu 512k
+set dpa dis
+set dpb dis
+set rpb dis
+set tua dis
+set fha dis
+set dpb dis
+set lpt dis
+set cr dis
+set dc dis
+set dtc dis
+set dk dis
 set pd off
 at mta0 out/pdp10-kl/sources.tape
 at rpa0 out/pdp10-kl/rp04.0

--- a/build/pdp10-kl/boot2
+++ b/build/pdp10-kl/boot2
@@ -12,7 +12,8 @@ set cr dis
 set dc dis
 set dtc dis
 set dk dis
-set pd off
+set pd ena
+set pd on
 at mta0 out/pdp10-kl/sources.tape
 at rpa0 out/pdp10-kl/rp04.0
 at rpa1 out/pdp10-kl/rp04.1

--- a/build/pdp10-kl/init
+++ b/build/pdp10-kl/init
@@ -1,6 +1,17 @@
 set console wru=034
 set cpu its
 set cpu 512k
+set dpa dis
+set dpb dis
+set rpb dis
+set tua dis
+set fha dis
+set dpb dis
+set lpt dis
+set cr dis
+set dc dis
+set dtc dis
+set dk dis
 at mta0 out/pdp10-kl/kl-magdmp.tap
 at mta5 out/pdp10-kl/kl-minsys.tape
 set rpa rp04

--- a/build/pdp10-kl/run
+++ b/build/pdp10-kl/run
@@ -1,5 +1,6 @@
 set console wru=034
 set cpu its
+set cpu idle
 set cpu 512k
 set dpa dis
 set dpb dis
@@ -12,6 +13,8 @@ set cr dis
 set dc dis
 set dtc dis
 set dk dis
+set pd ena
+set pd on
 at ptr bin/kl10/boot/dskdmp.rim
 set rpa rp04
 at rpa0 out/pdp10-kl/rp04.0

--- a/build/pdp10-kl/run
+++ b/build/pdp10-kl/run
@@ -1,6 +1,17 @@
 set console wru=034
 set cpu its
 set cpu 512k
+set dpa dis
+set dpb dis
+set rpb dis
+set tua dis
+set fha dis
+set dpb dis
+set lpt dis
+set cr dis
+set dc dis
+set dtc dis
+set dk dis
 at ptr bin/kl10/boot/dskdmp.rim
 set rpa rp04
 at rpa0 out/pdp10-kl/rp04.0


### PR DESCRIPTION
@rcornwell wrote:
> For ITS you should disable RPA, RPB, TUA, FHA, DPB.

That's a fair point, those devices aren't in use.  However, I wonder what ill effects you have in mind from leaving unused devices enabled?