### PR TITLE
Update to latest OpenSIMH.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ BINIGNORE=-e '^(ka10|kl10|ks10|minsys)$$'
 # These are on the minsrc tape.
 SRCIGNORE=-e '^(system|midas)$$'
 
-SUBMODULES = dasm itstar klh10 mldev simh sim-h sims supdup tapeutils tv11 pdp6 vt05 tek4010
+SUBMODULES = dasm itstar klh10 mldev simh sims supdup tapeutils tv11 pdp6 vt05 tek4010
 
 # These files are used to create bootable tape images.
 RAM = bin/ks10/boot/ram.262
@@ -84,14 +84,14 @@ KS10=tools/sims/BIN/pdp10-ks
 ITSTAR=tools/itstar/itstar
 WRITETAPE=tools/tapeutils/tapewrite
 MAGFRM=tools/dasm/magfrm
-GT40=tools/sim-h/BIN/pdp11 $(OUT)/bootvt.img
+GT40=tools/simh/BIN/pdp11 $(OUT)/bootvt.img
 TV11=tools/tv11/tv11
 PDP6=tools/pdp6/emu/pdp6
 KLFEDR=tools/dasm/klfedr
 DATAPOINT=tools/vt05/dp3300
 VT52=tools/vt05/vt52
 TEK=tools/tek4010/tek4010
-SIMH_IMLAC=tools/sim-h/BIN/imlac $(OUT)/ssv22.iml
+SIMH_IMLAC=tools/simh/BIN/imlac $(OUT)/ssv22.iml
 
 H3TEXT=$(shell cd build; ls h3text.*)
 DDT=$(shell cd src; ls sysen1/ddt.* syseng/lsrtns.* syseng/msgs.* syseng/datime.* syseng/ntsddt.*)
@@ -385,11 +385,11 @@ $(SMF):
 	$(GIT) submodule sync --recursive `dirname $@`
 	$(GIT) submodule update --recursive --init `dirname $@`
 
-tools/sim-h/BIN/pdp11:
-	$(MAKE) -C tools/sim-h pdp11
+tools/simh/BIN/pdp11:
+	$(MAKE) -C tools/simh pdp11
 
-tools/sim-h/BIN/imlac:
-	$(MAKE) -C tools/sim-h imlac
+tools/simh/BIN/imlac:
+	$(MAKE) -C tools/simh imlac
 
 check-dirs: Makefile
 	mkdir -p $(OUT)/check

--- a/build/pdp10-ka/start
+++ b/build/pdp10-ka/start
@@ -24,7 +24,7 @@ stop() {
 }
 
 gt40() {
-    (sleep 3; tools/sim-h/BIN/pdp11 build/pdp10-ka/gt40 >gt40.log 2>&1) &
+    (sleep 3; tools/simh/BIN/pdp11 build/pdp10-ka/gt40 >gt40.log 2>&1) &
     started GT40 "$!"
 }
 
@@ -69,7 +69,7 @@ tek() {
 }
 
 simh_imlac() {
-    (sleep 2; tools/sim-h/BIN/imlac build/pdp10-ka/imlac.simh >imlac.log 2>&1) &
+    (sleep 2; tools/simh/BIN/imlac build/pdp10-ka/imlac.simh >imlac.log 2>&1) &
     started "Imlac" "$!"
 }
 

--- a/build/pdp10-ks/start
+++ b/build/pdp10-ks/start
@@ -21,7 +21,7 @@ stop() {
 }
 
 gt40() {
-    (sleep 3; tools/sim-h/BIN/pdp11 build/pdp10-ks/gt40 >gt40.log 2>&1) &
+    (sleep 3; tools/simh/BIN/pdp11 build/pdp10-ks/gt40 >gt40.log 2>&1) &
     started GT40 "$!"
 }
 

--- a/build/simh/start
+++ b/build/simh/start
@@ -21,7 +21,7 @@ stop() {
 }
 
 gt40() {
-    (sleep 3; tools/sim-h/BIN/pdp11 build/simh/gt40 >gt40.log 2>&1) &
+    (sleep 3; tools/simh/BIN/pdp11 build/simh/gt40 >gt40.log 2>&1) &
     started GT40 "$!"
 }
 


### PR DESCRIPTION
Previously we were stuck on an older version of SIMH, since newer versions weren't able to complete the ITS build script.  The most recent version of OpenSIMH does work, so let's update to that.  This also removes the need to have two separate copies of SIMH.