### PR TITLE
CI updates.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,5 +66,5 @@ workflows:
     jobs:
       - build_ka10
       - build_kl10
-      - build_klh10
+      # build_klh10 # Fails almost all the time.
       - build_simh

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,7 +5,7 @@ stages:
 
 # Note, GitLab currently does not build well with KLH10.
 
-job1:
+build_simh:
   stage: build
   variables:
     EMULATOR: simh
@@ -16,7 +16,7 @@ job1:
     paths:
       - out/simh/
 
-job2:
+build_ka10:
   stage: build
   variables:
     EMULATOR: pdp10-ka
@@ -27,7 +27,7 @@ job2:
     paths:
       - out/pdp10-ka/
 
-job3:
+build_kl10:
   stage: build
   variables:
     EMULATOR: pdp10-kl


### PR DESCRIPTION
The CircleCI KLH10 build seems to have met the same fate as @eswenson1's Jenkins and GitLab.  It fails just about every time, usually somewhere around purifying EMACS libraries.