### PR TITLE
use open-simh, not OG simh

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -12,7 +12,7 @@
 	url = https://github.com/PDP-10/klh10
 [submodule "tools/simh"]
 	path = tools/simh
-	url = https://github.com/simh/simh
+	url = https://github.com/open-simh/simh
 [submodule "tools/supdup"]
 	path = tools/supdup
 	url = https://github.com/PDP-10/supdup
@@ -39,4 +39,4 @@
 	url = https://github.com/jdersch/sImlac
 [submodule "tools/sim-h"]
 	path = tools/sim-h
-	url = https://github.com/simh/simh
+	url = https://github.com/open-simh/simh


### PR DESCRIPTION
https://groups.io/g/simh/topic/91528716

In short: Mark Pizzolato made some decisions that almost everyone else, including Bob Supnik, disagreed with vigorously, and put the project under an extremely weird license:

https://github.com/simh/simh/blob/master/LICENSE.txt

Open SIMH is the resulting fork, under an MIT license, and it appears to be where the most actual development is happening. 