### PR TITLE
Add router.chaosnet.net as "friend"

### DIFF
--- a/conf/network
+++ b/conf/network
@@ -6,5 +6,5 @@ GW=192.168.0.45
 NETMASK=255,255,255,248
 CHAOS=no #Or octal Chaosnet address
 CHAFRIENDS=chip=3150/no.nocrew.org \
-           chip=3143/up.update.uu.se \
+           chip=3040/router.chaosnet.net \
            chip=7100/sj.gewt.net


### PR DESCRIPTION
In the default network config for klh10, replace up.update.uu.se with router.chaosnet.net, which is really the only one needed (since it knows everyone else, and tells you about them).