### PR TITLE
Fixed issue with VERB? in Zork when issued following an error in parsing input line.

### DIFF
--- a/build/zork.tcl
+++ b/build/zork.tcl
@@ -17,6 +17,6 @@ type "\033p"
 expect ":KILL"
 
 respond "*"  ":xxfile lcf;zork log_lcf;zork xxfile\r"
-expect "Job XXFILE interrupted: .VALUE;"
+expect -timeout 6000 "Job XXFILE interrupted: .VALUE;"
 type "\033p"
 expect ":KILL"

--- a/src/lcf/defs.172
+++ b/src/lcf/defs.172
@@ -524,15 +524,19 @@
 
 <DEFMAC VERB? ("ARGS" AL)
 	<COND (<1? <LENGTH .AL>>
-	       <FORM ==? <FORM VNAME '<PRSA>> <PSTRING <1 .AL>>>)
+               <FORM PROG (PV)
+                  #DECL ((PV) <OR ACTION VERB FALSE>)
+	          <FORM AND <FORM SET PV '<PRSA>> <FORM ==? <FORM VNAME <FORM LVAL PV>> <PSTRING <1 .AL>>>>
+	       >)
 	      (ELSE
-	       <FORM PROG ((VA <FORM VNAME '<PRSA>>))
-		     #DECL ((VA) PSTRING)
+	       <FORM PROG ((PV '<PRSA>) (VA <FORM AND <FORM LVAL PV> <FORM VNAME <FORM LVAL PV>>>))
+	           #DECL ((PV) <OR ACTION VERB FALSE> (VA) <OR PSTRING FALSE>)
+	           <FORM AND PV
 		     <FORM OR
 			   !<MAPF ,LIST
 				  <FUNCTION (A)
 				      <FORM ==? <FORM LVAL VA> <PSTRING .A>>>
-				  .AL>>>)>>
+				  .AL>>>>)>>
 
 <DEFMAC GET-DOOR-ROOM ('RM 'LEAVINGS)
 	<FORM PROG <LIST <LIST EL <FORM DROOM1 .LEAVINGS>>>


### PR DESCRIPTION
Fixes NTH OUT-OF-BOUNDS error when issuing a command like `tell master "kill me with sword"` in endgame when either there is no master there or no sword there.