### PR TITLE
Added sleep during DDT-based load of ITS 

### DIFF
--- a/build/kl10/include.tcl
+++ b/build/kl10/include.tcl
@@ -4,6 +4,7 @@ proc start_dskdmp_its {} {
     sleep 3
     respond "\n" "\033l"
     respond " " "its bin\r"
+    sleep 2
     respond "\n" "\033\033l"
     respond " " "salv bin\r"
     respond "\n" "\033y"


### PR DESCRIPTION
because sometimes expect sends the command too quickly and DDT gets confused. This is for
pdp10-kl build.  Resolves #1695.