### PR TITLE
Add support for color scope.

### DIFF
--- a/build/pdp10-ka/run
+++ b/build/pdp10-ka/run
@@ -50,7 +50,7 @@ set mta type=b
 set dt mpx=6
 set imp mpx=4
 set dpa noheaders
-set wcnsls enabled joystick
+set wcnsls enabled joystick cscope
 set ocnsls enabled
 set imx enabled mpx=3
 set imx channel=2;unit0;axis0;negate

--- a/build/pdp10-ka/start
+++ b/build/pdp10-ka/start
@@ -44,7 +44,13 @@ tvcon() {
 }
 
 type340() {
-    cp build/pdp10-ka/run out/pdp10-ka/run
+    sed -i 's/set dpy disabled/set dpy enabled/' \
+        out/pdp10-ka/run
+}
+
+cscope() {
+    sed -i 's/set wcnsls enabled joystick/set wcnsls enabled joystick cscope/' \
+        out/pdp10-ka/run
 }
 
 datapoint() {
@@ -81,13 +87,16 @@ tvcon - Start a TV display.
 datapoint - Start a Datapoint 3300 emulator.
 vt52 - Start a VT52 emulator.
 tek - Start a Tektronix 4010 emulator.
+cscope - Enable the color scope.
 
 EOF
 
     touch out/pdp10-ka/nohelp
 }
 
-sed 's/set dpy enabled/set dpy disabled/' < build/pdp10-ka/run > out/pdp10-ka/run
+sed -e 's/set dpy enabled/set dpy disabled/' \
+    -e 's/set wcnsls enabled joystick cscope/set wcnsls enabled joystick/' \
+    < build/pdp10-ka/run > out/pdp10-ka/run
 
 test -f out/pdp10-ka/nohelp || help
 


### PR DESCRIPTION
Update the KA10 emulator to bring in the color scope device.  Add cscope to start script.