### PR TITLE
Add missing -z option for listing a .tgz.

### DIFF
--- a/build/deploy-ftp.sh
+++ b/build/deploy-ftp.sh
@@ -29,7 +29,7 @@ create_archive() {
         (cd out; tar czf $EMULATOR.tgz $EMULATOR)
 
         # Verify the tarball
-        if tar tf $EMULATOR.tgz >/dev/null 2>&1; then
+        if tar tzf $EMULATOR.tgz >/dev/null 2>&1; then
             echo "Tarball is valid and can be expanded."
             break
         else


### PR DESCRIPTION
The FTP deploy script prints error messages due to not being able to list and verify the created .tgz file.  This is due to the tar command missing the z option.

CC @oilcan-productions, @mkostersitz