### PR TITLE
The dependencies.sh script is only for CI.

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,23 +64,6 @@ some of which are disk images with ITS installed.
 | pdp10-kl | git, c compiler, make, expect, curses, autoconf, sdl2, sdl2-image, gtk3
 | pdp10-ks | git, c compiler, make, expect, curses, autoconf, sdl2
 
-The repo comes with a handy script to install required dependencies.
-After cloning the repo change to the build folder. For example if you cloned into `~/its` use the following commands
-```
-cd ~/its/build
-sudo chmod +x dependencies.sh
-```
-the script takes 2 parameters to run: 
-`install_<os>` and `EMULATOR=<emnulatorname>`
-To install the dependencies 
-- on MacOS for the PDP-10 KA run
-  - `./dependencies.sh install_osx EMULATOR=pdp10-ka`
-- on Ubuntu run
-  - `./dependencies.sh install_linux EMULATOR=pdp10-ka`
-- on FreeBSD run
-  - `./dependencies.sh install_freebsd EMULATOR=pdp10-ka`
-  
-Once the script completes navigate back to the `~/its` folder with `cd ..` and run `make clean all EMULATOR=pdp10-ka`
 ### Usage
 
 To start ITS, type `./start`.  If you see `KLH10#`, type `go` and

--- a/build/dependencies.sh
+++ b/build/dependencies.sh
@@ -1,3 +1,7 @@
+# This is script is mainly for installing dependencies for continuous
+# integration builds.  It's not meant to support many kinds of
+# operating system or releases.
+
 if test -n "$GITLAB_CI" -o -n "$CIRCLECI"; then
     sudo() {
         "$@"


### PR DESCRIPTION
Removed the README.md text about dependencies.sh because it's only to aid continuous integration builds.  We don't want the maintenance burden of keeping this up to date for everyone's operating system release.