### PR TITLE
Use configured timezone name in IT IS NOW console printout

### DIFF
--- a/src/system/sysjob.118
+++ b/src/system/sysjob.118
@@ -2359,10 +2359,22 @@ SYSNWP:	MOVEI I,[ASCIZ /IT IS NOW /]
 	PUSHJ P,SYSTCD	;TYPE OUT TIME
 	POP P,B		;RESTORE AM OR PM WORD
 	PUSHJ P,SYS6	;TYPE IT OUT
+ifdef tzone,[		
+	pushj p,styos		;leading space
+	hlrz b,tznam+tzone	;standard name
+	tlne e,100000		;is DST bit set?
+	 hrrz b,tznam+tzone	;then get DST name
+	move b,(b)		;get the sixbit name
+	pushj p,sys6		;type it out
+	movei t,",
+	pushj p,styo		;followed by a comma
+]
+.else [
 	MOVE B,[SIXBIT / EST,/]
 	TLNE E,100000	;DST BIT
 	HRLI B,(SIXBIT / ED/)	;DAYLIGHT SAVINGS TIME, TYPE OUT EDT INSTEAD OF EST
 	PUSHJ P,SYS6	;TYPE IT OUT
+]
 	PUSHJ P,STYOS	;TYPE A SPACE
 	LDB B,[320300,,E]	;GET DAY OF WEEK (0 => SUNDAY)
 	MOVE B,DOWTBL(B)	;MON, TUES, WEDNES, ETC. (IN SIXBIT)
@@ -2378,9 +2390,34 @@ SYSNWP:	MOVEI I,[ASCIZ /IT IS NOW /]
 	PUSHJ P,SYSDPT	;TYPE OUT IN DECIMAL
 	MOVEI T,",
 	PUSHJ P,STYO	;TYPE A COMMA
+	PUSHJ P,STYOS	;AND A SPACE, PLEASE
 	MOVEI A,(E)	;GET YEAR
 	PUSHJ P,SYSDPT	;TYPE IT OUT
 	JRST SYSCRF	;END WITH CRLF
+
+ifdef tzone,[
+;; Table of time zone names, used in "IT IS NOW" printout
+;; see SYSENG; DATIME
+DEFINE TZNAMS STD,DST
+	[sixbit /STD/],,[sixbit /DST/]
+TERMIN
+	repeat 12.-2,TZNAMS	;Dunno -3..-12
+	tznams EET,EEST		;-2
+	tznams CET,CEST		;-1
+tznam:	TZNAMS GMT,BST	; 0 How to ask for British Summer Time??
+	TZNAMS		; 1
+	TZNAMS		; 2
+	TZNAMS		; 3 (NST = Newfoundland is -0330)
+	TZNAMS AST,ADT	; 4 Atlantic
+	TZNAMS EST,EDT	; 5 Eastern
+	TZNAMS CST,CDT	; 6 Central
+	TZNAMS MST,MDT	; 7 Mountain
+	TZNAMS PST,PDT	; 8 Pacific
+	TZNAMS YST,YDT	; 9 Yukon
+	TZNAMS HST,HDT	; 10 Alaska-Hawaii
+	TZNAMS BST,BDT	; 11 Bering
+	REPEAT 24.-11.,TZNAMS	; 12-24 unspecified
+] ; ifdef tzone
 
 		;TABLE OF NAMES OF MONTHS (FIRST THREE LETTERS, IN SIXBIT)
 


### PR DESCRIPTION
Rather than printing the "classic" timezone EST/EDT, print the configured timezone.