### PR TITLE
Update to GitHub Actions checkout@v4.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
         os: [ubuntu-22.04]
         emulator: [simh, klh10, pdp10-ka, pdp10-kl, pdp10-ks]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Install dependencies
         env:
           EMULATOR: ${{matrix.emulator}}


### PR DESCRIPTION
We're getting a warning: 
> The following actions uses node12 which is deprecated and will be forced to run on node16: actions/checkout@v2. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/

So apparently it's time to update.