### PR TITLE
Fix MCL (macsyma source compiler) to actually work.

### DIFF
--- a/build/macsyma.tcl
+++ b/build/macsyma.tcl
@@ -216,9 +216,22 @@ respond "File name->" "\002"
 respond ";BKPT" "(quit)"
 
 respond "*" ":midas maxtul;ts mcl_mcldmp midas\r"
-respond "*" ":link maxtul;.good. complr,sys;ts complr\r"
+respond "*" ":link maxtul;.good. complr,maxtul;mcldmp 32\r"
 
-respond "*" ":link maxtul;ts utmcl,maxtul;ts mcl\r"
+# build UTMCL -- the compiler invoked by compile_lisp_file in Macsyma
+respond "*" "complr\013"
+respond "_" "maxtul;utmcl\r"
+respond "_" "\032"
+type ":kill\r"
+
+# dump out UTMCL
+respond "*" "complr\013"
+respond "_" "\007"
+respond "*" "(load \"maxtul;utmcl fasl\")"
+respond_load "\007"
+respond "*" "(dump-utmcl)"
+respond "_" "\032"
+type ":kill\r"
 
 respond "*" "complr\013"
 respond "_" "mrg;macros\r"
@@ -302,8 +315,12 @@ respond "Type ALL;" "all;"
 respond "Type ALL;" "all;"
 respond "(C2)" "quit();"
 
-### build share;array fasl and ellen; check fasl for macsyma
-respond "*" ":maxtul;mcl\r"
+### build share;array fasl and ellen;check fasl for macsyma
+respond "*" "complr\013"
+respond "_" "\007"
+respond "*" "(load '((libmax) module))"
+respond_load "(load '((libmax) maxmac))"
+respond_load "(maklap)"
 respond "_" "share;_maxsrc;array\r"
 respond "_" "ellen;check\r"
 respond "_" "\032"
@@ -311,7 +328,6 @@ type ":kill\r"
 
 ### rebuild float because version built the first time gives
 ### arithmetic overflows.  See ticket #1211.
-
 respond "*" "complr\013"
 respond "_" "\007"
 respond "*" "(load '((libmax) module))"

--- a/src/maxtul/utmcl.3
+++ b/src/maxtul/utmcl.3
@@ -1,0 +1,37 @@
+;;;-*-lisp-*-
+
+(herald utmcl)
+
+;;; Load this file into a COMPLR, ^G it, and do (DUMP-UTMCL).
+
+;;; compilation environment for translated macsyma code.
+;;; N.B. This does NOT define the environment, the prelude file
+;;; for translated code does that. This merely dumps out the
+;;; proper environment to give fast system start-up response
+;;; for users of COMPILE_LISP_FILE.
+;;; (It saves a few seconds per compilation).
+
+(DEFVAR MACRO-FILES NIL)
+
+(DEFUN VERLOAD (NAME FILE)
+  (COND ((GET NAME 'VERSION))
+	(T (LOAD FILE)
+	   (PUSH NAME MACRO-FILES))))
+
+(DEFUN DUMP-UTMCL (&OPTIONAL (*PURE T))
+  (setq pure t)
+  (load '((liblsp)sharab))
+  (VERLOAD 'MAXMAC "LIBMAX;MAXMAC FASL")
+  (VERLOAD 'MOPERS "LIBMAX;MOPERS FASL")
+  (VERLOAD 'TRANSQ "LIBMAX;TRANSQ FASL")
+  (VERLOAD 'MDEFUN "MACSYM;MDEFUN FASL")
+  (VERLOAD 'DCL    "MAXDOC;DCL    FASL")
+  ;; important declarations not yet in DCL FASL
+  (VERLOAD 'TDCL   "MAXDOC;TDCL   FASL")
+  (VERLOAD 'FORMAT (GET 'FORMAT 'AUTOLOAD))
+  (SETQ *PURE NIL)
+  (GC)
+  (PURE-SUSPEND 'p "DSK:MAXTUL;TS UTMCL")
+  (sstatus toplevel 
+           '(progn (funcall (let ((obarray sobarray))
+                              (intern 'complr-tople-after-suspend))))))


### PR DESCRIPTION
It is invoked with :MAXTUL;MCL and can be used to compile any macsyma source.  Of course, if you change IN-CORE sources, you'll have to dump out a new macsyma, but for non-IN-CORE sources, you'll get the FASL and UNFASL files in the right places, and any macros loaded that are needed.

The original link of maxtul;.good. complr was incorrect -- it pointed to SYS;TS COMPLR. The link is supposed to point to the dumped out MCL image.