### PR TITLE
Update dependencies.sh to allow both "3rd party" installs for macos

### DIFF
--- a/build/dependencies.sh
+++ b/build/dependencies.sh
@@ -31,12 +31,24 @@ install_freebsd() {
 }
 
 install_osx() {
-    brew update
-    case "$EMULATOR" in
-        simh*) brew install automake sdl2 sdl2_image sdl2_net pkg-config;;
-        pdp10-*) brew install automake sdl2 sdl2_image sdl2_net pkg-config;;
-        klh10) brew install automake sdl2 sdl2_image sdl2_net pkg-config;;
-    esac
+    if [ -x /opt/local/bin/port ]; then
+        echo "Using macports under sudo - your password may be required"
+        case "$EMULATOR" in
+            simh*) sudo port install vde2 automake libsdl2 libsdl2_image libsdl2_net pkgconfig;;
+            pdp10-*) sudo port install vde2 automake libsdl2 libsdl2_image libsdl2_net pkgconfig;;
+            klh10) sudo port install vde2 automake libsdl2 libsdl2_image libsdl2_net pkgconfig;;
+        esac
+    elif [ -x /opt/homebrew/bin/homebrew ]; then
+        brew update
+        case "$EMULATOR" in
+            simh*) brew install automake sdl2 sdl2_image sdl2_net pkg-config;;
+            pdp10-*) brew install automake sdl2 sdl2_image sdl2_net pkg-config;;
+            klh10) brew install automake sdl2 sdl2_image sdl2_net pkg-config;;
+        esac
+    else
+        echo "Either MacPorts or Homebrew must be installed to /opt first"
+        exit 1
+    fi
 }
 
 "$1"


### PR DESCRIPTION
Since macos ships without a 3rd-party dependency manager, there are two systems in common use - macports and brew.  Both support the dependencies required to build this, so support both.  Also add guard to ensure that at least one is installed rather than just blowing up if brew is not installed.