### PR TITLE
Added equivalents for Unix echo and shell comments to doc/DDT.md

### DIFF
--- a/doc/DDT.md
+++ b/doc/DDT.md
@@ -43,3 +43,5 @@ The ◊ character represents typing <kbd>ESC</kbd>, or holding down the
 | man 2 open    |                      | :call open               |
 | dmesg         |                      | :sysmsg                  |
 | uptime        |                      | :time                    |
+| echo "Hello World!" | | <kbd>^W</kbd>:◊<kbd>^V</kbd>Hello World! <kbd>^W</kbd>◊<kbd>^V</kbd> *(in an xfile)* |
+| \#Comment     |       | <kbd>^W</kbd>:◊Comment◊<kbd>^V</kbd> *(in an xfile)* |


### PR DESCRIPTION
I've added DDT comments to the DDT cheat sheet as an equivalent to the Unix "echo" command and Unix shell comments. I've not submitted many pull requests in the past, please comment on whether I've done everything correctly procedurally.