### PR TITLE
Update GitHub Actions runner to the ubuntu-22.04 image.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-18.04]
+        os: [ubuntu-22.04]
         emulator: [simh, klh10, pdp10-ka, pdp10-kl, pdp10-ks]
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
The older ubuntu-18.04 image is no longer supported, which is why the builds stopped.