### PR TITLE
Use -u with all SIMH terminal line attach commands.

### DIFF
--- a/build/mchn/DB/boot
+++ b/build/mchn/DB/boot
@@ -3,11 +3,11 @@ set cpu its
 set cpu idle
 set tim y2k
 set dz 8b lines=8
-at dz0 10004
+at -u dz0 10004
 # VT52
-at dz0 line=7,10018
+at -u dz0 line=7,10018
 # GT40
-at dz0 line=6,10019
+at -u dz0 line=6,10019
 set rp0 rp06
 at rp0 out/simh/rp0.dsk
 b rp0

--- a/build/mchn/HX/run
+++ b/build/mchn/HX/run
@@ -18,17 +18,17 @@ set pd on
 set dk disabled
 set stk enabled
 set tk enabled
-at tk 10000 speed=300
+at -u tk 10000 speed=300
 # 10001 reserved for GE bagbiters, hah.
 set dpk enabled
-at dpk 10002 speed=4800
-at dpk line=11,10019 speed=4800
-at dpk line=15,10020 speed=4800
+at -u dpk 10002 speed=4800
+at -u dpk line=11,10019 speed=4800
+at -u dpk line=15,10020 speed=4800
 set mty enabled
-at mty 10003 speed=50000
-at mty line=9,10018 speed=9600
-at mty line=8,10017 speed=9600
-at mty line=7,10016;notelnet speed=50000
+at -u mty 10003 speed=50000
+at -u mty line=9,10018 speed=9600
+at -u mty line=8,10017 speed=9600
+at -u mty line=7,10016;notelnet speed=50000
 set ten11 enabled
 at ten11 10011
 set auxcpu enabled

--- a/build/mchn/KA/run
+++ b/build/mchn/KA/run
@@ -19,18 +19,18 @@ set dpy enabled
 set dk disabled
 set stk enabled
 set tk enabled
-at tk 10000 speed=300
+at -u tk 10000 speed=300
 # 10001 reserved for GE bagbiters, hah.
 set dpk enabled
-at dpk 10002 speed=4800
-at dpk line=11,10019 speed=4800
-at dpk line=15,10020 speed=4800
+at -u dpk 10002 speed=4800
+at -u dpk line=11,10019 speed=4800
+at -u dpk line=15,10020 speed=4800
 set mty enabled
-at mty 10003 speed=50000
-at mty line=9,10018 speed=9600
-at mty line=8,10017 speed=9600
-at mty line=7,10016;notelnet speed=50000
-at mty line=6,10015 speed=9600
+at -u mty 10003 speed=50000
+at -u mty line=9,10018 speed=9600
+at -u mty line=8,10017 speed=9600
+at -u mty line=7,10016;notelnet speed=50000
+at -u mty line=6,10015 speed=9600
 set ten11 enabled
 at ten11 10011
 set auxcpu enabled

--- a/build/mchn/TT/run
+++ b/build/mchn/TT/run
@@ -19,17 +19,17 @@ set dpy enabled
 set dk disabled
 set stk enabled
 set tk enabled
-at tk 10000 speed=300
+at -u tk 10000 speed=300
 # 10001 reserved for GE bagbiters, hah.
 # 10002 Datapoint kludge
 set mty enabled
-at mty 10003 speed=50000
-at mty line=10,10015;notelnet speed=50000
-at mty line=11,10019 speed=4800
-at mty line=12,10016;notelnet speed=50000
-at mty line=13,10017 speed=9600
-at mty line=14,10018 speed=9600
-at mty line=15,10020 speed=4800
+at -u mty 10003 speed=50000
+at -u mty line=10,10015;notelnet speed=50000
+at -u mty line=11,10019 speed=4800
+at -u mty line=12,10016;notelnet speed=50000
+at -u mty line=13,10017 speed=9600
+at -u mty line=14,10018 speed=9600
+at -u mty line=15,10020 speed=4800
 set ten11 enabled
 at ten11 10011
 #set auxcpu enabled

--- a/build/pdp10-ka/gt40
+++ b/build/pdp10-ka/gt40
@@ -16,7 +16,7 @@ set dlo enabled
 set dli lines=1
 set dli address=17775610
 set dlo0 8b
-at dli 10005,connect=localhost:10019
+at -u dli 10005,connect=localhost:10019
 set vt enabled
 set vt crt=vr14
 set vt scale=1

--- a/build/pdp10-ka/imlac.simh
+++ b/build/pdp10-ka/imlac.simh
@@ -1,4 +1,4 @@
-attach tty 12345,connect=localhost:10016;notelnet
+attach -u tty 12345,connect=localhost:10016;notelnet
 set rom type=stty
 load -s out/pdp10-ka/ssv22.iml
 reset

--- a/build/pdp10-kl/run
+++ b/build/pdp10-kl/run
@@ -8,13 +8,13 @@ set lpt dis
 set dc disable
 set tty enabled
 set tty 8b lines=15
-at tty 10007
+at -u tty 10007
 # VT52
-at tty line=14,10018 speed=9600
+at -u tty line=14,10018 speed=9600
 # Tektronix
-at tty line=13,10017 speed=9600
+at -u tty line=13,10017 speed=9600
 # Dial-up
-at tty line=12,10015 speed=9600
+at -u tty line=12,10015 speed=9600
 set pd ena
 set pd on
 set mta enabled type=b

--- a/build/pdp10-ks/boot
+++ b/build/pdp10-ks/boot
@@ -2,11 +2,11 @@ set console wru=034
 set cpu its
 set cpu idle
 set dz 8b lines=8
-at dz0 10004
+at -u dz0 10004
 # VT52
-at dz0 line=7,10018
+at -u dz0 line=7,10018
 # GT40
-at dz0 line=6,10019
+at -u dz0 line=6,10019
 set rpa0 rp06
 at rpa0 out/pdp10-ks/rp0.dsk
 b rpa0

--- a/build/simh/boot
+++ b/build/simh/boot
@@ -3,13 +3,13 @@ set cpu its
 set cpu idle
 set tim y2k
 set dz 8b lines=8
-at dz0 10004
+at -u dz0 10004
 # VT52
-at dz0 line=7,10018
+at -u dz0 line=7,10018
 # GT40
-at dz0 line=6,10019
+at -u dz0 line=6,10019
 # Dial-up
-at dz0 line=5,10015
+at -u dz0 line=5,10015
 set rp0 rp06
 at rp0 out/simh/rp0.dsk
 b rp0

--- a/build/simh/gt40
+++ b/build/simh/gt40
@@ -16,7 +16,7 @@ set dlo enabled
 set dli lines=1
 set dli address=17775610
 set dlo0 8b
-at dli 10005,connect=localhost:10004
+at -u dli 10005,connect=localhost:10004
 set vt enabled
 set vt crt=vr14
 set vt scale=1


### PR DESCRIPTION
The SIMH command `attach -u` makes terminal devices use SO_REUSEADDR.