### PR TITLE
Updated MLDEV device to handle 2- and 3-char ITS hostnames.

### DIFF
--- a/src/sysen2/mldev.108
+++ b/src/sysen2/mldev.108
@@ -129,11 +129,9 @@ nox:				; jump here if hostname minus first "x" is not a known ITS
 				; is it hhhdir or hhh
 	hrlz c,a		; get device in c
 	jumpe c, host3		; jump if no device
-	jrst hst2ck		;  have a device, nope, check for hhddd case
 
-hst2ck:				; check for hhddd case
 	ldb c,[000600,,a]	; can only be hhddd if last sixbit character is null
-	jumpn c,hhddd1		; handle hhddd case if last character is NUL
+	jumpe c,hhddd1		; handle hhddd case if last character is NUL
 	
 	hrlz c,a		; check for hhhddd, get ddd in c
 	jumpn e,hhhddd		; is there a ddd?, if so handle it
@@ -176,16 +174,16 @@ notits:				; here we've determined that hostname is invalid, check for special d
 	CAIN C,'XGP	;XGP THROUGH THE NET TO AI FROM ML/MC/DM
 	 JRST [	MOVEI A,'AI
 		JRST GOTHSX]
-	CAIN A,'GLP		;GOULD THROUGH THE NET TO MX
+	CAIN C,'GLP		;GOULD THROUGH THE NET TO MX
 	 JRST [ MOVEI A,'MX
 		JRST GOTHSX]
-	CAIN A,'DVR	;DVR THROUGH THE NET TO MC FROM AI/ML/DM
+	CAIN C,'DVR	;DVR THROUGH THE NET TO MC FROM AI/ML/DM
 	 JRST [ MOVEI A,'MC
 		JRST GOTHSX]
-	CAIN A,'DVS	;DVS THROUGH THE NET TO MC FROM ML/DM
+	CAIN C,'DVS	;DVS THROUGH THE NET TO MC FROM ML/DM
 	 JRST [	MOVEI A,'MC
 		JRST GOTHSX]
-	CAIN A,'TPL	;TPL THROUGH THE NETWORK FOR MC
+	CAIN C,'TPL	;TPL THROUGH THE NETWORK FOR MC
 	 JRST [ LDB B,[000400,,JBCOP]
 		CAIN B,2
 		 JRST TPLLK	;TRYING TO LINK ON TPL: LOSES
@@ -210,8 +208,9 @@ hhhddd:				; get device from last 3 characters
 doshoe:				; device is SHOE
 	lsh c,12.		; left justfify device
 	movem c,jbcdev		; set remote device
-	ldb b,[301400,,a]	; get 2-character hostname
-	lsh b,30		; left justify hostname
+	ldb a,[301400,,a]	; get 2-character hostname
+	lsh a,30		; left justify hostname
+	jrst gothst		; process host
 
 dodir:	hrlz b,a		;a is for example 'DIREX', or 'DIREXA' ; b becomes 'EX' or 'EXA'
 	hrlzm c,jbcdev		; save left-justified 'DIR' as remote device

--- a/src/sysen2/mldev.108
+++ b/src/sysen2/mldev.108
@@ -55,7 +55,6 @@ FILBLN:	0	;FILE LENGTH, IN BYTES OF SIZE WRITTEN IN.
 FILBSZ:	0	;BYTE SIZE FILE WRITTEN IN.
 FILDTP:	0	;-1 => WE KNOW THE CREATION DATE OF THIS FILE.
 FILDAT:	0	;FILE CREATION DATE (IF KNOWN).
-3char:  0	;-1 if hostname is 3 characters long, else 2 characters long
 dirdev: sixbit /DIR/	; DIR device
 dskdev: sixbit /DSK/	; DSK device
 
@@ -99,7 +98,7 @@ GO:	MOVE P,[-LPDLL-1,,PDL-1]
 	 .value
 	;; check for 4-character devices. Only one checked for is SHOE, which only works with 2-character
 	;;  hostnames.
-	ldb c,[003000,,a]	; get last four characters
+	ldb c,[003000,,a]		; get last four characters
 	camn c,[sixbit /  SHOE/]	; is it the SHOE device?
 	  jrst doshoe
 
@@ -112,77 +111,67 @@ GO:	MOVE P,[-LPDLL-1,,PDL-1]
 	ldb c,[.bp (770000),a]
 	cain c,'X
 	 jrst [	move b,a
-		lsh b,6              ;get rid of X
-		pushj p,isitsp       ; see if we now have a known ITS name
-		 jrst nox            ;  nope, skip handling as experimental case
-		move c,dskdev        ; assume DSK device
-		movem c,jbcdev       ; store as remote device
-		move a,b	         ; get host in A for gothst
-		jrst gothst ]        ; and go process request for this host
+		lsh b,6		;get rid of X
+		pushj p,isitsp	; see if we now have a known ITS name
+		 jrst nox	;  nope, skip handling as experimental case
+		move c,dskdev	; assume DSK device
+		movem c,jbcdev	; store as remote device
+		move a,b	; get host in A for gothst
+		jrst gothst ]	; and go process request for this host
 
