### PR TITLE
Muddle function for printing maze

### DIFF
--- a/src/imlac/maze.print
+++ b/src/imlac/maze.print
@@ -1,0 +1,84 @@
+; " -*- muddle -*- "
+; "Print an imtraned maze."
+
+<SETG MAZE <IVECTOR 34>>
+<SETG WEST [!<IVECTOR 13 " "> "W" "E" "S" "T" !<IVECTOR 15 " ">]>
+<SETG EAST [!<IVECTOR 13 ""> "     E" "     A" "     S" "     T"
+	    !<IVECTOR 15 "">]>
+
+<DEFINE GET4 ("AUX" (C <ASCII <READCHR>>))
+  ;"Read 4 bits from an imtraned file."
+  ;"Ignore all characters outside @-O."
+  <COND (<AND <G=? .C 64> <L=? .C 79>> <- .C 64>)
+	(ELSE <GET4>)>>
+
+<DEFINE GET8 ()
+  <+ <* <GET4> 16> <GET4>>>
+
+<DEFINE GET16 ()
+  <+ <* <GET8> 256> <GET8>>>
+
+<DEFINE GET-BLKLDR ()
+  ;"Skip over the block loader."
+  <REPEAT ((N 0))
+    <GET16>
+    <SET N <+ .N 1>>
+    <COND (<=? .N 65> <RETURN>)>>>
+
+<DEFINE READ-MAZE ()
+  ;"Read an imtraned maze."
+  <GET-BLKLDR>
+  <REPEAT ((I 1) N)
+    ;"Get block length."
+    <SET N <+ <GET8> .I>>
+    ;"Get block address.  All ones means end."
+    <COND (<=? <GET16> 65535> <RETURN>)>
+    <REPEAT ()
+      <PUT ,MAZE .I <GET16>>
+      <SET I <+ .I 1>>
+      <COND (<=? .I .N> <RETURN>)>>
+    ;"Get block checksum."
+    <GET16>>>
+
+<DEFINE WRITE-LINE (S)
+  <PRINC .S>
+  <TERPRI>>
+
+<DEFINE ZERO? (X)
+  <=? .X #WORD 0>>
+
+<DEFINE WRITE-ROW (I W E "AUX" (DATA <GET ,MAZE .I>))
+  ;"Print one row of the maze."
+  <PRINC ";       ">
+  <PRINC .W>
+  <PRINC "    ">
+  <REPEAT ((BIT <LSH 1 15>))
+    <COND (<ZERO? <ANDB .DATA .BIT>> <PRINC "   ">)
+	  (ELSE <PRINC "$$$">)>
+    <SET BIT <LSH .BIT -1>>
+    <COND (<ZERO? .BIT> <RETURN>)>>
+  <WRITE-LINE .E>>
+
+<DEFINE WRITE-MAZE ()
+  ;"Print the maze data."
+  <WRITE-LINE ";                             N O R T H">
+  <WRITE-LINE ";">
+  <WRITE-LINE ";">
+  <REPEAT ((I 1))
+    <WRITE-ROW .I <GET ,WEST .I> <GET ,EAST .I>>
+    <WRITE-ROW .I " " "">
+    <COND (<=? .I 32> <RETURN>)>
+    <SET I <+ .I 1>>>
+  <WRITE-LINE ";">
+  <WRITE-LINE ";">
+  <WRITE-LINE ";                              S O U T H">>
+
+<DEFINE PRINT-MAZE (INPUT "OPTIONAL" (OUTPUT <>))
+  ;"Read an imtraned maze and print it."
+  <PROG ((INCHAN <OPEN "READ" .INPUT>)
+	 (OUTCHAN <COND (.OUTPUT <OPEN "PRINT" .OUTPUT>)
+			(ELSE .OUTCHAN)>))
+    <READ-MAZE>
+    <CLOSE .INCHAN>>
+    <WRITE-MAZE>
+    <COND (.OUTPUT <CLOSE .OUTCHAN>)>>>


### PR DESCRIPTION
Create a file IMLAC; MAZE PRINT with a function PRINT-MAZE.

From MAZE source code:

```
;        Users may specify their own mazes if they are the first player in  a
;   maze by giving a file name after "maze to use: ".  Just a CR will default
;   to the standard maze.  User mazes must have a specific format if they are
;   to be able to work. They must begin with a LOC 10020 followed by the label
;   MAZE:  on  the first of  32.   octal words which  form a bit  map for the
;   maze.   The maze must  end with  LOC 17713, JMP @.+1, 101,  and an  END.
;   After assembling the maze must be imtraned by using the "IMTRAN" command.
;   A  muddle function exists for printing out formated source mazes.   It is
;   initiated by  floading "imlac;maze  print"  in  muddle and  then  issuing
;   <PRINT-MAZE  "input file spec" "output file spec">$ where the output file
;   spec defaults to the TTY.   An example of a formated source maze is given
;   below:
