### PR TITLE
Don't store Travis CI images on Amazon S3.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,17 +19,5 @@ matrix:
       env: EMULATOR=pdp10-kl BASICS=yes
 install: sh -ex build/dependencies.sh install_${TRAVIS_OS_NAME:-linux}
 script: make check-dirs all
-deploy:
-  provider: s3
-  access_key_id: "$AWS_ID"
-  secret_access_key: "$AWS_SECRET"
-  bucket: "$S3_BUCKET"
-  skip_cleanup: true
-  local_dir: out
-  acl: public_read
-  on:
-    branch: master
-after_deploy:
-  - build/deploy.sh
 notifications:
   email: lars@nocrew.org


### PR DESCRIPTION
They are no longer full builds.

@SMJ said he can host ITS images.