### PR TITLE
FTP "passive" command needs "on" argument.

### DIFF
--- a/build/deploy-ftp.sh
+++ b/build/deploy-ftp.sh
@@ -22,7 +22,7 @@ chmod 600 "$NETRC"
 echo "Deploying as $USER at $HOST"
 
 ftp "$HOST" <<EOF
-passive
+passive on
 type image
 cd $DIR
 lcd out


### PR DESCRIPTION
Deployment to @oilcan-productions' FTP server stopped working in the new Ubuntu 22 build image.  Apparently the ftp client command `passive` now only shows the status; the command `passive on` is needed to engage passive mode.