### PR TITLE
Don't make final full dump when building for KA10 on Cirrus CI.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -12,6 +12,7 @@ task:
       - EMULATOR: simh
       - EMULATOR: klh10
       - EMULATOR: pdp10-ka
+        NODUMP: true
       # EMULATOR: pdp10-kl
   install_script: sh -ex build/dependencies.sh install_freebsd
   script: gmake its EMULATOR=$EMULATOR

--- a/build/build.tcl
+++ b/build/build.tcl
@@ -29,6 +29,9 @@ if {![info exists env(MACSYMA)]} {
     set env(MACSYMA) "yes"
 }
 
+# If the NODUMP environment variable is set, don't do the final full
+# dump.
+
 proc cleanup {} {
     global spawn_id
     close -i $spawn_id
@@ -193,19 +196,20 @@ respond "*" ":copy sys; ts ddt, dsk0: backup;\r"
 respond "*" ":copy sys; ts dump, dsk0: backup;\r"
 respond "*" ":copy sys; ts midas, dsk0: backup;\r"
 
-# make output.tape
-
-respond "*" $emulator_escape
-create_tape "$out/output.tape"
-type ":dump\r"
-respond "_" "dump links full list\r"
-respond "LIST DEV =" "tty\r"
-respond "TAPE NO=" "1\r"
-expect -timeout 6000 "REEL"
-respond "_" "rewind\r"
-respond "_" "icheck\r"
-expect -timeout 6000 "_"
-type "quit\r"
+if {![info exists env(NODUMP)]} {
+    # make output.tape
+    respond "*" $emulator_escape
+    create_tape "$out/output.tape"
+    type ":dump\r"
+    respond "_" "dump links full list\r"
+    respond "LIST DEV =" "tty\r"
+    respond "TAPE NO=" "1\r"
+    expect -timeout 6000 "REEL"
+    respond "_" "rewind\r"
+    respond "_" "icheck\r"
+    expect -timeout 6000 "_"
+    type "quit\r"
+}
 
 shutdown
 quit_emulator


### PR DESCRIPTION
The Cirrus CI KA10 build often times out.  Skipping the final full dump is a workaround for this.