### PR TITLE
Shorten tvbrot's iter loop

### DIFF
--- a/src/lars/tvbrot.209
+++ b/src/lars/tvbrot.209
@@ -123,19 +123,20 @@ xloop:
 	move i,y
 	movei t,maxiter
 
+; This loop would fit in the KA registers, given r/i/a/t as regs 0-3.
 iter:	move a,i
 	fmpr a,a
 	fmpr i,r
 	fsc i,1
 	fmpr r,r
-	move b,r
 	fsbr r,a
-	fadr b,a
-	fsbri b,(4.0)
-	jumpge b,out
+	fsc a,1
+	fadr a,r
 	fadr r,x
 	fadr i,y
+	camge a,[203400,,]		;a (which must be positive) >= 4.0?
 	sojg t,iter
+	jumpn t,out			;Loc 20 - did we exceed iter?
 
 	xct dot				;Draw a dot.
 	setom dots			;At least one dot on this line.


### PR DESCRIPTION
The code is now short enough to run from the registers, which would give a speed improvement on a real KA.

(Since we don't have a real KA, it doesn't actually do so yet, but it should be a little faster in emulation anyway...)