### PR TITLE
Update MINSKY TRON to read switches in real time.

### DIFF
--- a/src/lars/minsky.tron
+++ b/src/lars/minsky.tron
@@ -21,7 +21,20 @@ NTS:	CONO DIS,100		;Reset display.
 	DATAO DIS,[020016]	;Parameter mode, go to point mode.
 	MOVE XY,[220000,,022000];Two point mode words.
 
-	DATAI APR,A		;Get switches.
+M2:	MOVE A,XA0		;Copy the initial state.
+	MOVEM A,XA
+	MOVE A,XB0
+	MOVEM A,XB
+	MOVE A,XC0
+	MOVEM A,XC
+	MOVE A,YA0
+	MOVEM A,YA
+	MOVE A,YB0
+	MOVEM A,YB
+	MOVE A,YC0
+	MOVEM A,YC
+
+LOOP:	DATAI APR,A		;Get switches.
 	HRLZ B,A
 M1:	JSP P,GSH		;Make six shift instructions.
 	MOVEM A,SH0
@@ -35,18 +48,6 @@ M1:	JSP P,GSH		;Make six shift instructions.
 	MOVEM A,SH4
 	JSP P,GSH
 	MOVEM A,SH5
-M2:	MOVE A,XA0		;Copy the initial state.
-	MOVEM A,XA
-	MOVE A,XB0
-	MOVEM A,XB
-	MOVE A,XC0
-	MOVEM A,XC
-	MOVE A,YA0
-	MOVEM A,YA
-	MOVE A,YB0
-	MOVEM A,YB
-	MOVE A,YC0
-	MOVEM A,YC
 
 M3A:	MOVE A,XA		;Update XA and YA.
 	ADD A,XB
@@ -92,7 +93,7 @@ M3C:	MOVE A,XC		;Update XC and YC.
 	JSP P,DPY
 
 	JSP P,DELAY
-	JRST M3A
+	JRST LOOP
 
 GSH:	SETZ A,			;Get a shift instruction.
 	ROTC A,3


### PR DESCRIPTION
Previously the Minskytron program would only read switches once, at start up.  With the PiDP-10, it's easy to change switches at run time.