### PR TITLE
Add the SIMH Imlac emulator.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -37,3 +37,6 @@
 [submodule "tools/simlac"]
 	path = tools/simlac
 	url = https://github.com/jdersch/sImlac
+[submodule "tools/sim-h"]
+	path = tools/sim-h
+	url = https://github.com/simh/simh

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Some important environment variables
-EMULATOR ?= simh
+EMULATOR ?= pdp10-ka
 
 # Sometimes you _really_ need to use a different `touch` or `rm`.
 TOUCH ?= touch

--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,7 @@ KLFEDR=tools/dasm/klfedr
 DATAPOINT=tools/vt05/dp3300
 VT52=tools/vt05/vt52
 TEK=tools/tek4010/tek4010
+SIMH_IMLAC=tools/sim-h/BIN/imlac $(OUT)/ssv22.iml
 
 H3TEXT=$(shell cd build; ls h3text.*)
 DDT=$(shell cd src; ls sysen1/ddt.* syseng/lsrtns.* syseng/msgs.* syseng/datime.* syseng/ntsddt.*)
@@ -101,7 +102,7 @@ out/simh/emulators: $(GT40) $(VT52)
 out/pdp10-ka/stamp: $(OUT)/rp03.2 $(OUT)/rp03.3
 	$(TOUCH) $@
 
-out/pdp10-ka/emulators: $(GT40) $(TV11) $(PDP6) $(DATAPOINT) $(VT52) $(TEK)
+out/pdp10-ka/emulators: $(GT40) $(TV11) $(PDP6) $(DATAPOINT) $(VT52) $(TEK) $(SIMH_IMLAC)
 	$(TOUCH) $@
 
 out/pdp10-kl/stamp: $(OUT)/rp04.1
@@ -176,11 +177,12 @@ $(OUT)/dskdmp.tape: $(WRITETAPE) $(RAM) $(DSKDMP)
 	$(MKDIR) $(OUT)
 	$(WRITETAPE) -n 2560 $@ $(RAM) $(DSKDMP)
 
-$(OUT)/bootvt.bin $(OUT)/aplogo.ptp: $(OUT)/output.tape
+$(OUT)/bootvt.bin $(OUT)/aplogo.ptp $(OUT)/ssv22.iml: $(OUT)/output.tape
 	$(RM) -rf $(OUT)/tmp
 	$(MKDIR) -p $(OUT)/tmp
 	$(ITSTAR) -xf $< -C $(OUT)/tmp
 	$(CP) $(OUT)/tmp/gt40/bootvt.bin $(OUT)/bootvt.bin
+	-$(CP) $(OUT)/tmp/imlac/ssv22.iml $(OUT)/ssv22.iml
 	-$(CP) $(OUT)/tmp/aplogo/logo.ptp $(OUT)/aplogo.ptp
 	$(RM) -rf $(OUT)/tmp
 
@@ -301,6 +303,9 @@ $(SMF):
 
 tools/sim-h/BIN/pdp11:
 	$(MAKE) -C tools/sim-h pdp11
+
+tools/sim-h/BIN/imlac:
+	$(MAKE) -C tools/sim-h imlac
 
 check-dirs: Makefile
 	mkdir -p $(OUT)/check

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ BINIGNORE=-e '^(ka10|kl10|ks10|minsys)$$'
 # These are on the minsrc tape.
 SRCIGNORE=-e '^(system|midas)$$'
 
-SUBMODULES = dasm itstar klh10 mldev simh sims supdup tapeutils tv11 pdp6 vt05 tek4010
+SUBMODULES = dasm itstar klh10 mldev simh sim-h sims supdup tapeutils tv11 pdp6 vt05 tek4010
 
 # These files are used to create bootable tape images.
 RAM = bin/ks10/boot/ram.262
@@ -64,7 +64,7 @@ KL10=tools/sims/BIN/pdp10-kl
 ITSTAR=tools/itstar/itstar
 WRITETAPE=tools/tapeutils/tapewrite
 MAGFRM=tools/dasm/magfrm
-GT40=tools/simh/BIN/pdp11 $(OUT)/bootvt.img
+GT40=tools/sim-h/BIN/pdp11 $(OUT)/bootvt.img
 TV11=tools/tv11/tv11
 PDP6=tools/pdp6/emu/pdp6
 KLFEDR=tools/dasm/klfedr
