### PR TITLE
Test for the 340 interrupt "hack hack".

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,7 @@ DUMP=$(shell cd src; ls syseng/dump.* sysnet/netwrk.*)
 SMF:=$(addprefix tools/,$(addsuffix /.gitignore,$(SUBMODULES)))
 OUT=out/$(EMULATOR)
 
-all: its $(OUT)/stamp/emulators tools/supdup/supdup
+all: its $(OUT)/stamp/test $(OUT)/stamp/emulators tools/supdup/supdup
 
 its: $(SMF) $(OUT)/stamp/its
 
@@ -240,6 +240,18 @@ tools/dasm/palx: tools/dasm/palx.c
 $(OUT)/bootvt.img: $(OUT)/bootvt.bin tools/dasm/palx
 	$(MKDIR) out/gt40
 	tools/dasm/palx -I < $< > $@
+
+out/pdp10-ka/stamp/test: out/pdp10-ka/stamp/its
+	$(KA10) build/pdp10-ka/hhtest.simh
+	$(TOUCH) $@
+
+out/simh/stamp/test:
+
+out/klh10/stamp/test:
+
+out/pdp10-kl/stamp/test:
+
+out/pdp10-ks/stamp/test:
 
 start: build/$(EMULATOR)/start
 	$(LN) -s $< $*

--- a/build/ka10/processor.tcl
+++ b/build/ka10/processor.tcl
@@ -258,3 +258,10 @@ respond "*" ":kill\r"
 respond "*" ":midas sys; atsign 6slave_sysen2; ld10\r"
 respond "   PDP6F = " "1\r"
 expect ":KILL"
+
+# Test for the 340 "hack hack".
+respond "*" $emulator_escape
+punch_tape "$out/hhtest.rim"
+type ":vk\r"
+respond "*" ":midas ptp:_maint;hhtest\r"
+expect ":KILL"

--- a/build/pdp10-ka/hhtest.simh
+++ b/build/pdp10-ka/hhtest.simh
@@ -1,0 +1,4 @@
+attach ptr out/pdp10-ka/hhtest.rim
+boot ptr
+if (PC != 000201) echof "FAIL"; ex pc; exit 1
+exit 0

--- a/src/maint/hhtest.1
+++ b/src/maint/hhtest.1
@@ -1,0 +1,47 @@
+	TITLE "HACK HACK" TEST
+
+;This tests the ITS "hack hack" for handling Type 340 display
+;interrupts.  Data is output to the display through a BLKO from a low
+;priority data channel, whereas other conditions are handled through a
+;higher priority special channel.  The "hack hack" is that when the
+;BLKO overflows, ITS triggers an interrupt on the special channel.
+;This interrupt is handled still in the overflow state, so the second
+;interrupt location should be used.  This hack goes back to at least
+;ITS 672.
+
+NOSYMS
+RIM10
+
+APR==0
+PI==4
+TTY==120
+
+SCHN==4
+DCHN==6
+
+LOC 40+2*DCHN
+	BLKO TTY,PTR			;2. BLKO overflows.
+	CONO PI,4000+200_<-SCHN>	;3. Trigger special interrupt.
+
+LOC 40+2*SCHN
+	JRST 4,.
+	JSR OFLOW			;4. Execute second instruction.
+
+LOC 100
+
+GO:	CONO APR,675550			;Reset APR.
+	CONO PI,711377			;Reset PI.
+	CONO PI,2000+<200_<-SCHN>>+<200_<-DCHN>> ;Enable channels.
+	CONO TTY,DCHN
+	CONO PI,4000+200_<-DCHN>	;1. Trigger data interrupt.
+REPEAT 10,JFCL
+	JRST 4,.			;Unsuccessful test ends here.
+
+LOC 200
+
+OFLOW:	0
+	JRST 4,.			;5. Successful test ends here.
+
+PTR:	-1,,["A]-1
+
+END GO


### PR DESCRIPTION
Adding an automated test that runs standalone to check that the KA10 emulator (currently unknown what other processors should do) supports the "hack hack" used by ITS to handle overflowing 340 display BLKO interrupts.  For now, it's just a draft because the KA10 emulator has regressed in this regard.  The problem was previously found and solved in 2018.

Reported here: https://github.com/rcornwell/sims/issues/297

```
;This tests the ITS "hack hack" for handling Type 340 display
;interrupts.  Data is output to the display through a BLKO from a low
;priority data channel, whereas other conditions are handled through a
;higher priority special channel.  The "hack hack" is that when the
;BLKO overflows, ITS triggers an interrupt on the special channel.
;This interrupt is handled still in the overflow state, so the second
;interrupt location should be used.  This hack goes back to at least
;ITS 672.
```

For more detailed analysis, see @aap's description here: http://pdp-6.net/asmhacks.html#pisystem