### PR TITLE
Set SYS;RECORD TIME timestamp for current uptime record.

### DIFF
--- a/build/basics.tcl
+++ b/build/basics.tcl
@@ -375,4 +375,9 @@ expect ":KILL"
 respond "*" ":palx gt40;_gt40;bootvt\r"
 expect ":KILL"
 
+# PLAN/CREATE
+respond "*" ":midas sys3;ts create_syseng;create\r"
+expect ":KILL"
+respond "*" ":link sys1;ts plan,sys3;ts create\r"
+
 processor_basics

--- a/build/build.tcl
+++ b/build/build.tcl
@@ -199,6 +199,12 @@ if [file exists $build/mchn/$mchn/custom.tcl] {
     source $build/mchn/$mchn/custom.tcl
 }
 
+# Set timestamp for current uptime record.
+respond "*" ":create sys;record time\r"
+respond "for help" "\003"
+expect ":KILL"
+respond "*" ":sfdate sys;record time, 0/0/00\r"
+
 if {![info exists env(NODUMP)]} {
     # make output.tape
     respond "*" $emulator_escape

--- a/build/misc.tcl
+++ b/build/misc.tcl
@@ -853,11 +853,6 @@ respond "*" "purify\033g"
 respond "TS @" "\r"
 respond "*" ":kill\r"
 
-# PLAN/CREATE
-respond "*" ":midas sys3;ts create_syseng;create\r"
-expect ":KILL"
-respond "*" ":link sys1;ts plan,sys3;ts create\r"
-
 respond "*" ":midas;324 dsk0:.;@ pt_syseng;pt\r"
 expect ":KILL"
 


### PR DESCRIPTION
The TIME program checks the SYS;RECORD TIME timestamp to see if a new uptime record has been set.  It's not a normal timestamp, but is relative to day 0 of month 0 in year 1900.

Thanks to Heinz-Bernd Eggenstein (@Bikeman) for discovering this.