### PR TITLE
Fix UBAASL

### DIFF
--- a/src/system/its.1650
+++ b/src/system/its.1650
@@ -19607,7 +19607,7 @@ UBAASL:	PUSH P,B
 
 UBASL1:	MOVNS B
 	MOVSI A,400000
-	LSH A,B			;A/ bit to snarf
+	LSH A,(B)		;A/ bit to snarf
 	ANDCAM A,UBAIFS
 	CONO PI,PION
 	MOVN A,B	


### PR DESCRIPTION
This is the function that allocates page slots in the KS10 Unibus adaptor - I was using it when I was experimenting with KS10 Ethernet a couple of years ago.

It wasn't updating `UBAIFS` owing to a typo (`LSH A,B` for `LSH A,(B)`), so it always returned the first slot number. It's not actually used anywhere in ITS 1650, so this didn't break anything.