### PR TITLE
Fixed issue with ECHO-ROOM treating <PRSO> as a vector

### DIFF
--- a/src/lcf/act1.255
+++ b/src/lcf/act1.255
@@ -1033,7 +1033,7 @@ His enflamed tongue protrudes from his man-sized mouth.">)>)
 		       <COND (<AND <SET V <LEX .B <REST .B .L>>>
 				   <EPARSE .V T>
 				   <==? <PRSA> .WALK>
-				   <NOT <EMPTY? <PRSO>>>
+                                   <PRSO>
 				   <MEMQ <2 .PRSVEC> <REXITS .RM>>>
 			      <SET RANDOM-ACTION <VFCN <PRSA>>>
 			      <APPLY-RANDOM .RANDOM-ACTION>


### PR DESCRIPTION
`<PRSO>` can be a scalar, and attempts to use EMPTY? on `<PRSO>` can cause an exception.  Addresses #2210.