### PR TITLE
Let COMSAT recompile .MAIL.;NAMES when HOSTS3 has been updated

### DIFF
--- a/src/sysnet/comsat.585
+++ b/src/sysnet/comsat.585
@@ -155,6 +155,13 @@ T==:U1	; Alternate names for smashable ACs.
 TT==:U2 ; This is mostly for NETWRK/RESOLV.
 IFE U2-OC,.ERR RESOLV temp ACs lose!!
 
+	; Check if SYSTEM;HOSTS3 has been updated in EQVCHK, to ensure
+	; that current addresses are used for hosts in NAMES.
+	; Note: this only has the intended effect for hosts/addresses
+	; in SYSTEM;HOSTS3. Some other mechanism would be needed for
+	; hosts/addresses from DNS or HOSTAB servers.
+IFNDEF $$H3CHK,$$H3CHK==1
+
 $$DQ==1		; Domain interface code in use (mostly for NETRTS)
 $$DQRN==1	; Use RENMWO hack to cut down on resolver overhead
 ;; These are IFNDEFs for now so that I can play with them without
@@ -2963,9 +2970,11 @@ EQVCHK:	PUSHAE P,[A,B]
 	SYSCAL RFDATE,[CIMM DKIC ? CRET A]	; Get creation time.
 	 JSR SYSLOS
 	CAMN A,EQVTIM		; Compare with time of last file gobbled
-	 JRST EQVCH9		; OK, still same
+IFE $$H3CHK, JRST EQVCH9		; OK, still same
+.ELSE    JRST EQVCH2		; but need to check EQV vs HOSTS3
 	EXCH A,EQVTIM		; Not same!!! Store new, get old time.
 	JUMPN A,EQVCH3		; Jump if cause is new ASCII file.
+IFN $$H3CHK, EQVCH2:
 	;; Initialization, see if really need to re-compile.
 	;; Get creation time for existing bin file and compare.
 	.IOPUSH DKIC,		; Save chan.
@@ -2977,7 +2986,8 @@ EQVCHK:	PUSHAE P,[A,B]
 	 JSR SYSLOS
 	.IOPOP DKIC,
 	CAML A,EQVTIM		; Bin created before ascii file?
-	 JRST EQVCH9		; Nope, created after, win!  Needn't compile.
+IFE $$H3CHK, JRST EQVCH9		; Nope, created after, win!  Needn't compile.
+.ELSE    JRST EQVCH5		; but need to check EQV vs HOSTS3
 	;; New ASCII file has appeared, must try to compile it.
 EQVCH3:	CALL EQVGOB		; Attempt compile
 	 CAIA			;   Compilation lost?
@@ -2993,6 +3003,25 @@ EQVCH7:	STAT (,("Note: EQV file compiled."))
 EQVCH9:	POPAE P,[B,A]
 	.CLOSE DKIC,
 	RET
+IFN $$H3CHK,[
+;; Double-check routine, for when normally no recompilation would be needed.
+;; Come here if NAMES hasn't been updated since last check,
+;; or if EQV file created after NAMES file, with A/ EQV creation time.
+;; Now compare EQV creation time with HOSTS3 creation time, and recompile
+;; if HOSTS3 has been updated. (Otherwise we may keep using old host addresses.)
+EQVCH5:	.IOPUSH DKIC,		; Save channel.
+	MOVE B,A		; Save EQV creation time. <
+	MOVEI A,[ SIXBIT 'DSK' ? SIXBIT 'SYSBIN' ? SIXBIT 'HOSTS3' ? SIXBIT '>' ]
+	CALL OPNFLI		; General purpose opener
+	 JRST EQVCH9		; We'll catch it when it appears again.
+	SYSCAL RFDATE,[CIMM DKIC ? CRET A ] ; Get creation date
+	 JSR SYSLOS
+	.IOPOP DKIC,
+	CAML B,A		; H3 created before EQV?
+	 JRST EQVCH9		; No need to do anything.
+	STAT (,("Note: HOSTS3 file updated, need to recompile EQV file"))
+	JRST EQVCH3		; H3 created after, so need to recompile
+]
 
 ;;; EQVBIN/EQVGET - Slurp binary up into core.
 


### PR DESCRIPTION
NAMES is normally recompiled to a binary "EQV file" when either there was no such file, or NAMES has been updated later than the creation date of the EQV file.

However, the compilation translates host names in NAMES to binary host addresses in the EQV file, so if the address of some host name has changed since compilation, the new addresses won't be used.

This PR checks for this case: when NAMES would not normally need recompilation, check if SYSBIN;HOSTS3 has been updated since the last NAMES compilation and if so, recompile to get any fresh host addresses.

All changed code is under a `$$H3CHK` switch.

Closes #2330.