### PR TITLE
UTNAM

### DIFF
--- a/build/misc.tcl
+++ b/build/misc.tcl
@@ -72,6 +72,10 @@ expect ":KILL"
 respond "*" ":midas;324 dsk0:.;@ mark_syseng; mark\r"
 expect ":KILL"
 
+# utnam
+respond "*" ":midas sys3; ts utnam_lars; utnam\r"
+expect ":KILL"
+
 respond "*" ":midas sys3;ts syslod_sysen1;syslod\r"
 expect ":KILL"
 

--- a/doc/programs.md
+++ b/doc/programs.md
@@ -369,6 +369,7 @@
 - UPTINI, program to create new UPTIME DATA.
 - URUG, GT40 debugger.
 - USQ/TYPESQ, unsqueeze/uncram or type a file.
+- UTNAM, set DECtape name.
 - VERSA/SPOOLR, Versatec/Gould printer spooler.
 - VDIR, view directory.
 - VIEW, view file.

--- a/src/lars/utnam.20
+++ b/src/lars/utnam.20
@@ -1,0 +1,29 @@
+	title utnam - set microtape name
+
+a=1
+b=2
+c=3
+d=4
+
+go:	movei a,0
+	.break 12,[..rjcl,,jcl]		;get jcl
+	move b,[440700,,jcl]
+	move c,[440600,,a]
+repeat 3,[				;convert three characters
+	ildb d,b			;from ascii to sixbit
+	cail d,140
+	 subi d,40
+	subi d,40
+	idpb d,c
+]
+	.break 12,[..rpfi,,def]		;get ddt :print defaults
+	hlr a,def			;get device
+	trz a,777770			;mask to unit number
+	.utnam a,
+	 .lose %lssys
+	.logout 1,
+
+def:	block 4
+jcl:	block 100
+
+end go


### PR DESCRIPTION
As far as I can see, the only way to set the name of a DECtape is from TECO no later than version 508.  No other program call the .UTNAM UUO.

I propose a new program called UTNAM to do this.  Take the name, three characters, from the JCL.  How to specify the tape unit?