### PR TITLE
Read the IP configuration from NOP from IMP

### DIFF
--- a/src/system/imp.368
+++ b/src/system/imp.368
@@ -607,8 +607,29 @@ IMPGD:	LDB B,[420200,,IMPILB+2]	;Reason (see 1822)
 	JRST IMPIRT
 
 ;;; IMP->Host Type 4 - NOP
+;;; With support in KLH10 (dpimp version 1.1.4 or later),
+;;; read the IP configuration from the NOP sent.
+;;; The IP address is in the network, source host, and source IMP fields,
+;;; and the subnet mask size is in the "handling type" field.
+;;; The first and last of these are very non-standard, but hey... it works.
 
-IMPIN:	JRST IMPIRT		;One more NOP from IMP
+IMPIN:	LDB T,[241000,,IMPILB+0]	;get network byte (ip[0])
+	JUMPE T,IMPIRT		; none: incompatible IMP code
+	LSH T,24.
+	LDB TT,IMSABP		; get source host+IMP (ip[1..3])
+	IOR T,TT
+	MOVEM T,NIFIPA		; save our IP address
+	LDB T,[341000,,IMPILB+1]	; get subnet mask size
+	SUBI T,32.		; bits to shift
+	HRLOI TT,37777		; 32 bits set
+	LSH TT,(T)		; shift right
+	MOVNS T	
+	LSH TT,(T)		; shift left again
+	MOVEM TT,NIFIPM
+	MOVE T,NIFIPA		; make network part of address
+	AND T,NIFIPM
+	MOVEM T,NIFIPN		; save it
+	JRST IMPIRT		;One more NOP from IMP
 
 ;;; IMP->Host Type 5 - RFNM (Ready For Next Message)
 


### PR DESCRIPTION
With support in KLH10 (dpimp version 1.1.4 or later, in a pull request for klh10), read the IP configuration from the NOP sent. The IP address is in the network, source host, and source IMP fields, and the subnet mask size is in the "handling type" field. The first and last of these are very non-standard, but hey... it works.