### PR TITLE
Fix the MIDAS 73 instruction names patch

### DIFF
--- a/src/midas/patch.73
+++ b/src/midas/patch.73
@@ -26,7 +26,7 @@ patch+23/10700,,cmbuf-1
 aftes,eisymt,10&FADSIw
 ./10&FADRI
 .+2/10&FSBRI
-.+4/10&FMPRI
-.+6/10&FDVRI
+.+2/10&FMPRI
+.+2/10&FDVRI
 :pdump midas;ts 73
 :kill


### PR DESCRIPTION
Having tried to compile some code that uses the other F*RI instructions, I realised I'd forgotten that `/` updates `.` when writing the original patch. This now puts the new instruction names in the right places.