@@ -299,8 +299,8 @@ $(SMF):
 	$(GIT) submodule sync --recursive `dirname $@`
 	$(GIT) submodule update --recursive --init `dirname $@`
 
-tools/simh/BIN/pdp11:
-	$(MAKE) -C tools/simh pdp11
+tools/sim-h/BIN/pdp11:
+	$(MAKE) -C tools/sim-h pdp11
 
 check-dirs: Makefile
 	mkdir -p $(OUT)/check

--- a/README.md
+++ b/README.md
@@ -99,6 +99,25 @@ Here is an overview of the repository:
 - out - build output.
 - user - optional user files installed in ITS.
 
+### Terminal Emulators
+
+Several emulators for terminals and peripheral processors are built
+along with ITS.  They can be started conveniently with the `start`
+script, or separately.  Not all terminal emulators are set up to work
+with all PDP-10 emulators by default.
+
+| Name    | Description       | Type   | klh10 | pdp10-ka | pdp10-kl | simh
+| ------- | ----------------- | ------ | ----- | -------- | -------- | ----
+| type340 | Type 340          | vector | no    | yes      | no       | no
+| gt40    | GT40 PDP-11       | vector | no    | yes      | no       | yes
+| imlac   | Imlac PDS-1       | vector | no    | yes      | no       | no
+| simh_imlac | Imlac PDS-1    | vector | no    | yes      | no       | no
+| tv11    | Knight TV PDP-11  | cpu    | no    | yes      | no       | no
+| tvcon   | Knight TV console | raster | no    | yes      | no       | no
+| datapoint | Datapoint 3300  | text   | no    | yes      | no       | no
+| vt52    | VT52              | text   | no    | yes      | yes      | yes
+| tek     | Tektronix 4010    | vector | no    | yes      | yes      | no
+
 ### Documentation
 
 See the [`doc` subdirectory](doc) for documentation.

--- a/build/pdp10-ka/imlac.simh
+++ b/build/pdp10-ka/imlac.simh
@@ -1,0 +1,5 @@
+attach tty 12345,connect=localhost:10016;notelnet
+set rom type=stty
+load -s out/pdp10-ka/ssv22.iml
+reset
+go

--- a/build/pdp10-ka/start
+++ b/build/pdp10-ka/start
@@ -62,6 +62,11 @@ tek() {
     started "Tektronix" "$!"
 }
 
+simh_imlac() {
+    (sleep 2; tools/sim-h/BIN/imlac build/pdp10-ka/imlac.simh >imlac.log 2>&1) &
+    started "Imlac" "$!"
+}
+
 help() {
     cat <<EOF
 This start script takes several command line arguments:
@@ -70,6 +75,7 @@ help - Display this help text.
 type340 - Enable the Type 340 display.
 gt40 - Start a GT40 emulator.
 imlac - Start an Imlac PDS-1 emulator.
+simh_imlac - Start the SIMH Imlac PDS-1 emulator.
 tv11 - Start a TV-11 emulator.
 tvcon - Start a TV display.
 datapoint - Start a Datapoint 3300 emulator.

--- a/build/pdp10-ka/start
+++ b/build/pdp10-ka/start
@@ -24,7 +24,7 @@ stop() {
 }
 
 gt40() {
-    (sleep 3; tools/simh/BIN/pdp11 build/pdp10-ka/gt40 >gt40.log 2>&1) &
+    (sleep 3; tools/sim-h/BIN/pdp11 build/pdp10-ka/gt40 >gt40.log 2>&1) &
     started GT40 "$!"
 }
 

--- a/build/simh/start
+++ b/build/simh/start
@@ -21,7 +21,7 @@ stop() {
 }
 
 gt40() {
-    (sleep 3; tools/simh/BIN/pdp11 build/simh/gt40 >gt40.log 2>&1) &
+    (sleep 3; tools/sim-h/BIN/pdp11 build/simh/gt40 >gt40.log 2>&1) &
     started GT40 "$!"
 }
 


### PR DESCRIPTION
Add the SIMH Imlac PDS-1 emulator to the build and start script.

New section in README.md to describe the terminal emulators.