### PR TITLE
Fix of issue #2012

### DIFF
--- a/src/libdoc/od.4
+++ b/src/libdoc/od.4
@@ -43,18 +43,18 @@
 	  (let ((ch (remainder word 64.)))
 	    (push (+ ch 32.) result)
 	    (setq word (quotient word 64.))))
-    (format t "~A  " (implode result))))
+    (format t "~A  " (maknam result))))
 
 (defun print-ascii (word)
   (setq word (quotient word 2))
   (let ((result nil))
     (loop for i from 0 below 5 do
 	  (let ((ch (remainder word 128.)))
-	    (if (< ch 32.)
+	    (if (or (< ch 32.) (= ch 127.))
 	      (setq ch "."))
 	    (push ch result)
 	    (setq word (quotient word 128.))))
-    (format t "~A  " (implode result))))
+    (format t "~A  " (maknam result))))
 
 (defun read-word (input)
   (let ((word (in input)))
@@ -82,4 +82,4 @@
 	  (read-word input))))
 
 (defun toplevel ()
-  (print-binary (implode (status jcl))))
+  (print-binary (maknam (status jcl))))


### PR DESCRIPTION
Exchanged "implode" for "maknam" to avoid choking the GC for larger files.

Filter out ASCII 127 (DEL) from output in ASCII-column.