### PR TITLE
Fix broken links in CHANNA causing TV-11 and NAMDRG to fail.

### DIFF
--- a/build/ka10/processor.tcl
+++ b/build/ka10/processor.tcl
@@ -28,13 +28,13 @@ respond "*" ":link syseng;tvkbd rooms, sysen2;\r"
 type ":vk\r"
 respond "*" ":midas sysbin;_sysen2;namdrg\r"
 expect ":KILL"
-respond "*" ":link channa;rakash namdrg, sysbin; namdrg bin;\r"
+respond "*" ":link channa;rakash namdrg, sysbin; namdrg bin\r"
 type ":vk\r"
 
 # STUFF
 respond "*" ":midas sys1;ts stuff_sysen2;stuff\r"
 expect ":KILL"
-respond "*" ":link channa;rakash tvfix, sys1; ts stuff;\r"
+respond "*" ":link channa;rakash tvfix, sys1; ts stuff\r"
 type ":vk\r"
 
 # IOELEV, PDP-11 doing I/O for the PDP-10 host.


### PR DESCRIPTION
@techfury90 noted the TV-11 would no longer work after booting up ITS.  The cause is a mistake in #2010.  The links to RAKASH NAMDRG and TVFIX were wrong due to an added semicolon at the end of the :LINK command.  This would cause the automatic TV-11 stuffing to fail, and also not start the name dragon.