### PR TITLE
SSIMP should use 18-bit mapping, not 16...

### DIFF
--- a/src/system/imp.369
+++ b/src/system/imp.369
@@ -187,7 +187,8 @@ IF2,IFN IMPIBF&777,.FATAL IMPIBF not on DEC page boundary
 IMPINI:	SETOM IMPUP		;Not up yet,
 	SETOM IMPTCU		; but thinking about it.
 	MOVEI A,IMPIBF_-9.	;DEC page # of IMP buffer page
-	TRO A,%UQ16B\%UQVAL	;Valid mapping, 16 bit device
+IFE SSIMP,TRO A,%UQ16B\%UQVAL	;Valid mapping, 16 bit device (for real imp)
+.ELSE	TRO A,%UQVAL		;Valid mapping, 18 bit device (for ssimp)
 	IOWRI A,UBAPAG+IUIMPG_1	;Set up 1 DEC page of UBA mapping. Note that
 				; the second half of IUIMPG isn't mapped at all
 	CONO PI,NETOFF		;Freeze things while IMP bashing occurs


### PR DESCRIPTION
...otherwise it will fail on a non-emulated KS10. Tested and confirmed on a non-emulated KS10.