### PR TITLE
Increase NAMDRG limits to accomodate larger system

### DIFF
--- a/src/sysen2/namdrg.150
+++ b/src/sysen2/namdrg.150
@@ -91,7 +91,9 @@ mapmsk==574377776000		;$<mapmsk>t; in ddt types out 10-11 interface map entry
 ifndef maxtty,maxtty==100	;max # tty's we can handle.
 ifndef nontty,nontty==40	;max # lisp machines
 	
-ifndef ttysiz,ttysiz=5000	;max size of TTYTYP.
+ifndef ttysiz,ttysiz=10.*2000	;max size of TTYTYP.
+				;Current size of TTYTYP is 4.5 blocks.
+				;Let's make this 10 blocks to last a while.
 
 loc 41
 		pushj p,uuoh

--- a/src/sysen2/namdrg.150
+++ b/src/sysen2/namdrg.150
@@ -61,7 +61,7 @@ termin
 
 ;pages 0 - <usrpag-1>;			the program
 
-;pages usrpag - c(ls2lpg)-1		LSRTAB REF file and HOSTS2 file
+;pages usrpag - c(ls2lpg)-1		LSRTAB REF file and HOSTS3 file
 
 ;pages c(ls2lpg) - hiporg-1;		dynamically allocated space
 
@@ -1445,7 +1445,7 @@ LS2MAP:	PUSH P,A
 	 JSR DIE
 	HRRZ A,B
 	MOVEI B,DKIC
-	PUSHJ P,NETWRK"HSTMAP	;Map in the HOSTS2 file.
+	PUSHJ P,NETWRK"HSTMAP	;Map in the HOSTS3 file.
 	 JSR DIE
 	MOVEM A,LS2LPG		;save # of first page free after LSR data.
 	.CALL [	SETZ ? SIXBIT/OPEN/ ? [.BII,,DKIC]

--- a/src/sysen2/namdrg.150
+++ b/src/sysen2/namdrg.150
@@ -88,7 +88,7 @@ ifndef tv11,tv11==0		;# of pdp-11 hassling ttys
 ifndef maxkbd,maxkbd==100	;maximum # of keyboards
 mapmsk==574377776000		;$<mapmsk>t; in ddt types out 10-11 interface map entry
 
-ifndef maxtty,maxtty==100	;max # tty's we can handle.
+ifndef maxtty,maxtty==120	;max # tty's we can handle.
 ifndef nontty,nontty==40	;max # lisp machines
 	
 ifndef ttysiz,ttysiz=10.*2000	;max size of TTYTYP.


### PR DESCRIPTION
With the addition of 16 more Datapoint Kludge ports, the number of ttys has overwhelmed NAMDRG.   @eswenson1 found out that MAXTTY needs to be increased.

But there's still a problem at XGPSTS.