### PR TITLE
Fix doc link to midas.26

### DIFF
--- a/doc/NITS.md
+++ b/doc/NITS.md
@@ -6,7 +6,7 @@ Note: `XX` means the name of the ITS you are building.
 
 0. Here are manuals for all programs mentioned below:
 
-   - [MIDAS](info/midas.25)
+   - [MIDAS](info/midas.26)
    - [SALV](kshack/nsalv.order)
    - [DSKDMP](sysdoc/dskdmp.order)
    - [DDT](_info_/ddtord.1462)

--- a/doc/README.md
+++ b/doc/README.md
@@ -19,7 +19,7 @@
 
 ### Programming
 
-- MIDAS: [manual](info/midas.25)
+- MIDAS: [manual](info/midas.26)
 - PDP-10: [instructions](info/pdp-10.15)
 - LISP: [manual](info/lisp.15), [compiler](info/lispc.6)
 - TECO: [primer](_teco_/teco.primer), [manual](info/tecman.20),


### PR DESCRIPTION
Previously pointing to midas.25, which doesn't exist in the repo.