### PR TITLE
Fixed COMSAT and DQXDEV on KA10. 

### DIFF
--- a/build/ka10/include.tcl
+++ b/build/ka10/include.tcl
@@ -217,3 +217,7 @@ proc patch_clib_16 {} {
 
 proc copy_to_klfe {file} {
 }
+
+proc comsat_switches {} {
+    respond "Limit to KA-10 instructions" "y\r"
+}

--- a/build/ka10/include.tcl
+++ b/build/ka10/include.tcl
@@ -221,3 +221,7 @@ proc copy_to_klfe {file} {
 proc comsat_switches {} {
     respond "Limit to KA-10 instructions" "y\r"
 }
+
+proc dqxdev_switches {} {
+    respond "Limit to KA-10 instructions" "y\r"
+}

--- a/build/kl10/include.tcl
+++ b/build/kl10/include.tcl
@@ -196,3 +196,7 @@ proc copy_to_klfe {file} {
 proc comsat_switches {} {
     respond "Limit to KA-10 instructions" "y\r"
 }
+
+proc dqxdev_switches {} {
+    respond "Limit to KA-10 instructions" "y\r"
+}

--- a/build/kl10/include.tcl
+++ b/build/kl10/include.tcl
@@ -192,3 +192,7 @@ proc copy_to_klfe {file} {
     respond "*" ":klfedr write $file\r"
     expect ":KILL"
 }
+
+proc comsat_switches {} {
+    respond "Limit to KA-10 instructions" "y\r"
+}

--- a/build/ks10/include.tcl
+++ b/build/ks10/include.tcl
@@ -210,3 +210,7 @@ proc copy_to_klfe {file} {
 proc comsat_switches {} {
     respond "Limit to KA-10 instructions" "n\r"
 }
+
+proc dqxdev_switches {} {
+    respond "Limit to KA-10 instructions" "n\r"
+}

--- a/build/ks10/include.tcl
+++ b/build/ks10/include.tcl
@@ -206,3 +206,7 @@ proc patch_clib_16 {} {
 
 proc copy_to_klfe {file} {
 }
+
+proc comsat_switches {} {
+    respond "Limit to KA-10 instructions" "n\r"
+}

--- a/build/misc.tcl
+++ b/build/misc.tcl
@@ -194,6 +194,7 @@ comsat_switches
 expect ":KILL"
 
 respond "*" ":midas device;jobdev dq_sysnet;dqxdev\r"
+dqxdev_switches
 expect ":KILL"
 
 respond "*" "comsat\033j"

--- a/build/misc.tcl
+++ b/build/misc.tcl
@@ -190,6 +190,7 @@ expect ":KILL"
 respond "*" ":link sys2;ts =,sys;ts srccom\r"
 
 respond "*" ":midas .mail.;comsat_sysnet;comsat\r"
+comsat_switches
 expect ":KILL"
 
 respond "*" ":midas device;jobdev dq_sysnet;dqxdev\r"

--- a/src/sysnet/comsat.584
+++ b/src/sysnet/comsat.584
@@ -14,6 +14,28 @@ TITLE NEW COMSAT
 	; System Communications Satellite
 	;(analogy pat. pend.-- running job has various actual sat. names)
 
+IF1,[
+
+DEFINE IFCE A,B
+IFE SIXBIT/A/-SIXBIT/B/,TERMIN	;SUBSTITUTE FOR IFSE THAT IGNORES CASE
+
+PRINTX /Limit to KA-10 instructions? /
+.TTYMAC KAONLY
+  IRPS Z,,[YES Y]
+  IFCE Z,KAONLY,{
+	$$KA10==1
+	.ISTOP
+	}
+  TERMIN
+TERMIN
+
+IFNDEF $$KA10, $$KA10==0
+
+IFN $$KA10, PRINTX /Limiting to KA-10 instructions 
+/
+IFE $$KA10, PRINTX /Using KS-10 and KL-10 instructions
+/
+]
 	F=0	; Flags
 	A=1	; A-E consecutive utility regs
 	B=2	;	( routines save all not used for value returning,

--- a/src/sysnet/dqxdev.42
+++ b/src/sysnet/dqxdev.42
@@ -92,6 +92,24 @@ $barf:	.call joberr
 	 quit
 	quit
 
+IF1,[
+
+DEFINE IFCE A,B
+IFE SIXBIT/A/-SIXBIT/B/,TERMIN	;SUBSTITUTE FOR IFSE THAT IGNORES CASE
+
+PRINTX /Limit to KA-10 instructions? /
+.TTYMAC KAONLY
+  IRPS Z,,[YES Y]
+  IFCE Z,KAONLY,{
+	$$KA10==1
+	.ISTOP
+	}
+  TERMIN
+TERMIN
+
+IFNDEF $$KA10, $$KA10==0
+]
+
 $$arpa==1
 $$chaos==1
 $$hostnm==1
@@ -373,7 +391,15 @@ qt.ptr:	move a,qclass		; which type of foo-ADDR are we lookinf for?
 	call strlen
 	sub a,t			; get difference
 	ifg. a			; better be something left!
-	  adjbp a,[440700,,qname]	; point at where trailer should be
+IFN $$KA10,[
+          move t,[440700,,qname]
+          ibp t
+          sojg a, .-1
+          move a,t
+]
+IFE $$KA10,[
+	 adjbp a,[440700,,qname]	; point at where trailer should be
+]
 	  call strcmp		; strings match?
 	anskp.			; yup
 	  setz t,		; tie off string

--- a/src/sysnet/netrts.357
+++ b/src/sysnet/netrts.357
@@ -6,6 +6,8 @@ IFNDEF $$FTP,$$FTP==0	; Do not assemble FTP routines anymore.
 IFNDEF $$TCP,$$TCP==1	; Normally assemble TCP routines.
 IFNDEF $$DQ,$$DQ==0	; Normally use host table, not DQ device.
 IFNDEF $$450,$$450==0	; Disable special casing of SMTP reply code 450
+IFNDEF $$KA10, $$KA10==0 ; default to KS/KL-10 instructions
+
 comment|   
          This file contains the network hacking code of COMSAT.
 
@@ -2165,12 +2167,19 @@ NHITS9:	POPAE P,[D,B,A]
 
 ; "NHMLTX" - routine skips if host in A is a Multics.
 NHMLTX:	PUSHAE P,[A,B,C,D]	; Save acs
-	DMOVE C,[ASCII "MULTICS"]	; What we are looking for
+
+IFN $$KA10,[
+	MOVE C,(B)
+	MOVE D,1(B)
+]
+IFE $$KA10, DMOVE C,[ASCII "MULTICS"]	; What we are looking for
+
 	JRST NHOPSY		; Join common code
 
 ; "NHITS" - routine skips if host in A is an ITS.
 NHITS:	PUSHAE P,[A,B,C,D]	; Save acs
-	DMOVE C,[ASCII "ITS" ? 0]	; What we are looking for
+	MOVE C,[ASCII "ITS"]	; What we are looking for
+	MOVEI D,0
 ;	JRST NHOPSY		; Join common code
 
 

--- a/src/sysnet/resolv.35
+++ b/src/sysnet/resolv.35
@@ -41,6 +41,8 @@ IFNDEF $$DQRN, $$DQRN==0
 IFNDEF $$DQCH, $$DQCH==1
 IFNDEF $$DQIN, $$DQIN==1
 
+IFNDEF $$KA10, $$KA10==0 ; default to KS/KL-10 instructions
+
 .BEGIN RESOLV
 
 IFN $$DQRN,{
@@ -118,7 +120,11 @@ TERMIN
 ;;; Non-skip means we are not on that network.
 
 OWNHST:	SETZ B,
-IFN $$DQIN, TLNN A,(NE%UNT) ? DMOVE A,[0 ? SQUOZE 0,IMPUS3]
+IFN $$DQIN,[
+ IFN $$KA10, TLNN A,(NE%UNT) ? MOVEI A, 0 ? MOVE B, [SQUOZE 0,IMPUS3]
+ IFE $$KA10, TLNN A,(NE%UNT) ? DMOVE A,[0 ? SQUOZE 0,IMPUS3]
+]
+
 IFN $$DQCH, CAMN A,[NW%CHS] ? MOVE B,[SQUOZE 0,MYCHAD]
 	SKIPE B
 	 .EVAL B,


### PR DESCRIPTION
Conditional assembly prompts for limiting to KA10 instructions. Also fixed DQXDEV (DQ) device to work on KA10.

Resolves #1671. Resolves #1669.