-nox:                         ; jump here if hostname minus first "x" is not a known ITS
-                             ; check to see if format is hhDIR
+nox:				; jump here if hostname minus first "x" is not a known ITS
+				; check to see if format is hhDIR
 	move c,a
-	lsh c,12.                ; move past hostname
-	camn c,dirdev            ; is what remains the DIR device?
-	  jrst dirchk            ;  yes, continue checking hhDIR case
+	lsh c,12.		; move past hostname
+	camn c,dirdev		; is what remains the DIR device?
+	  jrst dirchk		;  yes, continue checking hhDIR case
 
-                             ; is it hhhdir or hhh
-	hrlz c,a
-	jumpe c, host3		     ; jump if no device
-	  jrst hst2ck            ;  have a device, nope, check for hhddd case
-	movem c,jbcdev           ; we have a device; save it as remote device
-	jrst chkits              ; see if host part (hhh) is a known ITS machine
+				; is it hhhdir or hhh
+	hrlz c,a		; get device in c
+	jumpe c, host3		; jump if no device
+	jrst hst2ck		;  have a device, nope, check for hhddd case
 
-hst2ck:	                     ; check for hhddd case
-	ldb c,[000600,,a]        ; can only be hhddd if last sixbit character is null
-	cain c,0                 ; is last character null?
-	  jrst hhddd1            ;  yes, handle hhddd case
+hst2ck:				; check for hhddd case
+	ldb c,[000600,,a]	; can only be hhddd if last sixbit character is null
+	jumpn c,hhddd1		; handle hhddd case if last character is NUL
 	
-	move c,a                 ; check for hhhddd
-	lsh c,18.                ; get ddd in c
-	caie c,0                 ; is there a ddd?
-	  jrst hhhddd            ;  yes, handle it
-	jrst chkits              ; nope, assume that we just have hhh
+	hrlz c,a		; check for hhhddd, get ddd in c
+	jumpn e,hhhddd		; is there a ddd?, if so handle it
+	jrst chkits		; nope, assume that we just have hhh
 
-host3:                       ; seems like hhh, but may be special, check to see if ITS
-	move b,a                 ; hostname in A
-	pushj p,isitsp           ; is it a known ITS
-	  jrst notits            ;  nope, see if special device
-	move c,dskdev	         ; we have an ITS name, so assume DSK device
-	movem c,jbcdev           ; save remote device
-	jrst gothst              ; and process our host
+host3:				; seems like hhh, but may be special, check to see if ITS
+	move b,a		; hostname in A
+	pushj p,isitsp		; is it a known ITS
+	  jrst notits		;  nope, see if special device
+	move c,dskdev		; we have an ITS name, so assume DSK device
+	movem c,jbcdev		; save remote device
+	jrst gothst		; and process our host
 
-dirchk:	                     ; 2-char hostname with DIR device
-	ldb b,[.bp (777700),a]   ; get hh part in b
-	lsh b,24.                ; left justify hostname
-dirch2:	move c,dirdev        ; set remote device as DIR device
+dirchk:				; 2-char hostname with DIR device
+	ldb b,[.bp (777700),a]	; get hh part in b
+	lsh b,24.		; left justify hostname
+dirch2:	move c,dirdev		; set remote device as DIR device
 	movem c,jbcdev
