### PR TITLE
Light show.

### DIFF
--- a/src/lars/lites.79
+++ b/src/lars/lites.79
@@ -1,0 +1,132 @@
+	TITLE Light Show
+
+;Default is to build for both TS and NTS.
+IFNDEF TS,TS==1
+IFNDEF NTS,NTS==1
+
+A=1
+B=2
+T=10
+TT=11
+Q=16
+P=17
+
+APR==0
+PI==4
+
+TICKS=20*60.				;20 seconds.
+PDLLEN==20
+
+GO:	MOVE P,[-PDLLEN,,PDL-1]
+IFN TS,[
+	;Timesharing code starts here.  If not present, fall through to 
+	;non-timesharing code.
+	SETO A,				;Enable IOT luser mode.
+	.IOTLSR A,			;If running out of timesharing, go to UUO handler.
+	MOVE A,[SQUOZE 0,MIPGDS]
+	.EVAL A,
+	 .VALUE
+	HRLI A,[-1]			;Have ITS not clobber memory indicators.
+	.SETLOC A,
+	MOVE A,[%RLFLS\%RLSET,,[1]]
+	.REALT A,			;Clock interrupt every 1/60 seconds.
+	.SUSET [.SMASK,,[%PIRLT]]
+	JFCL
+	 .HANG
+
+TSINT:	0
+	0
+	PUSH P,A
+	SKIPL A,TSINT
+	 TLNN A,(%PIRLT)		;Is this the clock interrupt?
+	  .DISMIS TSINT+1
+	POP P,A
+	PUSHJ P,LITES
+	.DISMIS TSINT+1
+
+ZZ==.
+LOC 42
+	TSINT
+LOC ZZ
+]
+
+IFN NTS,[
+	;Non-timesharing code starts here.  If the TS code is executed
+	;first, the UUO handler will be called and jump here.
+NTS1:	CONO APR,3002			;APR interrupt at channel 2, enable clock.
+	CONO PI,12240			;Enable interrupt.
+	JRST .
+
+APRBRK:	0
+	CONSO APR,1000			;Is this the clock interrupt?
+	 JRST 12,@APRBRK
+	PUSHJ P,LITES
+	CONO APR,1002
+	JRST 12,@APRBRK
+
+ZZ==.
+IFN TS,[
+LOC 41
+	JRST NTS1
+]
+LOC 44
+	JSR APRBRK
+LOC ZZ
+]
+
+LITES:	PUSH P,A
+	SKIPE TICK
+	 JRST LITES0
+	MOVE A,[TICKS]			;Pattern ran out of ticks, get new one.
+	MOVEM A,TICK
+	MOVE A,PATRN
+	CAIN A,PATRNE
+	 MOVEI A,PATRNS			;Reached end of list.
+	MOVEM A,PATRN
+	MOVE A,@PATRN
+	AOS PATRN
+	MOVEM A,PC'
+LITES0:	MOVE Q,PC
+	POP P,A
+	JSP Q,(Q)			;Coroutine call.
+	MOVEM Q,PC
+	DATAO PI,A			;Display A on memory indicators.
+	SOS TICK
+	POPJ P,
+
+
+COUNTER:				;Simple counter pattern.
+	SETZ A,
+	JSP Q,(Q)
+	AOS A
+	JRST .-2
+
+ROT777:	MOVEI A,777			;Rotating pattern.
+	JSP Q,(Q)
+	ROT A,1
+	JRST .-2
+
+.INSRT XOROSH
+
+RANDOM:	PUSHJ P,XOROSHIRO"XOROSHIRO	;Random generator.
+	JSP Q,(Q)
+	JRST RANDOM
+
+SAIL:	SETZ A,				;SAIL null job.
+SAIL0:	ROT A,-1
+	TLNN A,200000
+	TLC A,400000
+	JSP Q,(Q) ? JSP Q,(Q) ? JSP Q,(Q)
+	JRST SAIL0
+
+PATRNS:	COUNTER
+	ROT777
+	RANDOM
+	SAIL
+PATRNE:
+
+PATRN:	PATRNE
+TICK:	0
+PDL:	BLOCK PDLLEN
+
+END GO

--- a/src/lars/xorosh.2
+++ b/src/lars/xorosh.2
@@ -1,0 +1,30 @@
+.begin xoroshiro
+
+xstate:	-1,, ? 1
+
+parm.a==2
+parm.b==9
+parm.c==5
+parm.r==11.
+
+xoroshiro:
+	push p,t
+	move t,xstate
+	xorm t,xstate+1
+	rot t,parm.a
+	xor t,xstate+1
+	movem t,xstate
+	move t,xstate+1
+	lsh t,parm.b
+	xorm t,xstate
+	move t,xstate+1
+	rot t,parm.c
+	movem t,xstate+1
+	pop p,t
+	move a,xstate
+	add a,xstate+1
+	rot a,parm.r
+	add a,xstate
+	popj p,
+
+.end


### PR DESCRIPTION
A program which has a framework for displaying various light patterns on the memory indicators.  It's interrupt-driven to update 60 times a second.  The same binary runs both on ITS and out of timesharing.  Patterns are called as co-routines so they can maintain an internal state and proceed where they last left off.

The program sets ITS location MIPGDS to -1 to have ITS leave the memory indicators alone.  It should be reset to 0 by the user after running this program.

One of the patterns displays data from a pseudo-random number generator.  The algorithm is a 36-bit version of xoroshiro+ with 2<sup>72</sup>-1 period.