### PR TITLE
Update CirrusCI image to FreeBSD 12.1.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -6,7 +6,7 @@ env:
 
 task:
   freebsd_instance:
-    image: freebsd-12-0-release-amd64
+    image: freebsd-12-1-release-amd64
   env:
     matrix:
       - EMULATOR: simh


### PR DESCRIPTION
Fixes problem building on CirrusCI.