### PR TITLE
Shutdown server.

### DIFF
--- a/build/build.tcl
+++ b/build/build.tcl
@@ -195,6 +195,10 @@ respond "*" ":copy sys; ts ddt, dsk0: backup;\r"
 respond "*" ":copy sys; ts dump, dsk0: backup;\r"
 respond "*" ":copy sys; ts midas, dsk0: backup;\r"
 
+if [file exists $build/mchn/$mchn/custom.tcl] {
+    source $build/mchn/$mchn/custom.tcl
+}
+
 if {![info exists env(NODUMP)]} {
     # make output.tape
     respond "*" $emulator_escape

--- a/build/mchn/HX/custom.tcl
+++ b/build/mchn/HX/custom.tcl
@@ -1,0 +1,2 @@
+#Gun down users that are idle and not logged in.
+respond "*" ":link dragon; hourly gunner, cstacy; gunner bin\r"

--- a/build/mchn/TT/custom.tcl
+++ b/build/mchn/TT/custom.tcl
@@ -1,0 +1,4 @@
+#Enable the remote shutdown service.
+respond "*" ":midas /t device;chaos shutdo_sysnet;shutsr\r"
+respond "end input with ^C" "ALLOW==3036\r\003"
+expect ":KILL"

--- a/build/mchn/TT/custom.tcl
+++ b/build/mchn/TT/custom.tcl
@@ -2,3 +2,6 @@
 respond "*" ":midas /t device;chaos shutdo_sysnet;shutsr\r"
 respond "end input with ^C" "ALLOW==3036\r\003"
 expect ":KILL"
+
+#Gun down users that are idle and not logged in.
+respond "*" ":link dragon; hourly gunner, cstacy; gunner bin\r"

--- a/src/sysnet/shutsr.35
+++ b/src/sysnet/shutsr.35
@@ -1,0 +1,64 @@
+	TITLE SHUTDOWN SERVER
+
+;This Chaosnet node is allowed to shut down.
+IFNDEF ALLOW,ALLOW==177001
+
+A==1
+P==17
+
+CHI=0
+CHO=1
+
+.INSRT SYSTEM;CHSDEF
+
+GO:	.CLOSE 1,
+
+	.SUSET [.SJNAME,,['SHUTDN]]
+
+	;Open Chaosnet channel and listen for SHUTDN connections.
+	.CALL [SETZ ? 'CHAOSO ? MOVEI CHI ? MOVEI CHO ? SETZI 5]
+	 .LOSE %LSSYS
+	.CALL [SETZ ? 'PKTIOT ? MOVEI CHO ? SETZI LSN]
+	 .LOSE %LSSYS
+
+	;Wait for an RFC.
+	MOVEI A,60.*60.
+	.CALL [SETZ ? 'NETBLK ? MOVEI CHI ? MOVEI %CSLSN ? A ? SETZM A]
+	 .LOSE %LSSYS
+	CAIE A,%CSRFC
+	 .LOGOUT 1,
+
+	;Receive the RFC packet and send an ANS response.
+	.CALL [SETZ ? 'PKTIOT ? MOVEI CHI ? SETZI PACKET]
+	 .LOSE %LSSYS
+	.CALL [SETZ ? 'PKTIOT ? MOVEI CHO ? SETZI ANS]
+	 .LOSE %LSSYS
+
+	;Check the source address.
+	LDB A,[$CPKSA PACKET]
+	CAME A,[ALLOW]
+	 .LOGOUT 1,
+
+	;Patch ITS to remove the lower bound on shutdown time.
+	MOVE A,[SQUOZE 0,ASHUTD]
+	.EVAL A,
+	 .LOSE %LSSYS
+	ADDI A,3
+	HRLI A,[CAIA]
+	.SETLOC A,
+	MOVEI A,30.
+	.SLEEP A,
+
+	;Shut down quickly.
+	MOVEI A,30.
+	.SHUTDN A,
+	 .LOSE %LSSYS
+	.LOGOUT 1,
+
+LSN:	.BYTE 8 ? %COLSN ? 0 ? 0 ? 8 ? .BYTE
+LOC LSN+%CPKDT
+	.BYTE 8 ? "S ? "H ? "U ? "T ? "D ? "O ? "W ? "N ? .BYTE
+ANS:	.BYTE 8 ? %COANS ? .BYTE
+PACKET:	BLOCK %CPMXW
+
+END GO


### PR DESCRIPTION
This is a Chaosnet server for quickly shutting down ITS.  For e.g. the PiDP-10, users are assumed to power off the host computer and expect ITS disks to be in a consistent time next time it boots.  Thus we need a mechanism for the host to tell ITS to shut down quickly and orderly.  See also #1683

Posting a draft for comments.

@ams suggested the shutdown request to include information on how to shut down, or rather, reboot.  There could be an optional character, or string, for this.

More important is some kind of security token.  Something to restrict who can shut down the target.

If we want to overengineer things, a shutdown time could be included.