-	jrst chkhst              ;and check our host
-
-dirch3:	                     ; 3-char hostname with DIR device
-	ldb b,[222200,,a]	     ; get hhh part in b
-	lsh b,18.                ; left-justify hostname
-	jrst dirch2              ; set remote device as DIR device and process host
+	move a,b		; get host in a
+	jrst gothst		; process host
 
 hhddd2: ldb a,[301400,,jbcdev]	; get hostname in A
-	lsh a,24.		            ; left justify hostname
-	movem c,jbcdev		        ; set remote device from C
-	jrst gothst                 ; process host
+	lsh a,24.		; left justify hostname
+	movem c,jbcdev		; set remote device from C
+	jrst gothst		; process host
 
-hhddd1:                      ; continue check for hhddd
-	ldb c,[003000,,a]        ; get device portion
-	lsh c,12.                ; left-justify
-	caie c,0                 ; no device?
-	  jrst hhddd2            ;   nope, have devie; get hostname and set remote device
+hhddd1:				; continue check for hhddd
+	ldb c,[003000,,a]	; get device portion
+	lsh c,12.		; left-justify
+	jumpn c,hhddd2		; jump if we have a device; get hostname and set remote device
 
-	; fall through; assume just an ITS name
+	;; fall through; assume just an ITS name
 chkits:	move b,a
-	pushj p,isitsp           ; is b an ITS name?
-	 jrst notits             ;  no, process as special device
-    jrst gothst              ; yes, process this host
+	pushj p,isitsp		; is b an ITS name?
+	 jrst notits		;  no, process as special device
+        jrst gothst		; yes, process this host
 
