### PR TITLE
Drop simh target on FreeBSD.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -10,7 +10,7 @@ freebsd_instance:
 task:
   env:
     matrix:
-      - EMULATOR: simh
+      # EMULATOR: simh
       # EMULATOR: klh10
       - EMULATOR: pdp10-ka
         NODUMP: true


### PR DESCRIPTION
The pull request #2356 will not build due to the FreeBSD compiler erroring out with the latest version of SIMH.  It looks like the error is with SIMH printf format strings.  But until that is fixed, SIMH on FreeBSD is out.