### PR TITLE
Fixed two issues with SHRDLU including the shape change on putting down an object

### DIFF
--- a/src/shrdlu/graphf.6
+++ b/src/shrdlu/graphf.6
@@ -535,14 +535,13 @@ PRLOOP
  (P1)
  (PROG (H1 H2 H3 T1 T2 T3 T4)
  (COMMENT REGARDLESS OF WHAT DISPLAY-AS CALLS THE TABLE/, I CALL IT :TABLE)
-
        (COND ((SETQ H1 (ASSQ (CAAR P1) GP-LINES))
 	      (DISFLUSH (CADDDR (CDDR H1)))))
-       (COND ((EQ (CADDAR P1) (QUOTE /#PYRAMID))
+       (COND ((EQ (CADDAR P1) (QUOTE !PYRAMID))
 	      (GP-PYRAMID (CAAR P1) (CADDDR (CAR P1)) (CADDDR (CDAR P1))))
-	     ((EQ (CADDAR P1) (QUOTE /#BLOCK))
+	     ((EQ (CADDAR P1) (QUOTE !BLOCK))
 	      (GP-BLOCK (CAAR P1) (CADDDR (CAR P1)) (CADDDR (CDAR P1))))
-	     ((EQ (CADDAR P1) (QUOTE /#HAND))
+	     ((EQ (CADDAR P1) (QUOTE !HAND))
 	      (SETQ H1 (CAR (CDDDAR P1)))
 	      (SETQ H3 (GP-PROJECT (CAR H1) (CADR H1) (CADDR H1)))
 	      (SETQ H2 (DISCREATE (CAR H3) (CADR H3)))
@@ -557,9 +556,9 @@ PRLOOP
 			  H2
 			  H3
 			  T4)))
-	     ((EQ (CADDAR P1) (QUOTE /#BOX))
+	     ((EQ (CADDAR P1) (QUOTE !BOX))
 	      (GP-DRBOX (CAAR P1) (CADDDR (CAR P1)) (CADDDR (CDAR P1))))
-	     ((EQ (CADDAR P1) (QUOTE /#TABLE))
+	     ((EQ (CADDAR P1) (QUOTE !TABLE))
 	      (SETQ T1
 		    (LIST (QUOTE 0) (QUOTE 0))
 		    T2
@@ -730,7 +729,7 @@ PRLOOP
 		      DISPLAY
 		      PACKAGE
 		      THE
-		      /#BOX
+		      !BOX
 		      CONSISTS
 		      OF
 		      FOUR

--- a/src/shrdlu/newans.82
+++ b/src/shrdlu/newans.82
@@ -783,7 +783,8 @@ TEST-LOOP
        ;;ANSWER HAS BEEN DECIDED ON.
        (PROG (COUNT EXAM X RES ANS COMMA?) 
 	     (SETQ NAMES (MAPCAR '(LAMBDA (X) (NAMEOBJ X SPEC))
-				 (cond ((atom names) (list names))
+				 (cond ((null names) names)
+				       ((atom names) (list names))
 				       (t names))))
 	                                                               ;NAMEOBJ RETURNS A LIST OF THE OBJECT AND THE
 	     (COND ((NULL NAMES) (RETURN '((SAY NOTHING)))))	       ;THIS PATCH MAY WELL BE TOTALLOUT OF PHASE WITH
@@ -941,7 +942,6 @@ TEST-LOOP
 ;;;############################################################
 
 (DEFUN NAMEOBJ (ITEM SPEC) 
-
        ;;NAMES THE OBJECT IN ENGLISH -- GENERATES LIST OF THINGS TO
        ;;BE EVALUATED.  SPEC IS EITHER 'INDEF OR 'DEF
        (PROG (TYPE: TYPELIST TYPE NAME: COLOR: COLORLIST SIZE:


### PR DESCRIPTION
Fixed an issue with SHRDLU where picking up the green pyramid and putting it down on top of the table or another object turned it into a block (as far as the display was concerned, not the PLNR state).

Also fixed an issue with SHRDLU where, if the answer to a question was supposed to be NOTHING, it sometimes became "THE IL".  This was because of a missing case being handled in LISTNAMES -- one to handle a NIL value passed in as the object.