### PR TITLE
Problem getting SENDS in DDT

### DIFF
--- a/src/sysen1/ddt.1549
+++ b/src/sysen1/ddt.1549
@@ -954,9 +954,10 @@ bret:	    aos -1(p)
 mchok0:	camn a,[sixbit /DSK/]  ;is this the local machine?
 	  jrst [ move a,itsnam ? jrst popj1]  ;then use that instead
 	movsi b,-mchcnt		;for all the machines
-mchok1:	camn a,mchtab(b)	;is it this one?
+mchok1:	skipn mchtab(b)		;empty table entry?
+	  ret			;  yes, exit early
+	camn a,mchtab(b)	;is it this one?
 	  jrst popj1		;  yes, it's OK
-	skipe mchtab(b)
 	aobjn b,mchok1		;no, try next
 	ret
 


### PR DESCRIPTION
There seems to be a problem getting SENDS in DDT using the <kbd>^A</kbd> command.  For example:

```
↑A
(Getting SENDS for LARS@ )
 : .TEMP.; LARS SENDS - NO SUCH DEVICE
```