### PR TITLE
Exclude KLH10 from FreeBSD build on CirrusCI.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -10,7 +10,7 @@ task:
   env:
     matrix:
       - EMULATOR: simh
-      - EMULATOR: klh10
+      # EMULATOR: klh10
       - EMULATOR: pdp10-ka
         NODUMP: true
       # EMULATOR: pdp10-kl


### PR DESCRIPTION
There is a problem with GNU m4 which is needed to build KLH10, and I haven't found a good fix.