### PR TITLE
Ignore error from removing tek4010 binary.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -287,7 +287,7 @@ $(VT52):
 	$(MAKE) -C tools/vt05 vt52
 
 tek-hack:
-	rm $(TEK)
+	rm -f $(TEK)
 
 $(TEK): tek-hack
 	$(MAKE) -C tools/tek4010 tek4010


### PR DESCRIPTION
This ought to fix #1970.