### PR TITLE
Optionally hide Zork source code

### DIFF
--- a/src/lcf/hide.zork
+++ b/src/lcf/hide.zork
@@ -1,0 +1,3 @@
+:This is a DDT xfile to patch ITS to hide the Zork files in LCF.
+:It mimics the effect of binary patches found in a 1980 DM ITS.
+patch/move q,udname(j)camn q,.+4jrst .+4qlook+3/î1qjrst qlook+31'lcfhrrz q,umove q,uname(q)came q,.+7camn q,.+7jrst .-7came q,.+6camn q,.+6jrst .-12jrst popjjîqlook+3/jrst patchîpatch+23 patch:î


### PR DESCRIPTION
Add binary patch as described in #850.

Move Zork sources to LCF or CFS.
EDIT: They moved to LCF, see #1933.