### PR TITLE
Fixes for MAZE

### DIFF
--- a/doc/games.md
+++ b/doc/games.md
@@ -34,9 +34,15 @@ board on a Type 340 display.  Type
 <code>FANCY<kbd>TAB</kbd>2<kbd>Enter</kbd></code> to get the fanc
 chess board.
 
-### Maze War
+### Maze
 
-First multi-user first person shooter.  Type `:games;maze` to play.
+First multi-user first person shooter.  When logged in on an Imlac,
+type `:games;maze c` to play.  The `c` is necessary to avoid
+restrictions on when the game can be played.  Use `r` to start a robot
+player.
+
+Game controls are: Arrow keys to move around, ESC to fire, and TAB to
+see the overhead view.  ^Z exits back to ITS.
 
 ### MAZLIB
 

--- a/src/imsrc/maze.3
+++ b/src/imsrc/maze.3
@@ -2524,7 +2524,8 @@ ININFO:	0			; input information from 10 buffer
 
 	CONSTANTS
 
-;loc 14000		;happens about here anyway, just needs precision.
+;       constants and WALLS must be below 14000
+IFGE .-14000, .ERR Code overflows 2k boundary.
 
 ;
 ;	distances to walls table

--- a/src/imsrc/maze.3
+++ b/src/imsrc/maze.3
@@ -280,25 +280,6 @@ MAZE:	177777 ? 106401 ? 124675 ? 121205 ? 132055 ? 122741 ? 106415 ? 124161
 	124405 ? 166575 ? 122005 ? 107735 ? 120001 ? 135575 ? 105005 ? 125365
 	125225 ? 121265 ? 105005 ? 135375 ? 100201 ? 135675 ? 110041 ? 177777
 
-
-; here to wait for the loader signal
-
-LOADER:	RSF
-	 JMP .-1
-	CLA
-	RRC
-	AND [177]
-	SAM [^A]
-	 JMP LOADER
-	RSF
-	 JMP .-1
-	CLA
-	RRC
-	AND [177]
-	SAM [^A]
-	 JMP LOADER
-	JMP @[40]
-
 ;	dstat, dx, dy, dir	is my position and point into info table
 
 DSTAT:	0			; status flag
@@ -3495,4 +3476,4 @@ DLIST:	DHLT
 ;
 ;	return to console program after loading
 ;
-	END LOADER
+	END 101'


### PR DESCRIPTION
The LOADER subroutine breaks MAZE because it pushes all code higher, making constants and WALLS cross over 14000 making them inaccessible to the lower 2K.  It's also unnecessary since setting the start address to 101 jumps back to SSV which will accept the next data block sent from the PDP-10.

A possible explanation is that LOADER was added by someone running MAZE without SSV.  No other version of the MAZE source code has LOADER.

I removed LOADER and added a check to ensure the lower part fits in 2K.