### PR TITLE
Fix Y2K bug in XGPSPL.

### DIFF
--- a/src/dcp/versa.212
+++ b/src/dcp/versa.212
@@ -945,7 +945,8 @@ gflag1:	movei x,[ [asciz /~%~T Processing DSK:.GLPR.;~6 ~6/]
 
 	move x,cdate
 	move a,p
-	ldb b,[.bp <177000,,>,x]
+	ldb b,[.bp <777000,,>,x]
+	addi b,1900.
 	push p,b	;1(a) year
 	ldb b,[.bp <000740,,>,x]
 	push p,b	;2(a) month
@@ -2943,7 +2944,9 @@ pgtitl:	aos pagnum
 	skipn header
 	 return			;no header
 	skipn infook
-	 call [	.ryear a,
+	 call [	syscal rqdate,[movem qtime']
+		 .value
+		.ryear a,
 		.rdati b,
 		movem a,ryear'
 		movem b,rtime'
@@ -2966,33 +2969,21 @@ pgtitl:	aos pagnum
 	call insstr
 	movei z,[asciz /, /]
 	call insstr
-	ldb z,[.bp <000077000000>,rdate]
-	ldb y,[.bp <000000770000>,rdate]
-	subi z,'0
-	imuli z,10.
-	addi z,(y)-'0
-	move z,(z)-1+[	irps mon,,[January   February March    April
+	ldb z,[.bp <000740,,>,qtime]
+	move z,(z)[	irps mon,,[January   February March    April
 				   May	     June     July     August
 				   September October  November December]
 			[asciz /mon/] ? termin ]
 	call insstr
 	movei x,<" >		;<">
 	call inschr
-	ldb x,[.bp <7700>,rdate]
-	addi x,"0-'0		;"
-	caie x,"0		;"
-	 call inschr
-	ldb x,[.bp <0077>,rdate]
-	addi x,"0-'0		;"
-	call inschr
-	movei z,[asciz /, 19/]
+	ldb x,[.bp <000037,,>,qtime]
+	call insdec
+	movei z,[asciz /, /]
 	call insstr
-	ldb x,[.bp <770000,,>,rdate]
-	addi x,"0-'0		;"
-	call inschr
-	ldb x,[.bp <007700,,>,rdate]
-	addi x,"0-'0		;"
-	call inschr
+	ldb x,[.bp <777000,,>,qtime]
+	addi x,1900.
+	call insdec
 	call tabchr
 	repeat 3,[
 	  ldb x,[.bp <<770000,,>_<-.rpcnt*12.>>,rtime]
@@ -3021,7 +3012,12 @@ pgtit4:	call tabchr
 	movei z,[asciz /Page /]
 	call insstr
 	move x,pagnum
-	push p,[-1]
+	pushj p,insdec
+	call outlin
+	call outlin
+	return
+
+insdec:	push p,[-1]
 pgtit5:	idivi x,10.
 	push p,y
 	jumpn x,pgtit5
@@ -3030,10 +3026,7 @@ pgtit6:	pop p,x
 		addi x,"0	;"
 		call inschr
 		jrst pgtit6]
-
-	call outlin
-	call outlin
-	return
+	popj p,
 
 .end text
 

--- a/src/share/aplot2.301
+++ b/src/share/aplot2.301
@@ -872,7 +872,7 @@
 						      (10. . "October")
 						      (11. . "November")
 						      (12. . "December")))))
-			      '(44. 32. 49. 57.) (explodec (car date))))
+			      '(44. 32.) (explodec (car date))))
 		     (t (append (exploden (caddr date)) '(46.)
 ;					    ((lambda (base)
 ;						     (mapcar (function

--- a/src/sysen2/xgpspl.198
+++ b/src/sysen2/xgpspl.198
@@ -2227,6 +2227,15 @@ samp7:	ildb a,b
 	jumpe a,cpopj
 	pushj p,samp5
 	jrst samp7
+
+samp9:	jumpe a,cpopj		;print decimal number in a
+	push p,b
+	idivi a,10.
+	pushj p,samp9
+	movei a,"0(b)
+	pushj p,samp5
+	pop p,b
+	popj p,
 
 ;:SKIP <n> command - set to skip first <n> pages of file
 setpsk:	movei e,pskip
@@ -3262,17 +3271,9 @@ hdrdat:	.rlpdt a,
 	pushj p,samp6
 	movei b,[asciz /day, /]
 	pushj p,samp6
-	.rdate b,
-	lshc a,2*6		;two six bit characters is year
-	lsh a,44-<2*6>		;suitable for six bit printing
-	push p,a
-	movei a,0
-	lshc a,6		;first digit of month
-	movei d,-20(a)
-	imuli d,10.
-	movei a,0
-	lshc a,6		;second digit of month
-	addi d,-20(a)
+	syscal RQDATE,[movem b]
+	 .lose %lssys
+	ldb a,[270400,,b]	;get month
 	push p,b	
 	move b,[	[asciz /????/]
 			[asciz /January /]
@@ -3286,23 +3287,21 @@ hdrdat:	.rlpdt a,
 			[asciz /September /]
 			[asciz /October /]
 			[asciz /November /]
-			[asciz /December /]](d)
+			[asciz /December /]](a)
+	pushj p,samp6
+	ldb a,[220500,,(p)]		;print day of month
+	pushj p,samp9
+	movei b,[asciz /, /]
 	pushj p,samp6
 	pop p,b
-	movei a,0			;print day of month
-	lshc a,6			;get first digit
-	caie a,'0			;don't print leading zero
-	 lshc a,-6
-	pushj p,samp4
-	movei b,[asciz /, 19/]
-	pushj p,samp6
-	pop p,b
-	pushj p,samp4			;year
+	ldb a,[330900,,b]		;year
+	addi a,1900.
+	pushj p,samp9
 	movei a,40
 	pushj p,samp5
 	pushj p,samp5
 	pushj p,samp5
-	.rtime b,			;date
+	.rtime b,			;time
 	lshc a,2*6
 	lsh a,6
 	iori a,':	


### PR DESCRIPTION
This should fix #2368.

I pre-emptively made the year field 9 bits in anticipation of the #853 fix.