-notits:	                     ; here we've determined that hostname is invalid, check for special device
+notits:				; here we've determined that hostname is invalid, check for special device
 	MOVS C,JBCDEV
 	CAIN C,'XGP	;XGP THROUGH THE NET TO AI FROM ML/MC/DM
 	 JRST [	MOVEI A,'AI
@@ -212,57 +201,39 @@ notits:	                     ; here we've determined that hostname is invalid, c
 NSD:	MOVSI A,%ENSDV
 	JRST NOGO2
 
-hhhddd:                 ; get device from last 3 characters
-	ldb c,[002200,,a]   ; get device
-	hrlz c,c            ; left-jusify
-	movem c,jbcdev      ; save remote device
-	ldb b,[222200,,a]   ; get hostname
-	hrlz a,b            ; left-justify
-	jrst gothst         ; process host
+hhhddd:				; get device from last 3 characters
+	hrlz c,a		; get device and left justify
+	movem c,jbcdev		; save remote device
+	hllzs a			; get hostname
+	jrst gothst		; process host
 
-doshoe:                 ; device is SHOE
-	lsh c,12.	        ; left justfify device
+doshoe:				; device is SHOE
+	lsh c,12.		; left justfify device
 	movem c,jbcdev		; set remote device
 	ldb b,[301400,,a]	; get 2-character hostname
-	lsh b,30		    ; left justify hostname
+	lsh b,30		; left justify hostname
 
-chkhst:                 ; b has host
-	pushj p,isitsp      ; is it a known ITS machine
-	  jrst .+1          ; ???
-	move a,b	        ; get host in a
-	jrst gothst         ; process host
-
-dodir:	hrlz b,a	    ;a is for example 'DIREX', or 'DIREXA' ; b becomes 'EX' or 'EXA'
-	pushj p,isitsp	    ;is it an ITS host that we know about
-	  jrst .+1          ; ???
-	lsh c,18.		    ; left-justift 'DIR'
-	movem c,jbcdev	    ; save remote device
-	move a,b	        ; get host in A for gothst
-	jrst gothst         ; process host
+dodir:	hrlz b,a		;a is for example 'DIREX', or 'DIREXA' ; b becomes 'EX' or 'EXA'
+	hrlzm c,jbcdev		; save left-justified 'DIR' as remote device
+	move a,b		; get host in A for gothst
+	jrst gothst		; process host
 
 ;; Check if B has the name of an ITS, if so, skip return
 ;; Messes up T
 isitsp:	movsi t,-nitses
 isitz0:	camn b,itses(t)
-	  jrst popj1	   ;match, skip return
+	  jrst popj1		;match, skip return
 	skipe itses(t)
 	aobjn t,isitz0
 	popj p,
 
-gothsx: ; a contains sixbit 2-char host, right-justified
+gothsx:	; a contains sixbit 2-char host, right-justified
 	lsh a,24.		; left-justify host
-	lsh c,18.       ; left justify device
-	movem c,jbcdev  ; save remote device
+	hrlzm c,jbcdev		; save left-justified remote device
 	;; fall through
 
 	; a contains sixbit host, left-justified
-GOTHST:	;; determine whether this is a 2-char or 3-char hostname
-	ldb d,[220600,,a]        ; check third character for nul
-	jumpe d,.+3              ; jump if 2-char host
-    setom 3char              ; mark as 3-char host
-	skipa                    ; skip
-goths0:	setzm 3char          ; mark as 3-char host
-	MOVE B,[440700,,BUF]		;Make ASCIZ host name
+GOTHST:	MOVE B,[440700,,BUF]	;Make ASCIZ host name
 GOTHS1:	LDB T,[360600,,A]
 	JUMPE T,GOTHS2
 	ADDI T,40

--- a/src/sysen2/mldev.108
+++ b/src/sysen2/mldev.108
@@ -55,6 +55,9 @@ FILBLN:	0	;FILE LENGTH, IN BYTES OF SIZE WRITTEN IN.
 FILBSZ:	0	;BYTE SIZE FILE WRITTEN IN.
 FILDTP:	0	;-1 => WE KNOW THE CREATION DATE OF THIS FILE.
 FILDAT:	0	;FILE CREATION DATE (IF KNOWN).
+3char:  0	;-1 if hostname is 3 characters long, else 2 characters long
+dirdev: sixbit /DIR/	; DIR device
+dskdev: sixbit /DSK/	; DSK device
 
 nitses==:40
 itses: block nitses
@@ -94,69 +97,107 @@ GO:	MOVE P,[-LPDLL-1,,PDL-1]
 	move c,[sixbit /ITSNMS/]
 	.getsys b,
 	 .value
-	;; is it DIRxx? See if xx is an ITS name, then make it xxDIR instead
-	hlrz c,a
+	;; check for 4-character devices. Only one checked for is SHOE, which only works with 2-character
+	;;  hostnames.
+	ldb c,[003000,,a]	; get last four characters
+	camn c,[sixbit /  SHOE/]	; is it the SHOE device?
+	  jrst doshoe
+
+	;; devices that are DIRhh or DIRhhh are converted to hhDIR or hhhDIR for later consistent handling.
+	hlrz c,a		; a is for example, 'DIREX'; c becomes '   DIR'
 	cain c,'DIR
-	 jrst [ hrlz b,a	;get xx part in b
-		pushj p,isitsp
-		 jrst .+1
-		;; b is an ITS, make device xxDIR
-		lsh c,-12.
-		dpb b,[.bp (777700),c]
-		movem c,jbcdev
-		move a,b	; get host in A for gothst
-		jrst gothst ]
-	;; is it Xxx? allow this as alias for "Xperimental" xx
+	  jrst dodir
+
+	;; is it Xhhx or Xhhh? allow this as alias for "Xperimental" hh or hhh
 	ldb c,[.bp (770000),a]
 	cain c,'X
 	 jrst [	move b,a
-		lsh b,6		;get rid of X
-		pushj p,isitsp
-		 jrst .+1
-		movem b,jbcdev
-		move a,b	;get host in A for gothst
-		jrst gothst ]
-	;; is it xxDIR?
+		lsh b,6              ;get rid of X
+		pushj p,isitsp       ; see if we now have a known ITS name
+		 jrst nox            ;  nope, skip handling as experimental case
+		move c,dskdev        ; assume DSK device
+		movem c,jbcdev       ; store as remote device
+		move a,b	         ; get host in A for gothst
+		jrst gothst ]        ; and go process request for this host
+
+nox:                         ; jump here if hostname minus first "x" is not a known ITS
+                             ; check to see if format is hhDIR
 	move c,a
