### PR TITLE
Have GitHub Actions finish jobs even if one of them failed.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,7 @@ jobs:
     environment: Deploy
     runs-on: ${{matrix.os}}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-18.04]
         emulator: [simh, klh10, pdp10-ka, pdp10-kl]


### PR DESCRIPTION
Currently the pdp10-ka job is prone to failing randomly, causing the other jobs to be cancelled.  This change will let them finish, and the failed pdp10-ka job can be restarted.