### PR TITLE
Update terminal emulators

### DIFF
--- a/build/pdp10-ka/start
+++ b/build/pdp10-ka/start
@@ -39,17 +39,17 @@ type340() {
 }
 
 datapoint() {
-    (sleep 2; tools/vt05/dp3300 -B telnet localhost 10020 >datapoint.log 2>&1) &
+    (sleep 2; tools/vt05/dp3300 -a -B -b 4800 telnet localhost 10020 >datapoint.log 2>&1) &
     started "Datapoint" "$!"
 }
 
 vt52() {
-    (sleep 2; tools/vt05/vt52 -B telnet localhost 10018 >vt52.log 2>&1) &
+    (sleep 2; tools/vt05/vt52 -B -b 9600 telnet localhost 10018 >vt52.log 2>&1) &
     started "VT52" "$!"
 }
 
 tek() {
-    (sleep 2; tools/tek4010/tek4010 telnet localhost 10017 >tek.log 2>&1) &
+    (sleep 2; tools/tek4010/tek4010 -b9600 telnet localhost 10017 >tek.log 2>&1) &
     started "Tektronix" "$!"
 }
 


### PR DESCRIPTION
Update the vt05 submodule to bring in the latest updates: improved Alt modifier, baudrate, arrow characters.

Use the -b feature to improve baudrate accuracy.  The SIMH baudrate limit is subject to bursts due to network buffering.