### PR TITLE
Re-run the new DSKDMP to ensure it's swapped out to disk.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -4,9 +4,10 @@ env:
   BASICS: yes
   CONFFLAGS_USR: -DKLH10_CTYIO_INT=0
 
+freebsd_instance:
+  image_family: freebsd-13-0
+
 task:
-  freebsd_instance:
-    image: freebsd-12-1-release-amd64
   env:
     matrix:
       - EMULATOR: simh

--- a/build/ks10/include.tcl
+++ b/build/ks10/include.tcl
@@ -100,6 +100,10 @@ proc prepare_frontend {} {
 
     shutdown
     start_dskdmp "$out/sources.tape"
+
+    # Run the new DSKDMP to ensure it's swapped out to disk.
+    respond "DSKDMP" "dskdmp bin\r"
+
     respond "DSKDMP" "nits\r"
 }
 


### PR DESCRIPTION
The last time DSKDMP is booted off tape, the newer on-disk DSKDMP must be run to ensure that version is written to disk.

Fixes #2099.