### PR TITLE
Add a 1 second delay before accessing the boostrap disk.

### DIFF
--- a/build/ks10/include.tcl
+++ b/build/ks10/include.tcl
@@ -22,6 +22,7 @@ proc start_dskdmp_its {} {
 }
 
 proc mark_pack {unit pack id} {
+    after 1000
     respond "\n" "mark\033g"
     respond "Format pack on unit #" "$unit"
     respond "Are you sure you want to format pack on drive" "y"


### PR DESCRIPTION
On my FreeBSD CI system, on a relatively old server, I was seeing "disk controller not ready" errors when trying the format the bootstrap disk pack when building ITS with simh.  This error occurred consistently when running on CI server, but did not happen when entering the commands manually.

The fix is to add a 1 second delay before trying to format the bootstrap pack.  This fixes the problem seen in CI and has no effect when building on may (much faster Apple M1) laptop.