### PR TITLE
EMACS; EMACS NEWS is missing. This breaks an "N" documentation function.

### DIFF
--- a/doc/emacs/emacs.news
+++ b/doc/emacs/emacs.news
@@ -1,0 +1,2276 @@
+Date: 20 September 1981 02:30-EDT
+From: Richard M. Stallman <RMS at MIT-AI>
+Subject: Changes in EMACS 162, now NE on AI.
+To: INFO-EMACS-RECIPIENTS at MIT-AI
+
+*) You can now specify which command should exit an incremental search
+(and not do anything else when it exits the search) by setting the
+variable Search Exit Char to the desired 9-bit character.
+The default is Altmode.  Commands whose definitions are to indirect to
+the specified character also exit the search.  C-Space's default
+definition is now indirect to C-@, so if you set Search Exit Char
+to 300 octal, both C-@ and C-Space will be search exit characters.
+
+I urge everyone to try out the use of C-@/C-Space as exit character,
+because eventually I'll conduct another poll and perhaps change the
+default.  Try any other characters you might like, also.
+
+*) The new command Correct Spelling corrects spelling through the
+entire buffer.  The new command Command to Spell passes its argument
+to the SPELL job as a command.
+
+*) The major modes for various assemblers, such as MIDAS, PALX, FAIL
+and MACRO-10, now each run their own mode hooks.  Previously they all
+ran MIDAS Mode Hook.
+
+*) The completing reader has various extensions intended to allow
+completion on more kinds of things.  Completion of buffer names and
+variable names may be available soon as an optional library.
+
+*) The new hook Exit to Superior Hook is executed before EMACS returns
+to its calling job.  Unlike Exit Hook, this new hook is in addition to
+all normal actions.
+
+Date: 25 August 1981 02:51-EDT
+From: Richard M. Stallman <RMS at MIT-AI>
+Subject:  Many new features
+To: INFO-EMACS-RECIPIENTS at MIT-AI
+
+These features are mostly due to people at the Canadian
+Defense Research Establishment Atlantic.
+
+MAZLIB is cleaner now, and well documented.  Try it.
+MAZE.MAZE is the new data file for the maze.
+
+The SORT functions sort in reverse order if given
+a numeric arg.
+
+FORTRAN mode now provides for files with and without tabs after
+statement numbers, and for converting between the two formats.
+Also, it can insert or remove sequence numbers.  It contains a Fortran
+Data mode for editing files of fixed-column data.
+
+SAIL mode now has an indenter, based on that of PASCAL mode.
+
+The new library MODE2 provides for having two mode lines: the
+actual EMACS mode line and one additional line stolen from the text
+area.  You can select various options for information to display in
+that area.
+
+The new library NCOLUMNS can take single-column text and turn it into
+any number of columns, but cannot turn it back.  This is different
+from the library COLUMNS, which can turn single-column text into
+two-column text or the opposite, but cannot handle more than two
+columns.  Perhaps someone would like to write a new COLUMNS which
+replaces both of these.
+
+A new hook, Exit to Superior Hook, is executed before EMACS returns to
+its superior job.
+
+Twenex Only changes:
+
+The new library BUGHUNT modifies the comment commands to put your name
+at the front of each comment you edit.
+
+The new library MOVE contains functions for moving pages or paragraphs
+between files, supposedly more convenient than doing so by killing and
+switching buffers.
+
+The new library PERSONAL contains functions for keeping track of your
+projects, phone conversations, and notes to yourself.
+
+SYSTEM uses the superior EXEC if possible rather than an inferior,
+and has new functions Check Job, Check System Job,
+Check Log File, Logout, Enable, and Disable.
+
+EFORK: ^R Invoke Inferior can be called as a subroutine.
+
+The new library FDB is useful for examining occult parts of the status
+of a file, on Twenex.
+
+There is now a BASIC20 mode, and also a PCL mode for editing command
+files.
+
+The new library TALK contains functions for initiating and accepting
+links with other users.  Only for Twenex.
+
+The VT132 terminal is supported.  There is a library NVT132 for it
+analogous to NVT52 and NVT100.
+
+Two new hooks, Exit to Inferior Hook and Return from Inferior Hook,
+are executed respectively before EMACS runs an inferior and after
+EMACS starts up again.  Not all invocations of inferiors call these
+hooks; those which are expected to be momentary and involve no
+keyboard input generally do not invoke the hooks.
+
+CSTACY@MIT-AI 08/15/81 02:49:30 Re: bug
+message two
+
+CSTACY@MIT-AI 08/15/81 02:45:43 Re: bug
+message number one
+
+Date: 14 August 1981 01:14-EDT
+From: Richard M. Stallman <RMS at MIT-AI>
+Subject: M-Y, keyboard macros
+To: INFO-EMACS-RECIPIENTS at MIT-AI
+
+Meta-Y now preserves the order of point and mark.
+If point was at the beginning of the un-killed text before M-Y,
+it will be at the beginning after the M-Y.
+
+C-U C-X ( now appends to the last defined keyboard macro,
+repeating its definition at the beginning.  It is just like
+typing C-X ( and then retyping the previous keyboard macro
+definition yourself, but omitting the C-X ), so that you
+can add to the end of the definition.
+
+Date: 6 August 1981 03:40-EDT
+From: Richard M. Stallman <RMS at MIT-AI>
+Subject: EMACS 161
+To: INFO-EMACS-RECIPIENTS at MIT-AI
+
+EMACS 161 is now NE on AI.  It has these new features:
+
+The defun commands, C-M-A, C-M-E and C-M-H, now believe that
+a defun is any character whose Lisp syntax is "(", appearing
+in column 0.  It does not have to be literally a "(".
+
+The names for the built-in TECO functions are always accessible.
+You do not have to load the BARE library by hand to use them.
+
+All error messages pertaining to auto saving now say which file
+the problem was encountered with.
+
+In an incremental search on a printing terminal, you can type
+C-L to reprint the line which the search has reached so far,
+and it will not exit the search.
+
+On Twenex, a file's major mode will be defaulted from its extension
+even if the file has a local modes list (which fails to specify
+the major mode).
+
+Date: 6 August 1981 03:40-EDT
+From: Richard M. Stallman <RMS at MIT-AI>
+Subject: EMACS 161
+To: INFO-EMACS-RECIPIENTS at MIT-AI
+
+EMACS 161 is now NE on AI.  It has these new features:
+
+The defun commands, C-M-A, C-M-E and C-M-H, now believe that
+a defun is any character whose Lisp syntax is "(", appearing
+in column 0.  It does not have to be literally a "(".
+
+The names for the built-in TECO functions are always accessible.
+You do not have to load the BARE library by hand to use them.
+
+All error messages pertaining to auto saving now say which file
+the problem was encountered with.
+
+In an incremental search on a printing terminal, you can type
+C-L to reprint the line which the search has reached so far,
+and it will not exit the search.
+
+On Twenex, a file's major mode will be defaulted from its extension
+even if the file has a local modes list (which fails to specify
+the major mode).
+
+Date: 18 April 1981 02:35-EST
+From: Richard M. Stallman <RMS at MIT-AI>
+Subject: M-$  ^R Correct Word Spelling
+To: INFO-EMACS-RECIPIENTS at MIT-AI
+
+The new M-$ command, implemented by Klotz, calls the spell program
+on the word before or around the cursor.  If the spell program
+thinks the word is misspelled, EMACS prints a list of suggested
+correct spellings, numbered with digits, and you can ask to replace
+the word with one of them by typing the corresponding digit.
+For more info, see the function's self-documentation.
+
+Date: 10 APR 1981 0158-EST
+From: RMS at MIT-AI (Richard M. Stallman)
+Subject: default for Auto Save Filenames on ITS
+To: INFO-EMACS-RECIPIENTS at MIT-AI
+
+The default FN1 for auto save filenames on ITS is now
+_SAVnn, where nn is the buffer number of the buffer being saved.
+The buffer number is the number printed by C-X C-B at the
+beginning of the line describing the buffer.  This is so that
+auto saves from different buffers do not clobber each other.
+
+In older versions of EMACS, which do not have the feature just
+installed to insert the nn, the default will be _SAV00.
+
+If you set Auto Save Filenames yourself you will not see the change
+unless you set the FN1 to something six characters long ending in 00.
+
+Date:  7 APR 1981 0239-EST
+From: RMS at MIT-AI (Richard M. Stallman)
+Subject: Name changes coming up
+To: INFO-EMACS-RECIPIENTS at MIT-AI
+
+M-X Occur    ->    M-X List Matching Lines
+M-X How Many   ->  M-X Count Occurrences
+M-X Keep Lines ->  M-X Delete Non-Matching Lines
+M-X Flush Lines -> M-X Delete Matching Lines
+M-X View Available Space -> M-X What Available Space
+
+The old names (on the left) will still be accepted.
+
+
+Date: 30 MAR 1981 0349-EST
+From: RMS at MIT-AI (Richard M. Stallman)
+Subject: EMACS 155 (now NE on AI)
+To: INFO-EMACS-RECIPIENTS at MIT-AI
+
+*) The function names ^R Set Bounds Region, ^R Set Bounds Full,
+and ^R Set Bounds Page have been changed.  The new function names are:
+^R Narrow Bounds to Region, ^R Widen Bounds, and ^R Narrow Bounds to Page.
+The old names still work, for now.  The purpose is to make the functions
+show up when expected in an Apropos.
+
+*) You can now turn auto save mode on and off safely by setting the
+variable Auto Save Mode.  This is compatible with all other minor modes.
+
+*) The mode line says "narrow" when you have narrowed down.
+
+Date: 11 MAR 1981 2356-EST
+From: KMP at MIT-AI (Kent M. Pitman)
+Sent-by: RMS at MIT-AI
+Subject: New Lisp Indentation Format
+To: INFO-EMACS-RECIPIENTS at MIT-AI
+
+In Emacs 154 (now NE on all sites), a new Lisp indentation style is in use.
+The changes have been provided for the following reasons:
+
+ * To increase the ease with which stylized ``LispMachine-style'' Lisp 
+   indentation can be obtained in a user-programmable way.
+
+ * To lessen loss of screen space due to indentation. This indenter is much 
+   more conservative about the amount of indent it gives to many kinds of
+   expressions.
+
+ * To enhance error checking. Many kinds of Lisp forms (DO, PROG,
+   LET, LAMBDA, ...) have some number of leading forms, treated specially,
+   followed by some trailing forms, called the body. Common forms of this
+   type will now have expressions in their bodies indented slightly 
+   differently than their leading expressions to accentuate the separation.
+   eg,
+		(DO ((X 0 (1+ X)))
+		    ((= X 10.))
+		  (PRINT X))
+
+What follows is information about how customized indentation.
+
+* How Indentation is Decided
+
+  The old indentation algorithm is first run, and a tentative indentation
+  is computed. Then a hook is run to allow selection of a different 
+  indentation if appropriate.
+
+* User-Level Variables
+
+  Lisp ... Indent where the '...' is replaced by the name of a Lisp operator,
+	defines a special indentation method for that operator. Eg,
+	Lisp PROG Indent controls how PROG's indent. The value of variables
+	may be a string, in which case they will be called to compute
+	the indentation (argument conventions and return values to be discussed
+	later) or a number indicating one of several common operations.
+
+	      n				description
+
+	  -4 or less	undefined
+	  -3		don't indent any special way unless the value of
+			 Lisp Indent DEFanything dictates that we should.
+			 This is the default for unknown functions.
+	  -2		don't indent any special way.
+	  -1		indent as a DEF-form. If this is the 2nd line of the
+			 definition, indent specially. Otherwise, indent under
+			 preceding line.
+	   0 or more	indent as a special form, assuming that this form
+			 has n leading expressions before its body. (eg, LET
+			 and LAMBDA have 1 special expression for the bound
+			 variable list, PROGN has none, DO has 2). These
+			 special fields are indented normally. The first 
+			 expression following these special ones is indented
+			 specially. Expressions after that are indented 
+			 under the previous line as normal.
+
+	The variable Lisp PROG Indent is initially defined to run code so that PROG
+	tags can line up right-justified. Variables corresponding to several
+	of the common Lisp special forms are set up with non-negative values 
+	corresponding to the indentation style suggested by their semantics.
+
+  Lisp Indent DEFanything, if nonzero, will cause all operator names
+	beginning with 'DEF' to default to definitional form style indentation
+	(corresponding to a Lisp DEF... Indent variable of -1). Setting this
+	to 0 will cause 'DEF...' operators to be indented specially only if
+	they have associated Lisp ... Indent variables set up to cause such
+	special indentation.
+
+  Lisp Indent Offset (default 0), if nonzero, indent this many columns past
+	the most recent unclosed "(" rather than worrying about indentation
+	relative to arguments (this also bypasses special form hackery).
+	If 0, normal Lispy indentation rules apply.
+
+	NOTE: Although this variable has been present for a long time,
+	      it has changed slightly. It used to measure offset from the 
+	      right side of the paren. Now it measures offset from the left
+	      of the paren. The change was made to provide greater flexibility
+	      since formerly it was impossible to say you wanted to indent
+	      just after the hanging open paren. 
+
+  Lisp Special Indent Offset (default 2), is the offset from the hanging
+	"(" which special form indentation uses. Eg, with the default setting,
+	Emacs will indent under the "E" of "DEFUN".
+  
+* Low-Level Variables (primarily of interest to Emacs implementors)
+
+  Lisp Indent Language contains a string (default "LISP") which is used
+	to decide which lisp-like language is to be used. Other hooks key
+	off of this string; ie, if the Indent Language is LISP, variables
+	like LISP Indent Offset and Lisp PROG Indent will be looked for.
+	If the language were Muddle, variables such as Muddle Indent Offset and
+	Muddle PROG Indent would be looked for instead. Currently, Muddle mode
+	doesn't use this feature, but perhaps it will in the near future.
+
+	In the remainder of this description, only Lisp ... variables
+	since they are the only ones which are currently useful to most users,
+	but implementors should bear in mind that similar variables for
+	other dialects may be defined if a local variable
+	Lisp Indent Language is created with the appropriate dialect
+	name as its contents.
+
+  Lisp Indentation Hook holds the function which tries to determine how
+	special forms should be indented. All of the effects described
+	farther down in this description are dependent on its containing
+	the default value. If you do not like the action of this hook,
+	you may wish to put a null string in this variable to keep it 
+	from doing anything -- effectively nullifying most of the changes
+	described in this text.
+
+* Extension Conventions (for sophisticated users only)
+
+  Lisp Indentation Hook (or Muddle Indentation Hook or ...) must be 
+	defined and must contain a string. Its args (,) are the
+	position in the buffer of the most recent unclosed "(" and
+	the buffer position of the beginning of the line to be indented.
+	The buffer position of the cursor at the time the tab was typed
+	is stored as an offset from Z in qZ, so Z-qZ is that buffer position.
+	The hook should NOT modify the buffer. If it returns 0 or no value,
+	it will be assumed that the horizontal cursor position (given by
+	fsshpos) is to be used as the indetnation level. Hence, to indent
+	under the "O" in PROG, it is sufficient to jump to that character in
+	the buffer and return. Replacement of the pointer to the appropriate
+	line will happen automatically later. If it returns nonzero, that
+	value will be assumed to be the desired indentation. Returning
+	negative values is undefined.
+
+  Lisp ... Indent variables containing strings to be executed observe the
+	same argument conventions as the Lisp Indentation Hook would.
+
+
+Date:  2 MAR 1981 1235-EST
+From: RMS at MIT-AI (Richard M. Stallman)
+Subject: Changes in EMACS 154 (now NE on AI)
+To: INFO-EMACS-RECIPIENTS at MIT-AI
+
+Incompatible changes (indicated by two *'s at beginning of item):
+EVARS file and local mode list format,
+Visit File Save Old vs. Inhibit Write,
+Meaning of argument to C-X C-V or C-X C-F,
+Meaning of Exit Hook,
+Format of Prefix Char List.
+
+*** Use ***
+
+**) Visit File Save Old now controls whether visiting a new file causes
+the old one to be saved.  If this variable is zero, the old file is
+not saved.  If it is -1, then the old file is automatically saved.  If
+the variable is 1, then you are asked whether to save.  The default
+value is 1.  This variable replaces the old distinction between C-X
+C-R and C-X C-V, which are now identical commands.
+
+The variable Inhibit Write is no longer used for anything, though
+it still exists to keep some old programs from bombing.  Find File
+Inhibit Write no longer exists at all.
+
+**) True read-only visiting is now implemented.  An argument to the
+file-visiting command (C-X C-V or C-X C-F) is used to request this.
+Either the buffer or the file can be read-only.  A read-only buffer
+means that you can't insert or delete anything.  A read-only file
+means you can change the text in the buffer, but it will not be saved
+in the file unless you insist.  To insist, you type C-X C-S and answer
+"Y" to confirm; absolutely nothing else will cause the read-only file
+to be saved.
+
+Normally what you get is a read-only file, whose buffer can be edited.
+The command C-X C-Q (^R Set Read-Only File) can be used to switch
+between the three modes (ordinary, read-only buffer, and read-only
+file).
+
+*) New self-documentation for recursive editing levels.
+When you are inside a recursive editing level, Help ? mentions this
+and tells you how to abort and how to exit, as well as listing the
+Help options available.  A new Help option, Help R, gives the full
+description of the command that got you into the recursive editing
+level.
+
+*) If the variable Auto Save All Buffers is nonzero, each auto save
+will save whichever buffers need to be saved.  It is up to you to make
+sure that the buffers are saved in different places, either by using
+Auto Save Visited File, or by giving each buffer a different value of
+Auto Save Filename (perhaps automatically in a Buffer Creation Hook).
+
+*) EMACS remembers the current version number of each visited file,
+and displays this in the mode line and in the printout from List
+Buffers.
+
+*) The Delete File command asks for confirmation if it is not sure
+that you know what default filenames were applied to the filename you
+specified.
+
+*) M-X View Available Space prints out how many pages of space are
+available in EMACS for more buffers or more libraries.
+
+*) The character "#" now has the syntax of a prefix character in Lisp
+mode.
+
+*) ^R Indent for Comment now does not move comments that start with a
+single semicolon in column 0.
+
+*** Customization ***
+
+**) The format of EVARS files and local mode lines has been changed to
+allow variable values to be multi-line strings.
+
+The value specified for a variable should now be either a number or a
+string enclosed in doublequote characters.  Indentation before the
+number or before the string is ignored.  To include a doublequote
+character in the contents of the string, quote it with a  character.
+
+Except for peculiar cases, old EVARS files and local modes lists still
+work.  Peculir cases include string values which happen to begin with
+spaces followed by a doublequote, or spaces followed by a digit.
+
+The change applies only to values of variables.  Lines which specify
+definitions for command characters are still single lines of TECO
+code.
+
+*) So that certain common forms of customization will not need to use
+FS flags, there are now variables which you can use instead of certain
+FS flags which people often set.  Setting the variable sets the FS
+flag.  Setting the FS flag explicitly also works, but the value of the
+variable does not change, so it is best not to mix the two styles of
+use.
+
+Here is a complete list of variables which control FS flags.  Not all
+of these are new.
+
+Auto Save Interval		FS ^R MDLY
+Bottom Display Margin		FS %BOTTOM
+Case Search			FS BOTHCASE
+Cursor Centering Point		FS %CENTER
+Display Mode Line Inverse	FS INVMOD
+Display Overprinting		FS ^H PRINT and FS ^M PRINT
+Echo Area Height		FS ECHO LINES
+End of Buffer Display Margin	FS %END
+Error Messages in Echo Area	FS ECHO ERRORS
+Fill Column			FS ADLINE
+Overwrite Mode			FS ^R REPLACE
+SAIL Character Mode		FS SAIL
+System Output Holding		FS TT PAGE (Twenex only)
+Top Display Margin		FS %TOP
+
+*** Extension ***
+
+**) The format of the value of the variable Prefix Char List is
+changed.  This should only affect people who create their own prefix
+characters.  The purpose of the change is to allow for prefix
+characters whose dispatch tables are kept in variables rather than in
+q-registers.  The new format of the value is: any number of lines,
+with a CRLF after each line, one line per prefix character.
+Each line contains the name to be printed for the prefix character,
+followed by two spaces, and the TECO expression which evaluates to the
+dispatch table for the prefix character.  Look at the initial value of
+this variable if this is not clear.
+
+**) & Exit EMACS now calls the Exit Hook in addition to auto saving and
+optional explicit saving.  The Exit Hook used to override them.
+
+*) The TECO feature FS SUPERIOR is now fully exploited by EMACS.
+Superiors can tell an EMACS to make space in the buffer, or to visit a
+file, by following the protocol described near the end of TECORD.
+
+*) M-X Describe can be given a precomma argument, which should be the
+character number of a ^R command being described.  This is passed
+along to any documentation-macros contained in the documentation
+string.
+
+*) FS TAB WIDTH now controls the distance between tab stops on
+display.  By setting this to 10, you can view a file the way it would
+look on Multics.
+
+*) On Twenex, Return from Inferior Hook is called on return from an
+inferior if Exit Hook is called before starting the inferior.
+
+Date: 17 AUG 1980 0144-EDT
+From: RMS at MIT-AI (Richard M. Stallman)
+Subject: Another change to SCRIBE mode.
+To: INFO-EMACS-RECIPIENTS at MIT-AI
+
+"@;" at the front of the line will also make the line
+a paragraph-separator, just like @begin and @end.
+Put "@;" (the SCRIBE no-op command) at the front of
+any line (such as @quotation[, @example[, or a line
+of just a closing delimiter) which should not be
+filled in with the surrounding lines.
+
+Also, SCRIBE mode is now defined on ITS as well as Twenex.
+
+Date: 13 AUG 1980 0219-EDT
+From: RMS at MIT-AI (Richard M. Stallman)
+Subject: SPLIT library for editing very big files.
+To: INFO-EMACS-RECIPIENTS at MIT-AI
+
+There is a new library SPLIT for operating
+on files too big to load into EMACS.
+It contains a command Split File which
+divides such a large file into small enough subfiles,
+and another command Unsplit File for putting the subfiles
+back together.
+
+On ITS, the subfiles made from FOO <anything> are called
+FOO 1, FOO 2, FOO 3, etc.  Unsplit Files looks for the
+same names to recombine.
+
+On Twenex, the file FOO.anything.version is split into
+FOO.1.1, FOO.2.1, etc.  After these have been edited
+to get FOO.1.3, FOO.2.2 (for example), Unsplit File
+combines those into a new version of FOO.anything
+
+The subfiles are made about 50,000 words long,
+and are divided at line boundaries.
+There is no limit to the size of file which can be split.
+
+Date: 10 AUG 1980 0557-EDT
+From: RMS at MIT-AI (Richard M. Stallman)
+To: INFO-EMACS-RECIPIENTS at MIT-AI
+
+EMACS 150 has the function Compare Windows, which is
+what used to be in LSPUTL under the name Window SRCCOM.
+It's very useful.  Also, now you can quit it at any time
+and the pointers in both windows are advanced as far as
+the comparison has gone.
+
+The character "@" at the front of a line no longer indicates
+a paragraph gap line by default.  In SCRIBE mode (which exists
+on Twenex), the strings "@begin" and "@end" are recognized
+as paragraph-separating lines, but not other lines which start
+with "@".  This is so that there is no problem with the many
+SCRIBE commands that are used within a paragraph.
+
+Date: 27 JUL 1980 0218-EDT
+From: RMS at MIT-AI (Richard M. Stallman)
+Subject: printing terminals
+To: INFO-EMACS-RECIPIENTS at MIT-AI
+
+TECO 1008 makes it possible to customize how cursor motion
+is indicated by EMACS on printing terminals.
+
+EMACS will still handle motion within one line or down
+only one screen line by backspacing or printing the characters
+moved over.
+
+Other cursor motion can be handled by the string of TECO commands
+stored in FS ^R TTM1.  It is up to you to define it.
+I hope you will come up with useful ideas for what to put there
+and try them out.  Then eventually I will look at what you've done
+and install something.
+
+Date: 26 JUL 1980 0121-EDT
+From: RMS at MIT-AI (Richard M. Stallman)
+To: INFO-EMACS-RECIPIENTS at MIT-AI
+
+The library OUTLIN is now called OUTLINE on Twenex systems.
+
+The variable Mail Reader, which holds the name of the library
+to use for reading mail, is now called Mail Reader Library.
+On Twenex, there is also Mail Reader Program.  Set the former
+if you use an EMACS library to read mail, or set the latter
+if you use a separate program to read mail.
+
+Date: 25 JUL 1980 0405-EDT
+From: RMS at MIT-AI (Richard M. Stallman)
+Subject: LSPUTL library.
+To: INFO-EMACS-RECIPIENTS at MIT-AI
+
+Boyer@SRI has contributed a few useful functions.
+
+Window SRCCOM compares the text in window 1 with that in window 2,
+moving to the next difference.  Useful with things other than Lisp also.
+
+Find Pat searches for lists that contain several specified strings.
+
+^R Extract Sublist replaces a list with one of its sublists.
+
+Date: 23 JUL 1980 1603-EDT
+From: RMS at MIT-AI (Richard M. Stallman)
+To: INFO-EMACS-RECIPIENTS at MIT-AI
+
+The obsolete duplicate function names
+Alter Options, Edit ..D, ^R Find File, and & Macro Get Full Name
+are being flushed.  The new names (which already work) are
+Edit Options, Edit Syntax Table, Find File, and & Macro Name.
+
+Date: 23 JUL 1980 0023-EDT
+From: RMS at MIT-AI (Richard M. Stallman)
+To: INFO-EMACS-RECIPIENTS at MIT-AI
+
+Reap File now only accepts one filename to reap.
+It used to accept any number of filenames, terminated
+by a null argument.  The change is to make it more like
+most other commands.
+
+Date: 13 July 1980 22:15-EDT
+From: Eugene C. Ciccarelli <ECC at MIT-AI>
+Subject:  Word Abbrev mode
+To: WORDAB at MIT-AI
+
+Here are some further details on the new WORDAB library, for those who
+might be doing lower-than-normal-level hacking:
+
+*  Note that List Word Abbrevs, Insert Word Abbrevs, and Edit Word
+   Abbrevs all take string arguments, though the one to Edit Word
+   Abbrevs is ignored.  (There just to catch assumptions people make
+   from analogy to the others and since it makes sense.  But there are
+   problems with its implementation.)
+
+*  A "1," numeric argument to Define Word Abbrevs tells it to kill all
+   word abbrevs before defining, but only after ensuring that the
+   definition list syntax is ok.
+
+*  Incremental saving should be "truer" -- e.g. abbrevs defined with
+   Define Word Abbrevs (and Edit Word Abbrevs which calls it) will
+   even be saved in the incremental list.  Word abbrev macros will
+   also be saved.  People probably haven't noticed the anomalies
+   regarding incremental saving -- at least no one's complained.
+
+*  If anyone cares, the variable QWABL Definitions is gone.
+
+*  Since no one voiced any objections, the Word Abbrev Mode Hook
+   variable is gone.  The WORDAB Setup Hook is used to tailor what
+   keys get connected.  (Or if you need functionality like the old
+   hook, you can replace the variable macro on Word Abbrev Mode,
+   currently trivial.)
+
+*  Have lots of abbrevs?  M-X List Word Abbrevs -- it lists abbrevs as
+   they are found, rather than building the entire list first, then typing.
+   You can also flush the list by typing ahead.  If you want to build
+   a kind of lister yourself, note that Insert Word Abbrevs is
+   the basic function, and takes a "1," numeric argument telling it to
+   list as it goes.
+
+*  If you are interested in providing your own abbrev-saving
+   mechanism, note the variable Word Abbrevs Modified.
+
+*  Another new variable is Last Word Abbrev Defined, with the name
+   of the abbrev variable.  This is used by Attach Word Abbrev
+   Keyboard Macro, and maybe could have other uses.
+
+*  Finally:  not in WORDAB now, but under consideration:  Abbrevs are
+   now defined by funny-named variables, e.g. X ab * Abbrev.  I
+   would like to have these not be variables any more, but instead
+   reside in the q-vector in q-register .E.  Does anyone currently
+   depend on abbrevs defined as variables?  E.g. anybody using abbrevs
+   that are local variables of a file?
+
+Date: 13 July 1980 22:14-EDT
+From: Eugene C. Ciccarelli <ECC at MIT-AI>
+Subject:  Word Abbrev mode
+To: INFO-EMACS-RECIPIENTS at MIT-AI
+
+There is a new version of the WORDAB library with the following
+changes.  This is now installed on AI, soon to move elsewhere.
+For details on new commands, see their on-line documentation.
+
+*  M-X Word Abbrev Apropos has been replaced by M-X List Word Abbrevs
+   with a string argument.  M-X Insert Word Abbrevs can also take a
+   string argument.
+
+*  Keys (C-X C-A, etc.) are connected when the library is loaded, and stay
+   connected outside of Word Abbrev mode:  you can define and expand
+   manually if the system is too slow for automatic expansion to be
+   tolerated.  Also, there is a new command M-X Expand Word Abbrevs in
+   Region (queries like M-X Query Replace).
+
+*  New option variable, Save Word Abbrevs, controls whether exiting EMACS
+   will cause abbrevs to be saved if necessary.  1 => save all abbrevs
+   on exit, -1 => just save incrementals, with default 0.
+
+*  M-X Edit Word Abbrevs lets you re-edit to correct syntax errors.
+   The error messages should be clearer too.
+
+*  You can have word abbrev "macros", keyboard macros (or Teco code if
+   you prefer) that can be "attached" to normal abbrevs, so that after
+   those abbrevs expand, their attached macros are run.  E.g.
+   "textmode" could expand to "-*-Text-*-" and then do a M-X Text Mode
+   automatically.  Describe M-X Attach Word Abbrev Keyboard Macro for
+   details.
+
+One final question:  does anyone use abbrevs that are local to a file?
+
+KMP@MIT-MC 07/12/80 03:53:25 Re: Minor changes to TAGS package
+To: INFO-EMACS-RECIPIENTS
+If qTags Find File is set to 2 instead of 1, it now means to force use
+of Find File always (rather than preferring to recycle the *TagSearch* 
+buffer where possible). This allows a user to override the recent changes
+to the Tags Find File behavior. You are not recommended to make this change
+unless you find yourself annoyed by the default behavior. -kmp
+
+
+
+Date: 30 JUN 1980 0956-EDT
+From: KMP at MIT-MC (Kent M. Pitman)
+Subject: New Emacs library for TeX users -- TeXmac
+To: INFO-EMACS at MIT-MC
+CC: RLB at MIT-MC, INFO-TEX at MIT-MC, RIVEST at MIT-ML
+
+I have created and installed a library called TeXmac for use in Emacs
+to support useful operations on TeX code. Currently, the following
+macros are all it contains:
+
+[1] M-X Setup Indented TeX Display
+
+    This macro will take a normally indented expression in a variable
+    width region and set it up so that it will be output aligned similarly
+    by TeX. *Only* the beginnings of lines will line up right. Example:
+    The region must be placed around the area that is to be set up.
+    This macro is primarily for setting up indented Lisp code in a variable
+    width font. Requires a \noflash macro to be defined (see [3] below)
+
+[2] M-X UnSetup Indented TeX Display
+
+    This macro will convert a region of the buffer which has had
+    M-X Setup Indented TeX Display run across it and turn it back into
+    normally indented text. The cursor may be placed generally anywhere
+    touching the \vbox{...} which is to be converted back.
+
+[3] M-X Insert TeXmac Aux Macros
+
+    Inserts macro definition for \noflash macro used by the output of
+    M-X Setup Indented TeX Display. If the \noflash macro is found to be
+    of general use to the TeX community, it may be moved into one of the
+    TeX libraries, but for now you'll have to manually include its definition
+    by running this macro at the top of your file.
+
+Date: 29 June 1980 19:12-EDT
+From: Earl A. Killian <EAK at MIT-AI>
+To: INFO-EMACS at MIT-AI
+
+The default EMACS init file has been changed to use Find File
+rather than Visit File to read in the file specified in the
+command line, if the variable Tags Find File is nonzero.
+
+Date: 27 June 1980 12:28-EDT
+From: Kent M. Pitman <KMP at MIT-MC>
+Subject:  Modifications to TAGS
+To: INFO-EMACS at MIT-MC
+
+The following changes have been made in the Emacs TAGS library:
+
+People who do 1m.vTags Find File (default 0, same as before) will
+now find that TAGS search over large tag libraries will not run out 
+of core. Now what happens if Tags Find File is nonzero is a buffer
+named *TagSearch* is used as a temporary during the search if the
+file being searched is not already in core. This affects only 
+M-X Tags Search, C-., and M-X Tags Query Replace. (If you do a search 
+that uses this facility, you are advised to use M-X Rename Buffer to 
+change the buffer name if you don't want the next such search to recycle
+that space.)
+
+Doing 0m.vTags Search Verbose (default 1) will suppress the filenames
+from printing out as M-X Tags Search moves from file to file. 
+M-X Tags Query Replace is not affected, since it is presumably more
+interactive anyway; if there are enough people who want the same or another 
+flag to affect that macro, as well, it can probably be arranged.
+
+Some minor bug fixes. Tags will no longer accidentally err out due to
+finding something in an invalid field in the tags file.
+
+-kmp
+
+
+Date:  6 JUN 1980 0555-EDT
+From: RMS at MIT-AI (Richard M. Stallman)
+To: INFO-EMACS at MIT-AI
+
+PURIFY has been changed to allow blank pages
+and pages containing just comments in library source files.
+They are ignored.  This should facilitate putting local modes lists
+in such files.
+
+KMP@MIT-MC 05/06/80 00:40:58 Re: MODLIN/TIME feature added
+To: INFO-EMACS at MIT-MC
+Users of the MODLIN mode-line handler can do
+
+	1 m.vTime Only
+
+in an init file if they would rather have only the time and not the date
+in the mode line. The default is still to get both date and time. For more
+info, send me net-mail. -kmp
+
+
+Date: 15 Apr 1980 0557-EST
+From: RWK at MIT-XX
+Subject: New SLOWLY library
+To: info-emacs at MIT-AI
+
+There is a new version of the SLOWLY library, with an improved incremental
+search.  This one only narrows the screen for searching when the item
+searched for is offscreen.  This means that when you search for something
+onscreen, you don't end up doing a redisplay just to put the item found
+at the top of the screen.
+-------
+
+Date: 11 APR 1980 0605-EST
+From: RMS at MIT-AI (Richard M. Stallman)
+Subject: Journal file feature
+To: INFO-EMACS at MIT-AI
+
+EMACS can now write journal files which record all your commands
+so that they can be replayed later after a system crash or other lossage.
+Documentation for this feature can be found in AI:RMS;JRNDOC >.
+This file is in SCRIBE input format but is probably comprehensible.
+
+Date:  4 APR 1980 0542-EST
+From: RMS at MIT-AI (Richard M. Stallman)
+To: INFO-EMACS at MIT-AI
+
+In EMACS 145, M-X and C-M-X will prompt for the command name
+with M-X and C-M-X rather than MM and :MM.
+this is so that the prompts will be understandable without
+reference to TECO, which users may not know anything about.
+These prompts can be overridden with the variables
+Read Command Prompt and Instant Command Prompt, as before.
+
+Date:  3 APR 1980 0805-EST
+From: RMS at MIT-AI (Richard M. Stallman)
+Subject: EMACS 145
+To: INFO-EMACS at MIT-AI
+
+EMACS 145 is now installed as NE on AI.
+For the most part it merely incorporates the patches for 144.
+However, there are these new minor features:
+
+View Buffer now takesthe name of the buffer to be viewed.
+A null argument means to view the selected buffer, as before.
+Also, Backspace moves back by screens, as in View File
+(which is used as a subroutine).
+
+A new command, Insert Buffer, inserts the contents of another
+buffer into the selected one.
+
+A new command, Make Space, tries to free up space.
+It offers to empty out the kill ring, to empty the undo
+memory, and to delete the EMACS buffers created automatically
+by TAGS, INFO, RMAIL, etc. (a separate offer for each such buffer).
+Even if you say "no" to each of these offers, it frees up some
+internal objects which you will not miss.
+
+Backtrace now has a new command, ".", which returns to any frame
+at any PC.  First select the frame to return to, then type ".".
+You can then position point at the PC to return to, in a
+recursive editing level.
+
+The commands List Commands, List Subroutines and List ^R Commands
+have been flushed to save space, on the grounds that their output
+has become so verbose that nobody would want to use them.
+You can get a similar effect from doing Apropos with a null argument.
+
+Date: 28 MAR 1980 0854-EST
+From: ECC at MIT-AI (Eugene C. Ciccarelli)
+Subject: Word Abbrev Mode
+To: INFO-EMACS at MIT-AI
+
+Minor changes, mostly fixes and a few new variables to make things easier
+for users with init and EVARS files.  Currently only on the ITS machines,
+but soon to move to others.
+
+1. A second C-X U (^R Unexpand Last Word) undoes the first one.
+
+2. M-X Word Abbrev Mode without an argument will toggle the mode.
+
+3. M-X Read Word Abbrev File can read in two kinds of definition file
+formats: the default fast-loading kind, and the human-readable kind (the
+one you see with M-X List Word Abbrevs).  M-X Write Word Abbrev File will
+write human-readable format files if the Readable Word Abbrev Files option
+variable is set to 1.
+
+4. Setting the Only Global Abbrevs option variable to 1 will cause only
+global abbrevs to be used.  Using only global abbrevs is faster, simpler
+and some people find it more appropriate.
+
+5. You can specify additional characters, e.g. the digits, that should
+cause expansion.  See the description of the M-X Make These Characters
+Expand command.  (Users with AI terminals: you can make Top-characters be
+expanders too.)
+
+Please send bugs to BUG-WORDAB@MIT-AI.
+
+Date: 5 FEB 1980 1251-EST
+From: EAK at MIT-AI (Earl A. Killian)
+
+Testing.
+
+Date: 13 JAN 1980 2042-EST
+From: RMS at MIT-AI (Richard M. Stallman)
+Subject: View Buffer
+To: INFO-EMACS at MIT-AI
+
+The way to exit from View Buffer while moving point into the screenful
+that is presently on the screen is now Return instead of C-C.
+
+Date: 9 JAN 1980 0324-EST
+From: RMS at MIT-AI (Richard M. Stallman)
+To: INFO-EMACS at MIT-AI
+
+The Set Key function will now ask for confirmation.
+Also, it really works to use prefix characters to
+specify the key to be redefined.
+
+Date: 7 December 1979 05:06-EST
+From: Eugene C. Ciccarelli <ECC at MIT-MC>
+Subject:  WORDAB problems
+To: Info-Emacs-News at MIT-AI
+
+The installation problem that Scott reported should be solved.  If
+anyone else encounters any difficulties at all with WORDAB, please
+mail to ECC@MIT-MC.  One thing mentioned before has been changed:  the
+commands MM Define Word Abbrevs, MM Insert Word Abbrevs, and MM Kill
+All Word Abbrevs have not gone away since they are used more than I
+thought they'd be.
+
+Another note, geographical:  the installations of WORDAB have occurred
+on the ITS machines, BBND, and MIT-XX.
+
+
+Date: 6 December 1979 22:47-EST
+From: Eugene C. Ciccarelli <ECC at MIT-MC>
+Subject:  New WORDAB release
+To: INFO-EMACS-NEWS at MIT-AI
+
+    A new version of the WORDAB (Word Abbrev Mode) library has been
+installed.  This new version is a minor change from XWORDA library
+which has been in use for quite a while among several users.  The old
+version of the WORDAB library will be available for a while as OWORDA.
+The major changes that uses of the old WORDAB library will see are:
+
+    1. The format used for files of saved abbrev definitions is
+different, less human readable but much faster to load.  For users
+with old-style format files, the MM Read Word Abbrev File will
+perform a conversion and rewrite the file in the new format.  (The old
+file will be copied, just in case, to WORDAB ODEFNS on ITS,
+WORDAB.ODEFNS.0 on Tenex/Twenex sites.)
+
+    2. Multiple-line expansions are supported.
+
+    3. MM Edit Word Abbrevs has a slightly different format, to allow
+the more general expansions, e.g. multiple-line.  Basically, if you
+have a double-quote character (") inside an expansion, it will be
+doubled (""), to distinguish it from the double-quotes that surround
+the entire expansion.
+
+    4. There is a new command, MM Word Abbrev Apropos, that will list
+some (not all) of the abbrevs currently defined.  Like MM Apropos,
+it takes a string argument to match against the defined abbrevs:  any
+abbrev containing that string, or having an expansion containing that
+string, will be listed.
+
+    5. Some commands went away, to leave a simpler looking user
+interface.  These commands were:  MM Define Word Abbrevs, MM Insert
+Word Abbrevs, MM Kill All Word Abbrevs, and MM Incremental Word
+Abbrev Apropos.  If this bothers anyone, contact me.  (There are some
+subroutine available to do the job, for instance.)
+
+
+Date: 23 NOV 1979 0550-EST
+From: RMS at MIT-AI (Richard M. Stallman)
+Subject: ^R Exchange Characters, etc.
+To: INFO-EMACS at MIT-AI
+
+In EMACS 141, all these functions will be renamed
+to things like ^R Transpose Characters.
+This should go better with commands like C-T, M-T, etc.
+
+Date: 23 NOV 1979 0530-EST
+From: RMS at MIT-AI (Richard M. Stallman)
+Subject: EMACS 141 change
+To: INFO-EMACS at MIT-AI
+
+Revert File with an argument will revert to the last version
+of the visited file, ignoring any auto save files made since then
+if you are autosaving under separate filenames.
+A precomma argument will make it not require confirmation.
+
+Date: 23 NOV 1979 0528-EST
+From: RMS at MIT-AI (Richard M. Stallman)
+Subject: EMACS 141 changes
+To: INFO-EMACS at MIT-AI
+
+In EMACS 141, there will be these changes:
+
+* Whether the parenthesis matching display feature beeps if there
+is no matching parenthesis is controlled by the new variable
+QPermit Unmatched Paren.  If it is 1, unmatched parens are permitted
+(no beep) in all major modes.  If it is 0, they are never permitted
+(always beep).  If it is -1, they are permitted except in Lisp mode
+(because Lisp mode sets the variable to 0 if it was -1!).
+The initial setting is -1.
+
+Also, mismatched parens, as in "[)", will always beep if the matching
+display feature is turned on.
+
+* Help N prints out the file EMACS NEWS of EMACS change information.
+
+* C-X = will now print out the total size of the file in characters
+as well as its other information.  It should be self-explanatory.
+
+* In M-X and C-M-X, just "I " as the start of a command will expand
+automatically into "Insert ".  This is in addition to "V" for "View,
+"L" for "List", "K" for Kill and "E" for Edit.  My intention is to
+rename the commands that do one of these sorts of things to start with
+the "standard" word for that type of operation, to make the command
+names easier to remember.
+
+* Get Date has been renamed to Insert Date.
+Alter Options has been renamed to Edit Options.
+Edit ..D has been renamed to Edit Syntax Table.
+The first two of these changes are examples of the policy
+described in the previous section.
+
+* The function Auto Save Mode will no longer set the number
+of versions to be kept or the number of characters between saves.
+Its argument will only say whether to turn the mode on or off.
+Those other parameters are the values of the variables
+QAuto Save Max and QAuto Save Interval.  The first one already
+existed; the second one is new.
+
+* Write File and Set Visited Filename now run the Visit File Hook,
+if there is one, but give it an argument of 1 to distinguish themselves
+from an actual Visit File.
+
+
+Also, these changes have been made in other libraries:
+
+In KBDMAC, there is now C-U C-X Q.  It causes a recursive editing level
+to be entered when the macro is defined and again when the macro is run.
+Thus, at that point in the macro, you can do a different thing each time
+around.
+
+In PAGE, there are several changes:
+
+* ^R Go to Page is now ^R Goto Page, so as to resemble the other commands,
+and lives by default on C-X C-P instead of on M-G.  M-G and C-M-G are
+no longer changed by the package.
+
+* C-X C-P when you are looking at the whole buffer
+will now narrow to just the page that point is in.
+
+* Print File Directory has been renamed to View Page Directory.
+(After all, a file directory is something entirely else).
+Make File Directory has been renamed to Insert Page Directory.
+
+* Trying to move to a nonexistent page will get an error, but
+will leave you in the first or last page with the correct page
+number in the mode line.
+
+Date: 23 NOV 1979 0416-EST
+From: RMS at MIT-AI (Richard M. Stallman)
+Subject: Reap File and Clean Directory
+To: INFO-EMACS at MIT-AI
+
+Giving a nonzero precomma argument to these
+will make them ignore the don't-reap bit.
+
+Date: 23 NOV 1979 0239-EST
+From: RMS at MIT-AI (Richard M. Stallman)
+Subject: Reap File and Clean Directory
+To: INFO-EMACS at MIT-AI
+
+These ITS-only functions will now never delete any file whose
+don't-reap bit is set.
+
+Date: 10 NOV 1979 0302-EST
+From: RMS at MIT-AI (Richard M. Stallman)
+Subject: EMACS 140
+To: INFO-EMACS at MIT-AI
+
+EMACS 140 now exists.
+C-X C-S does a real save now even in auto save mode.
+C-U C-X C-S is the way to ask for an "auto" save.
+C-M-X (^R Instant Extended Command) won't actually start
+ the command until you type a CR.  Before, it was unpredictable
+ whether a Space or Altmode would actually start the command.
+A library can now contain a macro & Kill <libname> Library to be
+ run when that library is killed (by Kill Libraries).
+
+Twenex users: if the system doesn't know a terminal type for
+ your terminal, you can use the Set Terminal Type command
+ to specify it to EMACS.
+
+
+RMS@AI  Here is what has changed in version 139 since version 135:
+* Tab Stop Definitions works differently now.
+The value of this variable is now just a string, not a buffer,
+so you can set it more easily in an init file or with a local modes list.
+Also, the two lines it is supposed to contain have been interchanged.
+This means that now it is the second line which can usually just be blank.
+When that happens, you are allowed to omit the CRLFs, which is an
+additional convenience in setting the variable.
+You can still set it with Edit Tab Stops.
+
+* C-X C-T now runs ^R Exchange Lines.
+
+* The variable Lisp ) Hack has been renamed to Display Matching Paren.
+It is now -1 by default.  Text and TECO modes turn it off locally, but
+you can have a Text Mode Hook or TECO Mode Hook to turn it back on if
+you like.  Whenever the feature is on, it will now apply automatically
+to all characters which have the syntax of ")" in ..D.  This uses the
+new FS ^R PAREN feature of TECO.
+
+* There is now a new standard way to get out of subsystems and
+recursive editing modes: the character C-].  All recursive editing
+modes (except minibuffers) will automatically support C-], and all
+subsystems ought to support C-].  For example, C-] while editing a
+message to send will exit and not send the message.  If there is some
+way to resume the command you aborted, C-] will tell you.  For
+example, after aborting a message, it will tell you how to resume
+editing it so that you do not lose what you had typed in.
+
+* The new Undo command will undo many sorts of gross changes to the
+buffer.  You do not have to give it immediately after the change
+occurs.  However, only the last gross change can be undone in this
+way.  Not all changes can be undone.  However, Undo always tells you
+what sort of change it plans to undo, and asks for confirmation.
+Also, Undo can be undone by a second Undo, so it is safe to try it out.
+
+* The C-X C-E command has been deleted.  To get auto-save to save as
+the visited filename, set QAuto Save Visited File nonzero and use
+C-X C-V.  A zero setting of QInhibit Write now means that C-X C-V
+was used.
+
+* Auto save can now be used when you are not visiting any file, but it
+will never be on by default at such times.  You must use M-X Auto Save
+to turn it on.  If you do C-X C-S when you are not visiting a file, it
+will ask you for filenames to save under.
+
+* Using Rubout or C-D with an argument now saves on the kill ring.
+
+* A CRLF will now appear to be a single character when you move over
+it with C-F or C-B.
+
+* M-K is now ^R Kill Sentence.  It kills the sentence containing
+point, or the one following point if point is between sentences.
+
+* C-M-X is now an alternative version of M-X which does not read any
+arguments for the command itself.  As soon as you terminate the
+command name the command is executed, and it reads its own arguments.
+This has the advantage that any special processing on these arguments
+(if they are command names or filenames) can take place.  It has two
+disadvantages: you can't rub out from the arguments back into the
+command name, and the command is not saved in the ring buffer of
+commands for access with C-X Altmode.
+
+* EVARS files are now better documented, and allow you to specify C-X
+subcommands and to include comment lines.
+
+* The mode line will no longer contain the name of the selected buffer
+when that is the same as the first filename of the file you are
+visiting.
+
+* When you ask for the documentation of a command, and it tells you
+about another command, it will tell you what that command is in your
+current environment, rather than what it is in the standard
+environment.  For example, when M-Q tells you about the ^R Set Fill
+Column command, it will normally say "C-X F", but if you move that
+command elsewhere it will say wherever it actually is.
+
+* The SORT library contains commands for sorting the region line by
+line, paragraph by paragraph, or page by page.
+The BCPL library implements BCPL mode.  The BLSLIB library implements
+BLISS mode.  Unfortunately, there is no documentation for either of
+those modes outside of their self-documentation.
+
+* The Apropos command will omit mention of subroutines if you give it
+a numeric argument.  Help A invokes it this way.  This is to avoid
+confusing new users with them.
+
+* ^R Just One Space is now available but not on any key by default.
+It is like the M-\ command but leaves one space (or how ever many the
+argument is).
+
+* The commands Make Local Q-register and Kill Local Q-register now
+allow you to make TECO FS flags local.  To make the flag FS CTLMTA
+local, just specify "FS CTLMTA" as the "q-register name" argument.
+
+* You can now set any variable conveniently with the Set Variable
+command, and put commands on characters conveniently with the Set Key
+command.
+
+* C-M-V with just a minus sign as argument scrolls the other window a
+full screen backwards.
+
+* M-X Revert File now asks for confirmation.
+
+* Commands M-X Delete File, M-X Copy File and M-X Rename File now
+exist for performing those operations.  They take one or two string
+arguments, as in M-X Copy File<from><to><cr>.  These should not be
+needed in TECO code since the ED, E_ and EN commands exist.
+
+Changed Names and Eliminated Commands
+
+* The commands ^R Set Column, ^R End Comment, ^R MM Via Mini and
+^R Mini Visited File have been flushed.
+
+* The commands Make Variable, Set Variable Comment, Make Dispatch
+String and Make Prefix Character now have "&" in front of their names.
+All commands names which used to start with "^^" now start with "&"
+instead.  & Macro Get Full Name is now called & Macro Name.
+
+* The command List One File has been flushed.  List Library can now be
+used to list the contents of libraries already loaded as well as
+libraries not loaded.  The command Variable Apropos has been flushed.
+The command List Variables now takes a string argument which is a
+substring to match on.  If the argument is null, all variables are
+listed.  Thus, List Variables can be used for either purpose.
+
+* The commands RMAIL and ^R RMAIL have been flushed in favor of the
+Read Mail command, which uses a variable to decide which library to
+use for reading the mail.
+
+* ^R Execute Completed MM Command has been renamed ^R Extended
+Command, but the old name has been kept around for the sake of
+libraries which refer to it.
+
+Date: 6 NOV 1979 0212-EST
+From: RMS at MIT-AI (Richard M. Stallman)
+To: INFO-EMACS at MIT-AI
+
+C-X C-S will be changed to do a real save always.
+C-U C-X C-S will explicitly request an auto save.
+
+KMP@MIT-MC 11/02/79 17:55:47
+To: INFO-EMACS at MIT-MC
+For those of you with VT100 terminals if you run in ANSII mode, the
+VT100 library, which you can get via
+
+   MM Load LibraryVT100
+
+will set up the keypad to do pretty reasonable things as follows:
+
+(1) Keypad digits and minus are args to the next command automatically.
+    [Normal digits in main key area are self-inserting still].
+
+(2) Comma will eventually be an arg separator for advanced commands that
+    take precomma args. I haven't coded this yet.
+
+(3) Dot runs ^R Documentation like ^_H or Top-H would normally do.
+
+(4) Arrows go vertically up, down, back and forth, independent of what
+    you define ^B,^F,^N,or ^P to do ...
+
+(5) PF1-4 run macros you can define. They are initially undefined.
+
+(6) Enter followed by a PF-key will read characters like the ^X(...^X) does
+    up until the next ^X), C-M-C, or Enter that you type. You can abort
+    a definition by doing ^].
+
+Sorry for the length of the message, but hopefully this will be of interest
+to enough of you to make it worthwhile.
+
+Interestingly enuf, this will not work on AI. No, I am not boycotting -- I
+just don't know what the new Emacs over there has done and I am nearly sure
+that my stuff is wholely incompatible at this point ... when the new emacs
+works its way back over to MC (which is happening slowly now), I will work
+on an all-ITS compatible version of the handler.
+
+-kmp
+
+
+Date: 2 NOV 1979 1752-EST
+From: rms at MIT-AI (Richard M. Stallman)
+Sent-by: SHIM0 at MIT-AI
+Subject: Tab Stop Definitions
+To: INFO-EMACS at MIT-AI
+
+The value of this variable is now just a string, not a buffer,
+so you can set it more easily in an init file or with a local modes list.
+Also, the two lines it is supposed to contain have been interchanged.
+This means that now it is the second line which can usually just be blank.
+When that happens, you are allowed to omit the CRLFs, which is an
+additional convenience in setting the variable.
+
+You can still set it with Edit Tab Stops.
+
+Date: 2 NOV 1979 0227-EST
+From: RMS at MIT-AI (Richard M. Stallman)
+Subject: Lisp ) Hack on by default in EMACS 139.
+To: INFO-EMACS at MIT-AI
+
+The variable Lisp ) Hack has been renamed to Display Matching Paren.
+It is now -1 by default.  Text and TECO modes turn it off locally, but
+you can have a Text Mode Hook or TECO Mode Hook to turn it back on if
+you like.  Whenever the feature is on, it will now apply automatically
+to all characters which have the syntax of ")" in ..D.  This uses the
+new FS ^R PAREN feature of TECO.
+
+Also, C-X C-T is now ^R Exchange Lines.
+
+Date: 11 OCT 1979 1841-EDT
+From: RMS at MIT-AI (Richard M. Stallman)
+Subject: FS TTY MAC$ and dumped EMACS environments
+To: INFO-EMACS at MIT-AI
+
+If you use FS TTY MAC$, make sure you put an impure string in it.
+Strings in libraries don't work, because FS TTY MAC$ is run
+at startup time before the libraries are loaded.
+
+Date: 3 OCT 1979 2349-EDT
+From: RMS at MIT-AI (Richard M. Stallman)
+To: INFO-EMACS at MIT-AI
+
+Ok, in the next version Auto Fill Mode, Atom Word Mode and
+Auto Save Mode and Overwrite Mode commands will toggle the modes.
+
+Date: 6 SEP 1979 1550-EDT
+From: BRIAN at MIT-AI (Brian C. Smith)
+Subject: Phrase macros
+To: INFO-EMACS at MIT-AI
+
+I have put a simple library of PHRASE macros (meant to be analogous to
+the word and sentence macros) onto EMACS;PHRASE :EJ on all ITS machines.
+Loading PHRASE gives you
+
+    ^R Forward Phrase  -- on Control-comma
+    ^R Backward Phrase -- on Meta-comma
+    ^R Mark Phrase     -- on Control-Meta-comma
+    ^R Delete Phrase   -- on Control-X comma
+
+A phrase is taken to be text plus the following punctuation.  They all do
+sensible things with arguments.  The search string defining a phrase
+boundary is kept in the user modifiable variable qPhrase Delimiters.
+See the auto-documentation.  Bugs to BRIAN@AI.
+
+Date: 25 JUN 1979 1628-EDT
+From: RMS at MIT-AI (Richard M. Stallman)
+To: INFO-EMACS at MIT-AI
+
+The change to save as a new version on Twenex has been approved.
+You will still be able to save as a fixed visited version
+if you use C-X C-W <cr>.
+Answers to the question are in EMACS;VERSIO ANSWER.
+
+Date: 23 JUN 1979 2352-EDT
+From: RMS at MIT-AI (Richard M. Stallman)
+To: INFO-EMACS at MIT-AI
+
+Tenex and Twenex people:
+would it be a good idea for C-X C-S and Save All Files
+to clobber the version number to 0 before saving?
+The effect of this is that if you visit a file specifying
+an explicit version number, then saving it will make a new
+version instead of rewriting the same version visited.
+
+Date: 19 JUN 1979 1511-EDT
+From: RICH at MIT-AI (Charles Rich)
+Subject: outline mode
+To: PGA at MIT-AI, INFO-E at MIT-AI
+CC: brian at MIT-ML
+
+Such a package has been evolving for a while.  The first version
+was written by Mitch Marcus.  I repackaged it as an EMACS
+library, and Brian Smith has been improving it since.  I have
+copied a middle-aged version to EMACS;OUTLIN :EJ and the source
+to EMACS1;OUTLIN > for those who want to try it out.  Get
+documentation by the usual method (MM apropos$outline).
+
+I am not currently working on this macro package, so please
+do not send any bug messages to me.  I would be quite happy
+to put this project up for adoption, but before you go
+charging off I recommend checking with Brian Smith.  I think
+his experimental version is superior in many ways to the
+one I have released.
+
+Yours in hacking,   Chuck Rich.
+
+pga@MIT-ML (Sent by GYRO@MIT-ML) 06/19/79 14:47:47
+To: info-emacs at MIT-MC
+COMSAT@MIT-ML 06/19/79 14:45:30 Re: Msg of 14:45:25
+To: GYRO at MIT-ML
+CC: MAIL-MAINTAINERS at MIT-ML
+WARNING - "INFO-EMACS" at MIT-ML is an unknown recipient.
+Your message is being returned:
+-------
+OUTLINES
+
+I) Has anyone considered (or is there hiding somewhere) an EMACS submode
+    for outline writing?  
+   A) It would know about  
+      1) Outline levels (I am on level I.A)
+      2) Entry numbers (I am on entry number I.A.1)
+   A) Commands might be:
+      1) Increment Outline Level
+         a) Sets outline down one level
+         b) Chooses the correct character string from the
+             heading string and sets the left margin so
+             auto-fill does the right thing
+      2) Decrement Outline Level
+         a) Sets outline up one level
+         b) As above
+      3) Start Outline Entry
+         a) Outputs the string which preceeds an entry, in
+             this case '       a) '
+         b) Invoked by tab?
+      4) Set Heading String, sets a variable which provides
+	  an appropriate string for each level.
+      5) Set Indent Increment, sets a variable which decides
+          how far to increment the indent on each change in
+          outline level
+      6) Insert New Entry, does a Start Outline Entry, but
+          relabels all the entries on the current level by
+	  incrementing them so that the new entry can be inserted.
+
+   B) That's the rough idea.  Any comments?
+^_
+
+
+
+Date: 10 MAY 1979 1917-EDT
+From: rms at MIT-AI (Richard M. Stallman)
+Sent-by: ___002 at MIT-AI
+To: INFO-EMACS at MIT-AI
+
+The change to incremental search echo area display
+has been unanimously approved.
+
+Date: 10 MAY 1979 0122-EDT
+From: RMS at MIT-AI (Richard M. Stallman)
+To: INFO-EMACS at MIT-AI
+
+Do you think it would be a good idea for incremental search
+to display its direction and status in the echo area only
+and leave the normal mode line in place?  Ie,
+EMACS  (Mode)  ...
+Failing I-Search: FOO
+
+Date: 12 APR 1979 0319-EST
+From: RMS at MIT-AI (Richard M. Stallman)
+Subject: EMACS 133 is NE on AI
+To: INFO-EMACS at MIT-AI
+
+This version is not going to be installed on ML, MC or DM.
+There are significant changes:
+*) The self documentation features now know about names for the
+built-in TECO ^R command definitions.  For example, Apropos of "Line"
+will now show ^R Open Line on C-O.  You can't actually call those
+commands by those names, unless you load the library BARE;  this
+library is temporarily loaded by the documentation commands that need
+it.  MM& Load BARE loads BARE and causes BARE to remain loaded until
+its caller returns.
+
+*) C-U C-Y differs from plain C-Y in that it leaves point before
+the un-killed text and the mark after.
+
+*) C-U C-L causes the line point is on to be redisplayed.
+Actual numeric arguments (not just C-U) still specify
+a line to display point on.
+
+*) C-; and M-; (^R Indent for Comment) now inserts the comment
+terminator as well as the comment starter, leaving point in between
+them.  M-N and M-P (^R Down Comment Line, and .. Up ..), have been
+modified for this behavior.
+
+*) M-G and M-Q (^R Fill Paragraph and ^R Fill Region) now by default
+remove excess spaces such as are produced by filling.
+
+*) Return now will not gobble a blank line followed by a nonblank
+line.
+
+*) C-K will now treat a blank line as if it were empty, killing
+through the CRLF instead of to it.  More specifically, if point is
+followed by a CRLF with only whitespace in between, C-K will kill
+through the CRLF.
+
+*) M-[ and M-] (^R Backward Paragraph, and ... Forward ...), now treat
+"\" at the front of a line just like "." and "-", for the sake of TEX
+files.  This special treatment is that if those characters are
+declared (using QParagraph Delimiter) to start paragraphs, then
+whenever a paragraph starts for that reason, that paragraph is only
+one line long.
+
+*) You can now put MM Query Replace on a character.  It will read its
+arguments in the echo area.
+
+*) Errors in auto-saving will type out "(Auto Save Error!)".
+
+*) ^R Indent Nested (the definition of Tab in certain modes) now does
+something useful with negative arguments.  It indents the line more
+than the previous line, (* (ABS ARGUMENT) (MAX 1 QIndent Increment))
+spaces more.  QIndent Increment is not initially defined.
+
+*) There is now an autoloading definition for C-X ( which loads in
+KBDMAC and transfers to it.  People need no longer load KBDMAC in
+their init files.  You will now see "Def" in the mode line while
+defining a keyboard macro.
+
+*) Exiting from the top-level ^R invocation now returns to EMACS's
+superior.  To exit from it back to TECO command level, do
+1MM Top Level.  This will advise you to re-enter ^R mode by doing
+:M..L.  Returning to the superior will now clear out the mode line
+completely.
+
+*) Creating a new buffer initializes it in the same mode as the
+previous selected buffer.  This uses the new @F^G command in TECO.
+
+*) Making variables like QAuto Fill Mode local now works
+straightforwardly;  it is no longer necessary to deal with the crock
+Switch Modes Process Options, which no longer exists.  These variables
+have been equipped with macros which are run whenever their values
+change.  Thus, simply doing 1UAuto Fill Mode is enough to turn on
+the mode.  MM & Process Options no longer exists.  A side effect of
+this is that buffer switching is much faster.  This uses the new
+FS VAR MACRO feature of TECO.  QProcess Options Hook no longer
+exists; instead, you must make macros to be run when your variables'
+values change.  This will be documented in CONV later.
+
+*) Instead of calling MM & Set Mode Line, macros should simply do
+1FS Mode Change, which will cause MM & Set Mode Line to be called
+when the mode line comes up for redisplay.  Thus, multiple reasons for
+calling it will not cause it to be called more than once.
+QSet Mode Line Hook still exists and works as before.
+
+Date: 2 APR 1979 2350-EST
+From: RMS at MIT-AI (Richard M. Stallman)
+To: INFO-EMACS at MIT-AI
+
+All three changes, to CR, C-K and M-Q, have been approved.
+Those of you who use C-K for getting rid of blanks should
+read about M-\.
+
+Date: 2 APR 1979 0443-EST
+From: RMS at MIT-AI (Richard M. Stallman)
+To: INFO-EMACS at MIT-AI
+
+Also, do you think that M-Q should by default flush excess spaces?
+This would be a little slower, and might sometimes do the wrong thing
+to double spaces at ends of sentences.
+
+Date: 2 APR 1979 0344-EST
+From: RMS at MIT-AI (Richard M. Stallman)
+To: INFO-EMACS at MIT-AI
+
+What do you think of these changes, suggested by EAK:
+1) C-K would not consider blanks when deciding whether
+it was at the end of a line.  In other words, C-K when point
+was followed by blanks and a CRLF would kill through thr CRLF.
+
+2) CR would not gobble up a blank line followed by a nonblank one.
+In other words, typing text with CR's at the end of a paragraph
+would not use up the blank line separating it from the next paragraph.
+
+I can imagine that 2) might bother people who on terminals without
+insert/delete line are used to inserting several lines of text by
+first making the lines with C-O and then filling in the text.
+Do people actually use that technique?
+
+Date:  5 Mar 1979 1514-PST
+From: Rubenstein at SUMEX-AIM
+Subject: Changes to PAGE library
+To:   info-emacs at AI
+
+The go to next and go to previous page commands have been moved to C-X ]
+and C-X [, respectively.  These commands were previously page handling
+commands but are now replaced by the commands from the page library.
+Also, if you like ^R String Search instead of the default Incremental
+Search, the PAGE library remembers that.  If you use some other search,
+or you put your search on a character other than C-S or M-S, then you
+will get a message saying that PAGE cannot find your search.  In that
+case, you must do M.M^R My Search$ M.VReal Search Macro$ for the PAGE
+search to work right.  Then you can put ^R PAGE search$ and ^R PAGE
+Reverse Search$ on whatever characters you want.
+
+Also, if ^R PAGE Search is given a precomma arg, it macros that
+instead of Q$Real Search Macro$.  Thus, other macros can use this
+facility to do things to the whole buffer, closing the bounds when finished.
+
+Comments, questions, etc. to Rubenstein @ Sumex-AIM
+-------
+
+Date:  1 Mar 1979 1430-PST
+From: Rubenstein at SUMEX-AIM
+Subject: New PAGE library
+To:   info-emacs at AI
+
+I've just finished a library of EMACS macros to handle pages in an
+intelligent manner (it turns out to be look very similar to the way E
+(SAIL's display editor) handles them).  The page number appears in the
+mode line, and commands are available to go to a specific page, go to
+next or previous page, insert pagemark, and Join pages.
+
+The file is AI:EMACS;PAGE :EJ, and documentation is in the INFO tree,
+Topic EMACS.Page handling (INFO;PAGE >)
+
+Bugs, comments -=> Rubenstein@Sumex or STEW@MIT-*
+-------
+
+JLK@MIT-MC 01/25/79 11:37:07
+To: INFO-EMACS at MIT-AI
+I have flushed the TEMACS macro library.  Instead there are now the libraries:
+SCRLIN - macros for moving over screen lines instead of text lines.
+         Automatically sets up ^A, ^E, ^N, ^P.  On non-display consoles,
+         these macros revert to text line movers.
+DELIM  - macros for moving over balanced pairs of []{}()<>"'.
+         Sets up C-[, C-], C-(, C-), etc. to move over pairs (forward or back).
+JLKMAC - Mostly defines setup hooks for JLK.
+
+Anybody currently using TEMACS probably wants to simply load SCRLIN or DELIM.
+Other people who wanted to try out screen line moving or delimiter moving,
+but didn't want to get screwed by JLK's hacks, now have a chance.
+
+
+Date: 15 DEC 1978 0309-EST
+From: RMS at MIT-AI (Richard M. Stallman)
+To: INFO-EMACS at MIT-AI
+
+I would like to flush ^R Make Insertion Command.
+Who uses it?
+It is not on any key in the default environment.
+
+Date: 10 DEC 1978 0019-EST
+From: MOON at MIT-AI (David A. Moon)
+Subject: DIRED 152 ([DIRE] 96) installed (ITS only)
+To: INFO-EMACS at MIT-AI
+
+A new version of DIRED has been installed.  The following changes exist:
+The $ command complements the don't-reap attribute of the file, which
+ displays as a $ to the left of the creation date.
+The X command now does what meta-X does in the default environment, use Q to exit.
+The Help key now gives information on Dired.
+Files whose FN1 begins with an underscore are considered temporary; this
+ applies to MM Clean and MM Reap also.
+The H command been's changed a bit; I think it still works.
+
+Date: 29 NOV 1978 2025-EST
+From: MOON at MIT-AI (David A. Moon)
+Subject: New NE exists
+To: INFO-EMACS at MIT-AI
+
+A new TS NE has been installed which contains changes relevant to
+users of ^R Character Search and ^R String Search (the default
+incremental search is not affected.)  The bugs in the ^F feature
+have been fixed, and Word Search (entered by ^W in String Search)
+has been introduced; try it.  Better ways to get into it are solicited.
+
+Date: 20 NOV 1978 0207-EST
+From: RMS at MIT-AI (Richard M. Stallman)
+To: INFO-EMACS at MIT-AI
+
+C-X 4 improved yet again:
+if you are already in two-window mode,
+it will go to the other window and select the buffer, file or tag.
+Also, C-X 4 never displays anything in the other window until
+you have finished saying what you want selected there.
+
+Date: 19 NOV 1978 0203-EST
+From: RMS at MIT-AI (Richard M. Stallman)
+To: INFO-EMACS at MIT-AI
+
+EMACS 129 is now NE.
+There is a new command ^X4 which enters two window mode
+and then lets you select a specific buffer, file or tag.
+Follow the ^X4 with B and a buffer name, F or ^F and a file name,
+or T or . and a tag name.
+
+Meta-' (^R Upcase Digit) now works on all keyboards.
+The first time you use it, it asks you to type the digits
+1, 2, ... 9, 0 holding down the shift key so it can tell
+what your keyboard looks like.  For then on it works automatically.
+If you don't recall, this command finds the last digit
+on the current or previous line and shifts the character.
+It is for when you forget to use the shift key.
+
+Date: 16 NOV 1978 2136-EST
+From: RMS at MIT-AI (Richard M. Stallman)
+To: INFO-EMACS at MIT-AI
+
+I find that the people who like the ^X2 change are
+those who usually use ^X^F, most of whom set Tags Find File to 1.
+The people who don't like the change are those who do not use
+^X^F, and they never set Tags Find File.  So I will make ^X2
+depend on Tags Find File.  However, if you don't use ^X^F,
+I recommend that you start.
+
+I will also put in a command that does ^X2 and ^X^F, some time.
+
+RWK@MIT-MC 11/16/78 12:04:03 Re: JLS's note re ^X2 vs. Slow terminal usage.
+To: INFO-EMACS at MIT-MC
+The SLOWLY library is shortly going to have exactly what JLS was looking for.
+I.e ^R Narrow Display which will take an argument to say how much of the
+screen to use.  A negative argument will mean to use the bottom of the screen
+instead of the top.
+
+Also, SLOWLY has ^R Slow Incremental Search, which uses a narrowed part of
+the screen for the search (say, a single line, or a couple lines) for it's
+redisplay of what's been found so far, and then displays the rest of the
+context when the search is exited.
+
+It will also have a version of & Minibuffer which uses the bottom or
+the top of the screen as you wish.  So you can use the top of your
+screen for editing, and the bottom part of your screen for minibuffers.
+
+Since I'm trying to get this stuff ready to go with the tapes RMS is going to
+take with him to the West Coast, I'm going to need volunteers to test this
+stuff thouroughly before then, on both ITS and TWENEX.  If you use slow
+terminals and would like to volenteer, send me a note; I should have it
+finished and documented sometime tonight.
+
+
+ECC@MIT-MC 11/16/78 04:19:20 Re: WORDAB library
+To: INFO-EMACS at MIT-MC
+A few bugs have been fixed (tab echoing, some bugs inhibiting proper upper-
+casing) and a small feature installed regarding upper-casing:
+
+If  you type an abbrev all in caps, e.g. "FOO", and it expands to more
+than one word, e.g. "find outer otter", then the default is the old
+action:  just capitalize each word, e.g. "Find Outer Otter".  However,
+if the variable WORDAB All Caps is non-zero, the entire expansion is
+upper-cased, e.g. "FIND OUTER OTTER", which may be much more convenient
+for those editing all-uppercase code for instance.
+
+Please let us know in the next couple of days if there are any bugs in
+the new fixes/feature as RMS wants to make a tape of working libraries
+for the outside world.
+
+
+Date: 14 NOV 1978 0037-EST
+From: RMS at MIT-AI (Richard M. Stallman)
+Subject: New KBDMAC features
+To: INFO-EMACS at MIT-AI
+
+A repeat count of zero means repeat forever (until an error).
+C-X) with a repeat count executes the macro that many times right away,
+ counting defining the macro as one time.
+C-X Q lets you define macros that work like Query Replace.
+All are documented in INFO under EMACS KBDMAC.
+
+Date: 10 NOV 1978 0119-EST
+From: RMS at MIT-AI (Richard M. Stallman)
+To: INFO-EMACS at MIT-AI
+
+When making a variable local its name must now be written in full.
+This change is a result of fixing a bug that made it impossible
+to create a variable whose name was an abbreviation of some
+other variable's name.
+
+Date: 6 NOV 1978 0341-EST
+From: RMS at MIT-AI (Richard M. Stallman)
+To: INFO-EMACS at MIT-AI
+
+It now works well to use the name of a machine instead
+of DSK: in source filenames in a tag table file.
+This is because the TECO feature that canonicalizes them,
+so that EMACS will realize that DSK:FOO;BAR > and
+AI:FOO;BAR > are the same file when you are on AI.
+
+Date: 6 NOV 1978 0339-EST
+From: RMS at MIT-AI (Richard M. Stallman)
+Subject: New in EMACS 127
+To: INFO-EMACS at MIT-AI
+
+1) ^X[ and ^X], new, move to the previous and next page boundary.
+^X^P will now always mark the page that point is in.
+
+2) Query Replace and Replace String, when Case Replace is set,
+will now preserve case only if the string to be replaced
+contains no upper-case letters.  Thus, you can use Query Replace
+to change something to lower case without turning off Case Replace.
+You can also use it to convert something to upper case, since
+the case-preservation works by upcasing only.  Anything you specify
+as upper case in the string to replace with will always go in
+as upper case.
+
+3) Meta-' is now ^R Upcase Digit, which finds the last 7, 8 or 9
+on the current line before point, or the previous line, and
+replaces it with a ', ( or ).
+
+4) ^Z and ^X^C, ^R Return to Superior, will now do an auto save
+first if auto saving is on.
+
+5) ^X Altmode, ^R Re-execute Minibuffer, will now print out
+the command that is to be re-executed and ask you for confirmation
+in the form of a Y or N.
+
+6) M-G and M-Q, which use ^R Fill Region, will now work better
+when a Fill Prefix has been established (with ^X.).
+
+7) It now works to set Underline Begin and Underline End
+to strings longer than one character.
+
+8) Visiting a file now calls the value of Visit File Hook
+if that value is nonzero.  The call is done after all the
+normal work of visiting.
+
+9) Local modes in a file can now include local ^R commands.
+Simply use, for example, .^RA instead of the variable name
+to bind control-A.
+
+Date: 6 NOV 1978 0240-EST
+From: RMS at MIT-AI (Richard M. Stallman)
+To: INFO-EMACS at MIT-AI
+
+EMACS in TECO 709 is now installed on all machines.
+All init files have been renamed.
+A new EMACS version (127) will appear as NE soon.
+
+Everyone, please do not make any changes to the EMACS
+sources for the next month without checking with me
+in advance.  A new distribution tape is being prepared.
+
+Date: 6 NOV 1978 0206-EST
+From: rms at MIT-AI (Richard M. Stallman)
+Sent-by: HIC at MIT-AI
+To: INFO-EMACS at MIT-AI
+
+With NE, the "right" name of the default init file is EMACS;* EMACS.
+EMACS;.EMACS (INIT) will continue to exist, but you should
+switch your init files over to referring to the file by the new name.
+
+Date: 3 NOV 1978 0840-EST
+From: RMS at MIT-AI (Richard M. Stallman)
+Subject: KBDMAC library
+To: INFO-EMACS at MIT-AI
+
+Use ^X( to start defining a keyboard macro, and ^X) to end the definition.
+^XE executes the last keyboard macro defined.  An argument serves
+as a repeat count.
+To save a keyboard macro for a longer time, use MM Name Kbd Macro.
+It takes as a string argument the name to use for an MM command to define
+to run the macro, and reads from the terminal a ^R command to define.
+Type Return or Rubout if you don't want to define a ^R command.
+Use a null string argument if you don't want to define an MM command
+(though you should always define one, even if your intended use is
+as via the ^R command).
+
+View Kbd Macro will print out the contents of a keyboard macro,
+reading the ^R command from the terminal.  You can give ^XE as
+the ^R command to view the last macro defined.
+
+^X commands can be used as the ^R commands to put macros on.
+However, you aren't allowed to clobber any already defined command
+this way, unless the definition is another keyboard macro or
+similar thing.
+
+Date: 1 NOV 1978 1706-EST
+From: RMS at MIT-AI (Richard M. Stallman)
+To: INFO-EMACS at MIT-AI
+
+FOR NE, LIBRARIES CALLED .EMACS :EJ SHOULD BE
+CHANGED OVER TO LIBRARIES WHICH GO UNDER THE SAME
+NAME AS INIT FILES.  THIS INVOLVES CHANGING THE
+& SETUP MACROS IN A SPECIFIC WAY DOCUMENTED
+IN EMACS;CONV >
+
+Date: 1 NOV 1978 0022-EDT
+From: RMS at MIT-AI (Richard M. Stallman)
+To: INFO-EMACS at MIT-AI
+
+NE now resides in TECO 708.  This means that you can use
+the library KBDMAC to get keyboard macros
+(your keystrokes are remembered and replayed).
+Also, the new init file scheme is installed,
+so your init file must be called <xuname> EMACS
+on your home directory.
+
+Date: 20 SEP 1978 1710-EDT
+From: EAK at MIT-AI (Earl A. Killian)
+Subject: new function in TAGS: MM Args
+To: INFO-EMACS at MIT-AI
+
+TAGS now contains MM Argstag which prints all the comments before tag.
+For assembly language programs this is usually a subroutine description
+giving the arguments and results.  Someone might want to hack it to
+know about LISP mode and print the argument list in addition to the comments.
+
+Date: 13 SEP 1978 0143-EDT
+From: RMS at MIT-AI (Richard M. Stallman)
+Subject: New command Compile for compiling your program.
+To: INFO-EMACS at MIT-AI
+
+MM Compile will compile the program you are editing.
+Unless given a numeric argument, it first offers to write
+out any files that have been changed.
+Then it compiled the visited file in whatever way is appropriate
+for the major mode you are in.  This method of compilation can
+be overridden by setting the variable Compile Command to a TECO
+command string to perform the compilation.  It can expect the
+name of the visited file to be in Q1 and in the default file names.
+Most compilation methods will involve valretting commands to DDT.
+They normally leave you in DDT so you can load up or test the program.
+
+A string argument to MM Compile is stuck into the compilation command
+so as to be useful for specifying extra switches or an output file.
+Thus, in a MIDAS program, MM Compile/T would give MIDAS the /T
+switch, and MM CompileFOO;_ would put FOO;_ at the front of the
+command string, thus putting the binary on FOO;.  User-supplied
+compilation methods can't be vouched for, but ought to try to do this.
+
+MM Compile is available only in NE, as yet.
+It will not self-document properly until the next EMACS version.
+
+Date: 13 SEP 1978 0059-EDT
+From: RMS at MIT-AI (Richard M. Stallman)
+To: INFO-EMACS at MIT-AI
+
+1) You can now have local character redefintions in files.
+They look almost like ordinary local modes,
+except that you use the name of tha character (such as, "...^RD")
+as the variable name, and some TECO code to come up with the 
+value instead of a literal string.  For example, this
+;Local Modes:
+;Mode:MIDAS
+;...D: M.M ^R Down List
+;End:
+willset up a mode like MIDAS mode except that C-M-D retains
+its normal definition instead of MIDAS mode's redefinition
+(This mode is good for editing Lisp machine microcode).
+
+2) Dump Environment has been greatly improved by EAK.
+The documentation in CONV has not been updated yet, but
+its self-documentation is informative.
+
+3) Compile One Macro has been renamed TCompile.
+
+Date: 2 SEP 1978 2140-EDT
+From: MOON at MIT-AI (David A. Moon)
+Subject: Changes to ^V, string-search
+To: INFO-EMACS at MIT-AI
+
+In the next Emacs, the following changes will exist.
+
+If you define the variable Next Screen Context Lines, it will be the
+number of lines of overlap used by c-V (^R Next Screen) and m-V (^R
+Previous Screen).  The default remains 2.
+
+In Character Search and String Search (note that these are different
+from the default search, Incremental Search), the ^F feature now
+will put the cursor Next Screen Context Lines down from the top
+instead of at the very top.  If you don't like this, complain
+and I'll flush it.
+
+String Search now obeys its numeric argument (a long-standing bug fix).
+
+String Search has two new features inspired by Multics Emacs.  Typing
+^Y will yank in the default without flushing what you've already typed.
+Compare this with ^D.  Typing ^W will put you in word-search mode, in
+which the words you type will be found regardless of what punctuation
+and white-space characters lie between them.  meta-F's definition of
+"word" is used, thus Atom Word Mode applies, but in Text Mode punctuation
+is considered part of the adjacent word.  Currently word-search
+only finds exact matches, (e.g. searching for "to and fro" doesn't find
+"grotto and frobs").  If anyone thinks it should be the other way, I can
+change it.
+
+Date: 26 AUG 1978 1952-EDT
+From: RMS at MIT-AI (Richard M. Stallman)
+Subject: New NE
+To: INFO-EMACS at MIT-AI
+
+There is a new NE with these changes:
+
+1) The word case-conversion commands do not move the cursor
+when given a negative argument.
+
+2) C-M-V scrolls the other window, just like C-V.
+No argument scrolls a full screen;  an argument is the number of lines
+to scroll by.
+
+3) C-X 2 the first time gives you the same buffer in both windows,
+instead of creating a buffer named W2.
+
+4) M-X now no longer echoes if you type everything ahead.
+
+Date: 23 AUG 1978 0249-EDT
+From: RMS at MIT-AI (Richard M. Stallman)
+To: INFO-EMACS at MIT-AI
+
+Often, people want to specify the exact name of a tag
+instead of just a part of the name, because they know
+there will be ambiguity.
+
+I am thinking of arranging to have a character which
+would mean the beginning or end of the tag name
+when typed in the argument to Meta-..
+It would probably be impossible to use that character
+itself in a tag.  Do you like this idea?
+What character would you like?
+
+Date: 18 Aug 1978 1120-EDT
+From: CICCARELLI at BBN-TENEXD (Eugene Ciccarelli)
+Subject: Auto Save Mode
+To:   INFO-EMACS at AI
+
+    Earl Killian and I are designing a new Auto Save Mode (probably to be
+put in the TMACS library).  Anyone interested (e.g. uses my version in the
+CSRLIB library, is dissatisfied with other Auto Save modes, or is just a
+hacker) is invited to read and comment on the design ideas, which are in
+the following files:
+
+MC: ECC; AUTOSA IDEAS
+[BBND]<Ciccarelli>Auto-Save.Ideas.0
+[BBNE]<EKillian>Auto-Save.Ideas;0
+
+    Or, if accessing one of these files is impossible/inconvenient, I can
+mail a copy to anyone requesting.
+
+    Comments or suggestions about these ideas can be mailed to ECC@MC,
+EAK@MC, Ciccarelli@BBND, or EKillian@BBNE.
+
+ - Gene Ciccarelli
+-------
+
+Date: 9 AUG 1978 0306-EDT
+From: ECC at MIT-MC (Eugene C. Ciccarelli)
+Subject: New Word Abbrev Mode ^R Command
+To: INFO-EMACS at MIT-AI
+CC: Ciccarelli at BBN-TENEXD
+
+    The WORDAB and XWORDA libraries now have a new command, which was
+suggested by KMP: ^R Inverse Add Mode Word Abbrev, which is put on ^X -
+(previously unused in the default EMACS environment).  I think people will
+find this a very useful command to complement ^X^A.
+
+    This command has an opposite sense from ^X^A (^R Add Mode Word
+Abbrev), namely: you define an expansion for the word before point.  (For
+instance: you thought you had an abbrev "foo", but "foo" didn't expand.
+So you type ^X -, "Find Outer Otter", return, and thus define the abbrev
+"foo".)  You can give ^X - a numeric argument, which means the abbrev to
+be defined is n words back.  ^X - will end by expanding the abbrev.
+
+
+Date: 31 JUL 1978 2141-EDT
+From: RMS at MIT-AI (Richard M. Stallman)
+To: INFO-EMACS at MIT-AI
+
+The library NCASE contains the experimental word case conversion
+commands, and puts them on M-L, M-C, and M-U unless
+you supply an NCASE Setup Hook.
+They apply to the previous word when the last character typed
+was not control, meta, or altmode.
+In addition, when given in the middle of a word, they apply
+to the whole word.
+Please take the trouble to try them out.  If you try them
+long enough to get used to them, I'll be interested in hearing
+how each of those two changes affects their convenience of use.
+
+Date: 31 JUL 1978 2017-EDT
+From: RMS at MIT-AI (Richard M. Stallman)
+Subject: Answering questions about changing EMACS.
+To: INFO-EMACS at MIT-AI
+
+When I ask for people's opinions on a possible change to EMACS,
+I don't just want to get a "yes" or a "no".  Such answers don't
+really help me.  I don't regard the answers as votes, and I don't
+just count the "yes" and "no" answers.  What I am looking for
+by asking these questions is an idea of which segments of the
+user community will be helped and which will be hurt.  I want
+to know what it is about a user that determines what his
+opinion will be.  For this, I need more information in answers.
+
+In addition, a lot of people just say "Don't change it.  I don't
+think anything should ever be changed".  Such a statement does
+not address the question I have asked, which is whether the changed
+command would be better than the existing one.  Since I have already
+decided that it is better to make improvements than never change
+anything, such statements are wasted breath.
+
+Some replies to my latest question (about case-conversion commands)
+which did supply some information are those which say "Don't change them.
+Typing M-B is easy enough".  These replies generally come from
+people who use Meta-keyboards, and it is logical that they should
+have that opinion.  A few came from people whose keyboard usage
+I do not know, but would like to find out, since how easy
+people on non-Meta keyboards regard the typing of M-B is
+clearly the center of the issue.
+
+I will probably make the changed case commands available
+in a library for people to try out.
+
+Date: 25 JUL 1978 0016-EDT
+From: RWK at MIT-MC (Robert W. Kerns)
+Subject: Incremental search and redisplay
+To: INFO-300 at MIT-MC
+CC: INFO-EMACS at MIT-MC
+
+The SLOWLY library is a library (maintained by me, more or less) for
+slow terminals.  Currently it contains just one feature, a version of
+^R Incremental Search and ^R Reverse Search which limit re-display while
+searching to a fixed number of lines at the top of the screen.  The default
+is to use only one line, but it may be changed by giving Q$Slow Search Lines Used$ a value other than 1 (use M.V to create it).
+
+If MM Load Library$SLOWLY$$ is used to load this library, it will
+put these macros on ^S and ^R IFF your OSPEED is unknown or slower than
+1200.
+
+For more info, see me.  If you have any other ideas, I might be willing to
+implement them, so send them too...
+
+
+Date: 15 JUL 1978 0358-EDT
+From: RMS at MIT-AI (Richard M. Stallman)
+To: INFO-EMACS at MIT-AI
+
+EMACS 125 is now NE on all ITS machines.
+The only visible differences are:
+ C-= and C-X = now run a different command which
+  prints, not just the hpos, but the vpos, the
+  octal code for the next character, point both
+  absolutely and as a percentage of the total size,
+  and the virtual buffer boundaries if any.
+ C-T at the end of a line with no argument will
+  exchange the previous two characters.
+
+Date: 13 JUL 1978 2224-EDT
+From: RMS at MIT-AI (Richard M. Stallman)
+To: INFO-EMACS at MIT-AI
+
+.EMACS (INIT) files which are libraries work fine in EMACS 124.
+These libraries MUST have & Setup .EMACS Library commands in them.
+Full details are in EMACS;CONV > and are accessible through INFO.
+
+Date: 12 JUL 1978 0000-EDT
+From: RMS at MIT-AI (Richard M. Stallman)
+To: INFO-EMACS at MIT-AI
+
+The default EMACS init file wil now set Inhibit Write from
+Find File Inhibit Write, and if a file is visited under JCL control
+that too will use Find File Inhibit Write.
+
+Date: 6 JUL 1978 0445-EDT
+From: RMS at MIT-AI (Richard M. Stallman)
+To: INFO-EMACS at MIT-AI
+
+NE has become E on all ITS systems.
+An additional new feature, for printing terminals,
+is that Help M prints what on a display would be in the mode line.
+
+Date: 3 JUL 1978 0440-EDT
+From: RMS at MIT-AI (Richard M. Stallman)
+Subject: .EMACS (INIT) files which are :EJable libraries
+To: INFO-EMACS at MIT-AI
+
+These files will have to do all the initialization
+themselves, so their & Setup macros will have to
+load in and jump to the default init file.
+In addition, the feature may require some tweaking
+to get working right, for which I would appreciate the
+help of someone who has such an init library, since I don't.
+
+Date: 3 JUL 1978 0138-EDT
+From: RMS at MIT-AI (Richard M. Stallman)
+To: INFO-EMACS at MIT-AI
+
+EMACS 124 is now NE on AI.
+
+Tabular Text Mode and Indented Text Mode are now gone as
+major modes.  Instead, there are Edit tabular Text and
+Edit Indented Text, which are commands that call ^R
+recursively with the appropriate things rebound.
+They are the first examples of "submodes", which are
+commands that call ^R recursively on the buffer
+with auto-saving still turned on.  When you are inside
+a submode, the name of the submode appears inside square-brackets
+after the name of the major mode.
+
+A few commands concerning q-registers, which were not in the default
+enviroment but used by TECMAC, have been deleted.
+
+The library purifier now no longer converts uparrow-L to
+a control-L.  You were already told to change the uparrow-L's
+to control-L's, with preceding ^]^Q's when they were at the
+beginnings of lines.
+
+*** If you have a start-up library instead of just an init file,
+you can now call that library the same thing you would call the
+init file.  EMACS can tell what kind of file it is.
+Soon, EMACS will stop looking for .EMACS :EJ.
+
+Please wait for me to move this version off of AI.
+
+ECC@MIT-MC 07/01/78 20:48:32 Re: Word Abbrev Mode
+To: INFO-EMACS at MIT-MC
+When defining an abbrev for the last N words, ^X ^A (^R Add Mode Word
+Abbrev) now works slightly differently (better, I think -- a good
+suggestion by KMP):  the abbrev's expansion includes only up to the end of
+the last word -- and not any break characters following it (but preceding
+point).  This lets you not worry about whether you've typed a space or
+something after the word you want to abbreviate.
+
+For the times when you want to include break characters before or
+following a string of words, you can give ^X^A an argument of 0, telling
+it to use the region.  (This is as it always was.)
+
+
+JLK@MIT-MC 06/30/78 11:16:30
+To: info-emacs at MIT-AI
+People that have init files which check FS LISPT"N to see if they should
+load LISPT, should check FS %OPLSP "N and the XJNAME of the job instead.
+
+Date: 29 JUN 1978 1124-EDT
+From: rich at MIT-AI (Charles Rich)
+Sent-by: HES at MIT-AI
+Subject: New E
+To: INFO-E at MIT-AI
+
+If you have an .EMACS :EJ file make sure
+that the setup macro is called
+
+& Setup .EMACS Library
+
+The word Library is compulsory in the new
+emacs, and it was not necessary in the old
+version.
+
+Many people have been losing on this.
+
+Date: 28 JUN 1978 1642-EDT
+From: RMS at MIT-AI (Richard M. Stallman)
+To: INFO-EMACS at MIT-AI
+
+I would like to make ^R Execute Completed MM Command
+available from non-^R subsystems such as RMAIL, INFO, Backtrace, etc.
+Since Meta-prefixes aren't available, M-X can't be the way to get it.
+It has to be put on an ASCII character.
+Does anyone have a suggestion for what character to use?
+The one that makes sense to use is "X", but it has the problem
+of meaning "eXit" already.  Since "Q" also means exit, it would
+be possible to reuse "X".  Does that sound like a good idea?
+
+Date: 28 JUN 1978 1635-EDT
+From: RMS at MIT-AI (Richard M. Stallman)
+To: INFO-EMACS at MIT-AI
+
+EMACS 123 is now installed as E.
+
+ECC@MIT-MC 06/26/78 03:01:09 Re: Word Abbrev Mode
+To: INFO-EMACS at MIT-MC
+NWORDA and XWORDA versions of Word Abbrev Mode (only runnable in NE) are
+allow much faster buffer- and mode-switching now.  Also, there is a
+new, special kind of abbrev expander for Tab which should help LISP and
+TECO users who have had trouble:  it won't expand if Tab is not inserting
+space at point.
+
+Did anyone use the $Untouched by Word Abbrev$ or $Word Abbrev Hook$
+variables?  If so, please contact me.
+
+
+ 


### PR DESCRIPTION
In ^R Mode Documentation, the "N" command attempts to print out emacs news, which is expected to live in emacs;emacs news.  This file doesn't exist in our DB/KA/KL builds.