### PR TITLE
Update Makefile to export EMULATOR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# Some important environment variables
+t # Some important environment variables
 EMULATOR ?= pdp10-ka
 
 # Sometimes you _really_ need to use a different `touch` or `rm`.
@@ -24,6 +24,10 @@ else
 MCHN ?= DB
 endif
 endif
+
+# This is necessary because the default value won't be passed in the environment to
+# the Tcl build scripts otherwise.
+export EMULATOR
 
 IMAGES=http://hactrn.kostersitz.com/images
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-t # Some important environment variables
-EMULATOR ?= pdp10-ka
+# Some important environment variables
+export EMULATOR ?= pdp10-ka
 
 # Sometimes you _really_ need to use a different `touch` or `rm`.
 TOUCH ?= touch
@@ -24,10 +24,6 @@ else
 MCHN ?= DB
 endif
 endif
-
-# This is necessary because the default value won't be passed in the environment to
-# the Tcl build scripts otherwise.
-export EMULATOR
 
 IMAGES=http://hactrn.kostersitz.com/images
 


### PR DESCRIPTION
Default value of EMULATOR is not passed in the environment in newer versions of gmake without an explicit export.