### PR TITLE
Dockerize

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -1,0 +1,26 @@
+name: Build Docker
+
+on: [push, pull_request]
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build-docker:
+    runs-on: ${{matrix.os}}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-24.04]
+        emulator: [klh10, simh, pdp10-ka, pdp10-kl, pdp10-ks]
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+      - run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+      - name: Build Docker image
+        run: docker build . --file build/docker/Dockerfile --build-arg EMULATOR=${{ matrix.emulator }} --tag ghcr.io/${GITHUB_REPOSITORY_OWNER}/its-${{ matrix.emulator }}:${{ github.sha }}
+      - name: Push Docker image
+        run: docker push ghcr.io/${GITHUB_REPOSITORY_OWNER}/its-${{ matrix.emulator }}:${{ github.sha }}

--- a/build/dependencies.sh
+++ b/build/dependencies.sh
@@ -15,13 +15,13 @@ install_linux() {
     sudo apt-get install -my git make gcc libncurses-dev autoconf
     case "$EMULATOR" in
         simh*) sudo apt-get install -y libegl1-mesa-dev libgles2-mesa-dev
-              sudo apt-get install -y libsdl2-dev;;
+              sudo apt-get install -y libssl-dev libsdl2-dev;;
         pdp10-k?) sudo apt-get install -y libegl1-mesa-dev libgles2-mesa-dev
               sudo apt-get install -y libx11-dev libxt-dev libsdl2-dev
               sudo apt-get install -y libsdl2-image-dev libpcap-dev
               sudo apt-get install -y libssl-dev libsdl2-ttf-dev
               sudo apt-get install -y libgtk-3-dev libsdl2-net-dev;;
-        klh10) sudo apt-get install -y libusb-1.0-0-dev;;
+        klh10) sudo apt-get install -y libusb-1.0-0-dev libssl-dev pkg-config;;
     esac
 }
 

--- a/build/docker/Dockerfile
+++ b/build/docker/Dockerfile
@@ -1,0 +1,15 @@
+FROM ubuntu:24.04
+
+ARG EMULATOR
+
+RUN apt-get update
+RUN apt-get install -y git sudo
+
+RUN mkdir its
+ADD / its/
+
+WORKDIR its
+RUN sh -ex ./build/dependencies.sh install_linux
+RUN make EMULATOR=${EMULATOR}
+
+ENTRYPOINT ["./start"]

--- a/build/lisp.tcl
+++ b/build/lisp.tcl
@@ -335,7 +335,7 @@ type ":kill\r"
 respond "*" "comlap\033\033\023"
 respond "*" ":lisp ccload\r"
 expect "Dumping LSPDMP"
-sleep 1
+sleep 10
 type ":vk\r"
 respond "*" ":kill\r"
 


### PR DESCRIPTION
* Fix `dependencies.sh` so it works in Ubuntu 24.04
* Generate a Docker image per emulator: `KLH10`, `SIMH`, `pdp10-ka`, `pdp10-kl` and `pdp10-ks`.
* Increase timeout in `lisp.tcl` because half of the time the workflow would fail to build the image for `KLH10`
* Push images to GitHub Packages <-- WARNING! I only tested this in my repo!