### PR TITLE
Stray ], CRDSB CRDTST multiply defined

### DIFF
--- a/src/system/time.952
+++ b/src/system/time.952
@@ -217,7 +217,7 @@ IFL TZONE,[ ;; negative offset
 GLPDT2:	JFCL		;POPJ FOR STD TIME
 			;JRST CRDDST FOR DAY LIGHT TIME
 			;JFCL "NORMAL"
-IFDEF DSTEU,IFN DSTEU,[
+IFDEF DSTEU,[IFN DSTEU,[
 	;; [BV] hack DST for EU rules
 	CAML A,[<MAR <31.-6>>*SPD+7200.]	;If before 2am last Sunday in March,
 	CAML A,[<OCT 31.>*SPD+7200.]	;or after 2am Oct 31 (standard time!),
@@ -226,7 +226,7 @@ IFDEF DSTEU,IFN DSTEU,[
 	CAML A,[<OCT <31.-6>>*SPD+7200.]	;or after 2am possbly last Sunday in October,
 	 JRST GLPDT3		;then we have to compute
 	;; else it's obviously DST
-]
+]]
 .ELSE [
 	CAML A,[<APR 1>*SPD+7200.]	;IF BEFORE 2AM APR 1,
 	CAML A,[<OCT 31.>*SPD+3600.]	;OR IF AFTER 1AM STANDARD TIME OCT 31,
@@ -263,13 +263,13 @@ GLPDT3:	PUSH P,A	;SAVE # SECS
 	POP P,A		;DAYLIGHT SAVINGS TIME, RESTORE A
 	JRST CRDDST	;MUNG A AND E AND RETURN
 
-IFDEF DSTEU,IFN DSTEU,[
+IFDEF DSTEU,[IFN DSTEU,[
 CRDSB:	7200.			;In Mar changes at 2AM (standard time)
 	7200.			;In October also changes at 2AM (standard time!)
 
 CRDTST:	CAIGE A,<MAR <31.-6>>	;First possible last Sunday in March
 	CAIL A,<OCT <31.-6>>	;First possible last Sunday in October
-]
+]]
 .ELSE [
 CRDSB:	7200.		;IN APR CHANGES AT 2AM EST
 	3600.		;IN OCTOBER CHANGES AT 1AM EST


### PR DESCRIPTION
These assembler warnings appeared recently:

```
*:midas dsk0:.;_system;its
ITS
MACHINE NAME = KA
    ==> INSERTED:  CONFIG 202
    ==> INSERTED:  BITS 117
VERSION = 1651
ML:TIME 952 SYSTEM;
GLPDT2+7        23523    2.     4-061   Stray ]
CRDTST+2        23562    2.     5-032   Stray ]
CRDTST+2        23562    2.     5-034   CRDSB   Multiply defined
CRDTST+4        23564    2.     5-037   CRDTST  Multiply defined
    ==> INSERTED:  TIME 952
```