### PR TITLE
In COMSAT, let BUGHST default to local host

### DIFF
--- a/src/sysnet/comsat.585
+++ b/src/sysnet/comsat.585
@@ -8418,6 +8418,7 @@ RXPBUG:	PUSHAE P,[C,D,L]
 	  JRST [SETZ B, ? JRST RXPB90]	; Yikes, recursing!  Just ignore...
 	MOVE L,$ARLOC+EQVAR	; All stuff must be CONSed in EQVAR.
 	MOVE D,BUGHST		; Are we the magic host on which most program
+	JUMPE D,RXPB50		;  or is it unspecified?
 	CAME D,OWNHS2
 	CAMN D,OWNHST		;   maintainers reside?
 	 JRST RXPB50		; Yes, send to (BUG RANDOM-PROGRAM)
@@ -8439,7 +8440,7 @@ RXPB90:	AOS -3(P)
 	RET
 
 ;; Kludge -- magic host address which can deal with BUG-RANDOM-PROGRAM
-BUGHST:	HN$MC				; MC.LCS.MIT.EDU this week...
+BUGHST:	0			; If zero, use local host
 
 SUBTTL RXPERR - send error message after expansion/header.
 


### PR DESCRIPTION
BUGHST in COMSAT is used as destination for mail to "BUG type recipients" which have no explicit entry in .MAIL.;NAMES. The default is HN$MC, i.e. MC.LCS.MIT.EDU at Chaosnet address 3131 (not in use on the global Chaosnet).

The build process sets BUGHST to the local ITS address, to keep things local. However, if your IP/Chaos address changes, you must remember to patch COMSAT with the new address, otherwise BUG email will be sent to the old address.

This PR simplifies this by letting BUGHST default to 0, and change the code in RXPBUG to check for 0 and treat it in the same way as if it was (one of) the local address(es).

Closes #2331.