-	lsh c,12.
-	cain c,'DIR
-	 jrst [ ldb b,[.bp (777700),a] ;get xx part in b
-		pushj p,isitsp
-		 jrst .+1
-		move a,b	; get host in A
-		jrst gothst ]		
-	move b,a
-	;; is b an ITS name?
-	pushj p,isitsp
-	 jrst notits
-	  jrst gothst
+	lsh c,12.                ; move past hostname
+	camn c,dirdev            ; is what remains the DIR device?
+	  jrst dirchk            ;  yes, continue checking hhDIR case
+
+                             ; is it hhhdir or hhh
+	hrlz c,a
+	jumpe c, host3		     ; jump if no device
+	  jrst hst2ck            ;  have a device, nope, check for hhddd case
+	movem c,jbcdev           ; we have a device; save it as remote device
+	jrst chkits              ; see if host part (hhh) is a known ITS machine
+
+hst2ck:	                     ; check for hhddd case
+	ldb c,[000600,,a]        ; can only be hhddd if last sixbit character is null
+	cain c,0                 ; is last character null?
+	  jrst hhddd1            ;  yes, handle hhddd case
 	
-notits:	;; nothing came of it, fall through
-	MOVS A,JBCDEV
-	CAIN A,'XGP	;XGP THROUGH THE NET TO AI FROM ML/MC/DM
-	 JRST [	MOVS A,[SIXBIT/AIXGP/]
-		MOVSM A,JBCDEV
-		MOVEI A,'AI
-		JRST GOTHST]
+	move c,a                 ; check for hhhddd
+	lsh c,18.                ; get ddd in c
+	caie c,0                 ; is there a ddd?
+	  jrst hhhddd            ;  yes, handle it
+	jrst chkits              ; nope, assume that we just have hhh
+
+host3:                       ; seems like hhh, but may be special, check to see if ITS
+	move b,a                 ; hostname in A
+	pushj p,isitsp           ; is it a known ITS
+	  jrst notits            ;  nope, see if special device
+	move c,dskdev	         ; we have an ITS name, so assume DSK device
+	movem c,jbcdev           ; save remote device
+	jrst gothst              ; and process our host
+
+dirchk:	                     ; 2-char hostname with DIR device
+	ldb b,[.bp (777700),a]   ; get hh part in b
+	lsh b,24.                ; left justify hostname
+dirch2:	move c,dirdev        ; set remote device as DIR device
+	movem c,jbcdev
+	jrst chkhst              ;and check our host
+
+dirch3:	                     ; 3-char hostname with DIR device
+	ldb b,[222200,,a]	     ; get hhh part in b
+	lsh b,18.                ; left-justify hostname
+	jrst dirch2              ; set remote device as DIR device and process host
+
+hhddd2: ldb a,[301400,,jbcdev]	; get hostname in A
+	lsh a,24.		            ; left justify hostname
+	movem c,jbcdev		        ; set remote device from C
+	jrst gothst                 ; process host
+
+hhddd1:                      ; continue check for hhddd
+	ldb c,[003000,,a]        ; get device portion
+	lsh c,12.                ; left-justify
+	caie c,0                 ; no device?
+	  jrst hhddd2            ;   nope, have devie; get hostname and set remote device
+
+	; fall through; assume just an ITS name
+chkits:	move b,a
+	pushj p,isitsp           ; is b an ITS name?
+	 jrst notits             ;  no, process as special device
+    jrst gothst              ; yes, process this host
+
+notits:	                     ; here we've determined that hostname is invalid, check for special device
+	MOVS C,JBCDEV
+	CAIN C,'XGP	;XGP THROUGH THE NET TO AI FROM ML/MC/DM
+	 JRST [	MOVEI A,'AI
+		JRST GOTHSX]
 	CAIN A,'GLP		;GOULD THROUGH THE NET TO MX
-	 JRST [	MOVS A,[SIXBIT/MXGLP/]
-		MOVSM A,JBCDEV
-		MOVEI A,'MX
-		JRST GOTHST]
+	 JRST [ MOVEI A,'MX
+		JRST GOTHSX]
 	CAIN A,'DVR	;DVR THROUGH THE NET TO MC FROM AI/ML/DM
-	 JRST [	MOVS A,[SIXBIT/MCDVR/]
-		MOVSM A,JBCDEV
-		MOVEI A,'MC
-		JRST GOTHST]
+	 JRST [ MOVEI A,'MC
+		JRST GOTHSX]
 	CAIN A,'DVS	;DVS THROUGH THE NET TO MC FROM ML/DM
-	 JRST [	MOVS A,[SIXBIT/MCDVS/]
-		MOVSM A,JBCDEV
-		MOVEI A,'MC
-		JRST GOTHST]
+	 JRST [	MOVEI A,'MC
+		JRST GOTHSX]
 	CAIN A,'TPL	;TPL THROUGH THE NETWORK FOR MC
