### PR TITLE
Make 340 display optional

### DIFF
--- a/build/pdp10-ka/start
+++ b/build/pdp10-ka/start
@@ -38,7 +38,24 @@ type340() {
     cp build/pdp10-ka/run out/pdp10-ka/run
 }
 
+help() {
+    cat <<EOF
+This start script takes several command line arguments:
+
+help - Display this help text.
+type340 - Enable the Type 340 display.
+gt40 - Start a GT40 emulator.
+tv11 - Start a TV-11 emulator.
+tvcon - Start a TV display.
+
+EOF
+
+    touch out/pdp10-ka/nohelp
+}
+
 sed 's/set dpy enabled/set dpy disabled/' < build/pdp10-ka/run > out/pdp10-ka/run
+
+test -f out/pdp10-ka/nohelp || help
 
 while test -n "$1"; do
     "$1"

--- a/build/pdp10-ka/start
+++ b/build/pdp10-ka/start
@@ -34,10 +34,16 @@ tvcon() {
     started "TV-console" "$!"
 }
 
+type340() {
+    cp build/pdp10-ka/run out/pdp10-ka/run
+}
+
+sed 's/set dpy enabled/set dpy disabled/' < build/pdp10-ka/run > out/pdp10-ka/run
+
 while test -n "$1"; do
     "$1"
     shift
 done
 
-tools/sims/BIN/pdp10-ka build/pdp10-ka/run
+tools/sims/BIN/pdp10-ka out/pdp10-ka/run
 exit 0


### PR DESCRIPTION
When built with the SDL library, the current use of the KA10 simulator will always open a window 340 display.

I think it would be better for users to explicitly say if they want the 340.  For example, `./start 340`.
