### PR TITLE
Document some removed UUOs.

### DIFF
--- a/doc/sysdoc/uuos.113
+++ b/doc/sysdoc/uuos.113
@@ -164,17 +164,25 @@ are described in more detail in the file .INFO.;ITS .CALLS.
 	The symbolic call RFPNTR may be used to read the current
 	access pointer for a file.
 
-.ARMOFF
+.ARMOFF					turn AMF arm off
 
-This uuo was for hacking the AMF arm.  The arm no longer exists.
+Turn the ARM arm off.  The arm no longer exists.
 
-.ARMOVE
-
-This uuo was for hacking the AMF arm.  The arm no longer exists.
+.ARMOVE ac,				move AMF arm
+	;normal return
+	;test successful return
+		
+        This system call allows one job at at time to exercise
+        special control over several D/A multiplexor channels.
+        It provides acceleration and velicoty limiting, software
+        limit stops, and conversion from joint number to multiplexor
+        channel.  The accumulator <ac> should contain -<length>,,<addr>
+        pointing to a block of words, each specifying a command.
+        If any test command is true, the .ARMOVE will skip.
 
-.ARMRS
+.ARMRS					reset AMF arm lock flags
 
-This uuo was for hacking the AMF arm.  The arm no longer exists.
+Reset the AMF arm lock flags.  The arm no longer exists.
 
 .ASSIGN ac,				assign a microtape
 	;skip if successful
@@ -1404,6 +1412,22 @@ This uuo was for hacking the AMF arm.  The arm no longer exists.
 	Needless use of it is considered to be antisocial, and may
 	be grounds for harassment.
 
+.MSPACE ac,		ANCIENT HISTORY hack magtape unit 0
+	;skip if successful
+
+	This uuo NO LONGER EXISTS.
+	It is documented here for historical purposes only.
+	Its function has been superseded by .MTAPE.
+	Its opcode has been recycled as .DWORD.
+
+	Accumulator <ac> should have a function code.
+	The job should have device MT0 open.
+	Valid function codes are:
+	0	Rewind tape.
+	1	Space to end-of-tape.
+	2	Write end-of-file.
+	17	Hang until interrupt routine dies.
+
 .MTAPE ac,				hack magtape
 	;skip if successful
 
@@ -1614,6 +1638,25 @@ This uuo was for hacking the AMF arm.  The arm no longer exists.
 	.OPER 110	.GENNUM
 	.OPER 111	.NETINT
 
+.ORGI ac,		ANCIENT HISTORY read organ keboard
+
+	This uuo NO LONGER EXISTS.
+	It is documented here for historical purposes only.
+	Its function is obsolete.
+	Its opcode has been recycled as .PDTIME.
+
+	Read input from an electric organ keyboard and store in <ac>
+	through <ac+2>.
+
+.ORGO ac,		ANCIENT HISTORY write tone generator
+
+	This uuo NO LONGER EXISTS.
+	It is documented here for historical purposes only.
+	Its function is obsolete.
+	Its opcode has been recycled as .ARMRS.
+
+	Write output to a tone generator from <ac> through <ac+2>.
+
 .PDTIME ac,				PD time
 
 	Returns in accumulator <ac> the time since the beginning of the
@@ -1622,7 +1665,10 @@ This uuo was for hacking the AMF arm.  The arm no longer exists.
 	clock on which this was based.  Said clock ceased to work many
 	years ago.
 
-.POTSET
+.POTSET [block]				read pots
+
+	This call gives the user a flexible means of controlling
+	program parameters via the input multiplexer.
 
 .RBTC ac,				robot console switches
 
@@ -2256,9 +2302,23 @@ This uuo was for hacking the AMF arm.  The arm no longer exists.
 	disowned from its superior.  See the DDT documentation
 	for specific details on .VALUE.
 
-.VSCAN
+.VSCAN <block>				read vidissector data
+
+	The effective address should point at an eleven word
+	block of parameters defining the points to be scanned,
+	the locations to be read into, the mode they are to be
+	read in, and whether the call should hang until the
+	scan is through.
 
-.VSTST
+.VSTST ac,				test vidissector
+
+	This system call allows later control of and sensing by
+	a job that has overlapped computation with a .VSCAN.  If
+	the contents of <ac> is positive, the .VSTST hangs till
+	the scan is over.  If the contents of <ac> is negative,
+	any scan in progress is aborted.  If the contents is zero,
+	the user's location then being stored into by the scan,
+	if any, replaces it.
 
 .WMAR ac,		ANCIENT HISTORY	write mar address
 


### PR DESCRIPTION
Work in progress.  I found the .ORGI and .ORGO UUOs in AI memo 161.  I think it would be fitting to add them and other obsolete UUOs to the documentation.

I also found .MSPACE in ITS 674, and some UUOs have empty descriptions: .POTSET, .VSCAN, and .VSTST.  The robot arm UUOs can also be improved.