### PR TITLE
Updated RRS; TEST GRAPHS for RRS.

### DIFF
--- a/src/rrs/test.graphs
+++ b/src/rrs/test.graphs
@@ -135,18 +135,20 @@
 		   <GO LOOP>>>>
 
 <DEFINE MOUNDR (X1 Y1
-		"AUX" (X <+ .X1 .99999999E-7>)
-		      (Y <+ .Y1 .99999999E-7>)
+		"AUX" (X <+ .X1 0.99999999E-7>)
+		      (Y <+ .Y1 0.99999999E-7>)
 		      (A <SQRT <+ <* .X .X> <* .Y .Y>>>))
 	</ <SIN <* .A 4.0000000>> .A>>
 
-<DEFINE MOUND (X1 Y1 "AUX" (X <+ .X1 .99999999E-7>) (Y <+ .Y1 .99999999E-7>) A B
-)
+<DEFINE MOUND (X1 Y1 
+			   "AUX" (X <+ .X1 0.99999999E-7>)
+			   	     (Y <+ .Y1 0.99999999E-7>) A B)
 	<SET A </ <SIN <* .X 4.0000000>> .X>>
 	<SET B </ <SIN <* .Y 4.0000000>> .Y>>
 	<* .A .B>>
 
-<DEFINE MOUNDL (X1 Y1 "AUX" (X <+ .99999999E-7 .X1>) (Y <+ .99999999E-7 .Y1>))
+<DEFINE MOUNDL (X1 Y1 
+			    "AUX" (X <+ 0.99999999E-7 .X1>) (Y <+ 0.99999999E-7 .Y1>))
 	<LOG <+ 5.0000000
 		<* </ <SIN <* 4.0000000 .X>> .X>
 		   </ <SIN <* 4.0000000 .Y>> .Y>>>>>
@@ -336,7 +338,7 @@
 <DEFINE CARD (STRING)
 	<PAGE>
 	<SLEEP 3>
-	<MOVE 0 800>
+	<MOVE 0 775>
 	<TERPRI>
 	<PRINC "                HAPPY HOLLY DAYS">
 	<TERPRI>
@@ -351,14 +353,14 @@
 	     3D
 	     #FALSE ()
 	     (-1 MT!-MCELLS <SCALE 5> <XLATE 0 0 5000>)
-	     (-1 TREE!-MCELLS <SCALE .50000000> <XLATE 700 100>)
-	     (-1 TREE!-MCELLS <SCALE .50000000> <XLATE -100 0 3000>)
-	     (-1 BOX!-MCELLS <SCALE .50000000> <XLATE 100 0 50>)
+	     (-1 TREE!-MCELLS <SCALE 0.50000000> <XLATE 700 100>)
+	     (-1 TREE!-MCELLS <SCALE 0.50000000> <XLATE -100 0 3000>)
+	     (-1 BOX!-MCELLS <SCALE 0.50000000> <XLATE 100 0 50>)
 	     (-1
 	      BOX1!-MCELLS
-	      <SCALE .50000000 .50000000 1>
+	      <SCALE 0.50000000 0.50000000 1>
 	      <XLATE 205 0 200>)
-	     (-1 TREE!-MCELLS <SCALE .30000000> <XLATE 50 50 325>))>
+	     (-1 TREE!-MCELLS <SCALE 0.30000000> <XLATE 50 50 325>))>
 
 <SET BOX!-MCELLS
      '#MCELL(()
@@ -791,4 +793,10 @@
 	<MT3>
 	<MSPT>
 	<MSENE1>>
+
+<DEFINE MK&DSP ("AUX" R S T)
+	<SET T <LOOKUP "SENE1" <GET MCELLS OBLIST>>>
+	<SENE1>
+	<DISP SENE1 <XLATE 500 400 200>>>
+
 


### PR DESCRIPTION
This change comes from RRS:

This version includes one new function to test graphs,
<MK&DSP>$ which compiles all the MCELLs in the SENE1 image and then displays
the complete SENE1 cell. It takes about 15 to 20 seconds to compile the
display. That's pretty amazing for source code, much faster then DM, or USC-ISI's pdp10s.
Just think what a difference the compiler will make...