### PR TITLE
Fix two pdp10-kl problems.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,7 @@ download: $(SMF) $(OUT)/stamp/pdp10
 	$(CP) -r $(EMULATOR)/system $(OUT)
 	$(CP) $(EMULATOR)/*.tape $(OUT)
 	$(CP) $(EMULATOR)/rp0* $(OUT)
-	$(CP) $(EMULATOR)/*.rim $(OUT)
+	-$(CP) $(EMULATOR)/*.rim $(OUT)
 	$(CP) $(EMULATOR)/dskdmp* $(OUT)
 	$(TOUCH) $(OUT)/stamp/its
 

--- a/build/pdp10-kl/run
+++ b/build/pdp10-kl/run
@@ -7,7 +7,7 @@ set tua dis
 set lpt dis
 set dc disable
 set tty enabled
-set tty 8b lines=15
+set tty 8b
 at -u tty 10007
 # VT52
 at -u tty line=14,10018 speed=9600


### PR DESCRIPTION
- "make download" complains that the .rim file is missing.
- "set tty lines=" is invalid.  
