### PR TITLE
Removed duplicate hostnames in build/h3text 

### DIFF
--- a/build/h3text.2016
+++ b/build/h3text.2016
@@ -148,7 +148,7 @@ HOST : CHAOS 3404 : SRV.Victor.SE, SERVER.Victor.SE : PC : UNIX : :
 HOST : CHAOS 3412 : Amnesia.aosnet.CH, LMI-Amnesia.aosnet.CH : LISPM : LISPM : :
 HOST : CHAOS 3430 : Lambda-X.Victor.SE, LAMA.Victor.SE, LX.Victor.SE : Lambda : LISPM : :
 HOST : CHAOS 401 : Greek.UPDATE.UU.SE : Symbolics-3600 : LISPM : :
-HOST : CHAOS 442 : Lambda-D.UPDATE.UU.SE, LAMD.UPDATE.UU.SE, LD.UPDATE.UU.SE, LAMD.UPDATE.UU.SE, LD.UPDATE.UU.SE : Lambda : LISPM : :
+HOST : CHAOS 442 : Lambda-D.UPDATE.UU.SE, LAMD.UPDATE.UU.SE, LD.UPDATE.UU.SE : Lambda : LISPM : :
 HOST : CHAOS 4400 : AMS.aosnet.CH : : : :
 HOST : CHAOS 4401 : LISPM-1.AMS.aosnet.CH, CADR-1.AMS.aosnet.CH, CADR1.AMS.aosnet.CH, LM1.AMS.aosnet.CH : CADR : LISPM : :
 HOST : CHAOS 4402 : LISPM-2.AMS.aosnet.CH, CADR-2.AMS.aosnet.CH, CADR2.AMS.aosnet.CH, LM2.AMS.aosnet.CH : CADR : LISPM : :


### PR DESCRIPTION
The duplicate names cause warnings when compiled. Resolves #1676.