-	 JRST [	MOVS A,[SIXBIT/MLTPL/]
-		MOVSM A,JBCDEV
-		LDB B,[000400,,JBCOP]
+	 JRST [ LDB B,[000400,,JBCOP]
 		CAIN B,2
 		 JRST TPLLK	;TRYING TO LINK ON TPL: LOSES
 		LDB B,[410100,,JBCOP]	;0 => INPUT  1 => OUTPUT
@@ -166,10 +207,38 @@ notits:	;; nothing came of it, fall through
 			.SUSET [.RUNAME,,JBCFN2]
 			JRST (A) ]
 		MOVEI A,'ML		;USE THE MATHLAB LINE PRINTER
-		JRST GOTHST ]
+		JRST GOTHSX ]
 ;HOST NOT RECOGNIZED
 NSD:	MOVSI A,%ENSDV
 	JRST NOGO2
+
+hhhddd:                 ; get device from last 3 characters
+	ldb c,[002200,,a]   ; get device
+	hrlz c,c            ; left-jusify
+	movem c,jbcdev      ; save remote device
+	ldb b,[222200,,a]   ; get hostname
+	hrlz a,b            ; left-justify
+	jrst gothst         ; process host
+
+doshoe:                 ; device is SHOE
+	lsh c,12.	        ; left justfify device
+	movem c,jbcdev		; set remote device
+	ldb b,[301400,,a]	; get 2-character hostname
+	lsh b,30		    ; left justify hostname
+
+chkhst:                 ; b has host
+	pushj p,isitsp      ; is it a known ITS machine
+	  jrst .+1          ; ???
+	move a,b	        ; get host in a
+	jrst gothst         ; process host
+
+dodir:	hrlz b,a	    ;a is for example 'DIREX', or 'DIREXA' ; b becomes 'EX' or 'EXA'
+	pushj p,isitsp	    ;is it an ITS host that we know about
+	  jrst .+1          ; ???
+	lsh c,18.		    ; left-justift 'DIR'
+	movem c,jbcdev	    ; save remote device
+	move a,b	        ; get host in A for gothst
+	jrst gothst         ; process host
 
 ;; Check if B has the name of an ITS, if so, skip return
 ;; Messes up T
@@ -180,8 +249,20 @@ isitz0:	camn b,itses(t)
 	aobjn t,isitz0
 	popj p,
 
-;A CONTAINS SIXBIT HOST, RIGHT-JUSTIFIED
-GOTHST:	MOVE B,[440700,,BUF]		;Make ASCIZ host name
+gothsx: ; a contains sixbit 2-char host, right-justified
+	lsh a,24.		; left-justify host
+	lsh c,18.       ; left justify device
+	movem c,jbcdev  ; save remote device
+	;; fall through
+
+	; a contains sixbit host, left-justified
+GOTHST:	;; determine whether this is a 2-char or 3-char hostname
+	ldb d,[220600,,a]        ; check third character for nul
+	jumpe d,.+3              ; jump if 2-char host
+    setom 3char              ; mark as 3-char host
+	skipa                    ; skip
+goths0:	setzm 3char          ; mark as 3-char host
+	MOVE B,[440700,,BUF]		;Make ASCIZ host name
 GOTHS1:	LDB T,[360600,,A]
 	JUMPE T,GOTHS2
 	ADDI T,40
@@ -196,11 +277,8 @@ GOTHS2:	LSH A,6
 	MOVEM TT,NETWRK'		;Network number
 	PUSHJ P,NETWRK"HSTUNMAP		;Don't need host table any more
 	 .VALUE
-	LDB A,[3000,,JBCDEV]		;Right-hand four characters
-	JUMPN A,.+2
-	 MOVE A,[SIXBIT /  DSK/]
-	LSH A,14
-	MOVEM A,JBCDEV
+
+	move a,jbcdev
 	MOVEM A,FDEVN
 	SETOM JBGTN'	;FLAG INITIAL JOBGET DONE
 	MOVE A,NETWRK


### PR DESCRIPTION
Addresses #2231.

Also a prior change to support the ITS ITSNMS table broke some of the case handling in MLDEV. This PR fixes those as well.  